### PR TITLE
fix: corrige typo no nome do registry de 'registrys' para 'mcp-registry'

### DIFF
--- a/registry/app.json
+++ b/registry/app.json
@@ -1,6 +1,6 @@
 {
   "scopeName": "deco",
-  "name": "registrys",
+  "name": "mcp-registry",
   "friendlyName": "MCP Registry",
   "connection": {
     "type": "HTTP",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed a typo in registry/app.json: renamed “registrys” to “mcp-registry” to ensure consistent naming in the UI and integrations.

<sup>Written for commit 7bdaa23fa67e0ac11a11f53e1b30f1a662c1df9f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

