### PR TITLE
feat(registry): add legacy where schema for simplified filtering

### DIFF
--- a/registry/server/main.ts
+++ b/registry/server/main.ts
@@ -7,12 +7,10 @@
 import { type DefaultEnv, withRuntime } from "@decocms/runtime";
 import {
   type Env as DecoEnv,
-  Scopes,
   StateSchema as BaseStateSchema,
 } from "../shared/deco.gen.ts";
 import { z } from "zod";
 import { tools } from "./tools/index.ts";
-import { ensureTables, isDatabaseAvailable } from "./lib/postgres.ts";
 
 /**
  * StateSchema with MCP Registry configuration.
@@ -39,12 +37,6 @@ export type Env = DefaultEnv<typeof StateSchema> & DecoEnv;
 
 const runtime = withRuntime<Env, typeof StateSchema>({
   configuration: {
-    onChange: async (env) => {
-      // Only create tables if DATABASE binding is available
-      if (isDatabaseAvailable(env)) {
-        await ensureTables(env);
-      }
-    },
     /**
      * These scopes define the asking permissions of your
      * app when a user is installing it. When a user
@@ -53,7 +45,7 @@ const runtime = withRuntime<Env, typeof StateSchema>({
      * and utilize the user's own AI Gateway, without having to
      * deploy your own, setup any API keys, etc.
      */
-    scopes: [Scopes.DATABASE.DATABASES_RUN_SQL],
+    scopes: [],
     /**
      * The state schema of your Application defines what
      * your installed App state will look like. When a user
@@ -73,13 +65,7 @@ const runtime = withRuntime<Env, typeof StateSchema>({
     state: StateSchema,
   },
   tools: (env: Env) => tools.map((createTool) => createTool(env)),
-  bindings: [
-    {
-      type: "mcp",
-      name: "DATABASE",
-      app_name: "@deco/postgres",
-    },
-  ],
+  bindings: [],
   cors: {
     origin: (origin) => {
       // Allow localhost and configured origins

--- a/registry/server/tools/index.ts
+++ b/registry/server/tools/index.ts
@@ -14,11 +14,9 @@ import {
   createGetRegistryTool,
   createVersionsRegistryTool,
 } from "./registry-binding.ts";
-import { createSyncTool } from "./sync-tool.ts";
 
 export const tools = [
   createListRegistryTool,
   createGetRegistryTool,
   createVersionsRegistryTool,
-  createSyncTool,
 ];


### PR DESCRIPTION
- Add LegacyWhereSchema with appName, title, and binder fields
- Support union of WhereExpression and LegacyWhereSchema
- Update extractSearchTerm to process legacy format (prioritizes appName/title)
- Remove unused database mode references
- Simplify main.ts and tools/index.ts by removing postgres bindings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a legacy where filter to registry tools for simpler queries using appName, title, or binder. Removes database mode and Postgres bindings, simplifying configuration and relying on allowlist or dynamic filtering.

- **New Features**
  - LegacyWhereSchema with appName, title, binder.
  - WhereSchema now accepts WhereExpression or legacy format.
  - extractSearchTerm prioritizes appName/title from legacy filters.

- **Refactors**
  - Removed database mode, Postgres bindings, and related code paths.
  - Cleared scopes and removed DATABASE MCP binding and sync tool.
  - Registry fetch now consistently uses allowlist or API (no DB fallback).

<sup>Written for commit 21bf798bab2e106530e75bc8aaa8ef14ba465322. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

