### PR TITLE
fix: remove useless try/catch wrappers and add proper error messages

### DIFF
--- a/registry/app.json
+++ b/registry/app.json
@@ -1,6 +1,7 @@
 {
   "scopeName": "deco",
   "name": "registrys",
+  "friendlyName": "Registry",
   "connection": {
     "type": "HTTP",
     "url": "https://sites-registry.decocache.com/mcp"
@@ -9,4 +10,3 @@
   "icon": "https://assets.decocache.com/decocms/cd7ca472-0f72-463a-b0de-6e44bdd0f9b4/mcp.png",
   "unlisted": false
 }
-

--- a/registry/server/lib/registry-client.ts
+++ b/registry/server/lib/registry-client.ts
@@ -115,7 +115,9 @@ export async function listAllServers(
       cursor = response.metadata.nextCursor;
     }
   } catch (error) {
-    throw error;
+    throw new Error(
+      `Error fetching all servers from registry: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 
   return servers;
@@ -155,7 +157,9 @@ export async function getServer(
 
     return latest || matchingServers[0];
   } catch (error) {
-    throw error;
+    throw new Error(
+      `Error fetching server ${name}${version ? `:${version}` : ""}: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 }
 


### PR DESCRIPTION
- Replace bare 'throw error' with actual error messages
- Include context in error messages for better debugging
- Fixes eslint warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved error handling in the registry client with descriptive, contextual error messages to make debugging easier.

- **Refactors**
  - listAllServers and getServer now throw errors with operation context (name/version).
  - Resolved ESLint warnings by replacing bare "throw error".
  - Added "friendlyName": "Registry" to registry/app.json.

<sup>Written for commit c7aaf226bc41193aaad2d1e13e8a5a2e64888e2b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

