### PR TITLE
Feat/registry preserve original api data

### DIFF
--- a/registry/server/tools/registry-binding.ts
+++ b/registry/server/tools/registry-binding.ts
@@ -320,9 +320,6 @@ export const createListRegistryTool = (env: Env) =>
           totalCount: servers.length,
           hasMore,
           nextCursor,
-          nextOffset: hasMore
-            ? finalOffset + paginatedServers.length
-            : undefined,
         };
       } catch (error) {
         throw new Error(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the registry listing to cursor-based pagination to match the official API. This makes paging stable even when data changes and preserves the original server and _meta objects.

- **New Features**
  - Added cursor input ("name:version") and nextCursor in the response.
  - Kept offset as a fallback for compatibility.

- **Bug Fixes**
  - Removed leftover nextOffset from the response.

<sup>Written for commit 06d725cdc66fc93cd352bb32894c3ca56090ab7a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

