### PR TITLE
Remove totalCount and hasMore fields from registry list response

### DIFF
--- a/registry/server/tools/registry-binding.ts
+++ b/registry/server/tools/registry-binding.ts
@@ -69,8 +69,6 @@ const ListInputSchema = z
  */
 const ListOutputSchema = z.object({
   items: z.array(RegistryServerSchema),
-  totalCount: z.number(),
-  hasMore: z.boolean(),
   nextCursor: z
     .string()
     .optional()
@@ -149,8 +147,6 @@ export const createListRegistryTool = (env: Env) =>
 
         return {
           items,
-          totalCount: response.metadata.count,
-          hasMore: !!response.metadata.nextCursor,
           nextCursor: response.metadata.nextCursor,
         };
       } catch (error) {

--- a/scripts/build-mcp.ts
+++ b/scripts/build-mcp.ts
@@ -1,25 +1,25 @@
 import { $ } from "bun";
 
 const SITE_NAME_TO_MCP_FOLDER_OVERRIDES = {
-	vibemcp: "mcp-studio",
+  vibemcp: "mcp-studio",
 };
 
 const getMcpFolder = (siteName: string) => {
-	return SITE_NAME_TO_MCP_FOLDER_OVERRIDES[siteName] || siteName;
+  return SITE_NAME_TO_MCP_FOLDER_OVERRIDES[siteName] || siteName;
 };
 
 const siteName = process.env.DECO_SITE_NAME;
 
 if (!siteName) {
-	console.error("❌ Error: DECO_SITE_NAME environment variable is not set");
-	process.exit(1);
+  console.error("❌ Error: DECO_SITE_NAME environment variable is not set");
+  process.exit(1);
 }
 
 const folderToBuild = getMcpFolder(siteName);
 
 if (!folderToBuild) {
-	console.error("❌ Error: MCP folder not found");
-	process.exit(1);
+  console.error("❌ Error: MCP folder not found");
+  process.exit(1);
 }
 
 await $`bun run --filter=${folderToBuild} build`;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed totalCount and hasMore from the registry list API response. Pagination now relies on nextCursor only.

- **Migration**
  - Stop reading totalCount and hasMore from ListOutputSchema responses.
  - Use nextCursor to determine if more results exist (absence means end).

- **Refactors**
  - scripts/build-mcp.ts: whitespace cleanup (tabs → spaces), no behavior change.

<sup>Written for commit 50fbf92dbe3b948a6a1fedb19889d1c776b810a8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

