### PR TITLE
bump bindings and rename agents -> assistants

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
       "name": "mcp-studio",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/bindings": "1.0.1-alpha.17",
+        "@decocms/bindings": "1.0.1-alpha.26",
         "@decocms/runtime": "1.0.0-alpha.31",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-popover": "^1.1.15",
@@ -140,16 +140,10 @@
         "zod": "^3.24.3",
       },
       "devDependencies": {
-        "@cloudflare/vite-plugin": "^1.13.4",
-        "@cloudflare/workers-types": "^4.20251014.0",
         "@decocms/mcps-shared": "workspace:*",
-        "@mastra/core": "^0.24.0",
         "@modelcontextprotocol/sdk": "1.20.2",
-        "@types/mime-db": "^1.43.6",
         "deco-cli": "^0.28.0",
         "typescript": "^5.7.2",
-        "vite": "7.2.0",
-        "wrangler": "^4.28.0",
       },
     },
     "nanobanana": {
@@ -652,7 +646,7 @@
 
     "@deco/mcp": ["@jsr/deco__mcp@0.5.5", "https://npm.jsr.io/~/11/@jsr/deco__mcp/0.5.5.tgz", { "dependencies": { "@jsr/deco__deco": "^1.112.1", "@jsr/hono__hono": "^4.5.4", "@modelcontextprotocol/sdk": "^1.11.4", "fetch-to-node": "^2.1.0", "zod": "^3.24.2" } }, "sha512-46TaWGu7lbsPleHjCVrG6afhQjv3muBTNRFBkIhLrSzlQ+9d21UeukpYs19z0AGpOlmjSSK9qIRFTf8SlH2B6Q=="],
 
-    "@decocms/bindings": ["@decocms/bindings@1.0.1-alpha.17", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.20.2", "zod": "^3.25.76", "zod-from-json-schema": "^0.0.5" } }, "sha512-lFIqOQm8/9yhXIvRq5pETTuzZaEMtMsMbz5noPi+lVZ+6VRykLULsGCpEYT0rP1IlgFjGgXv7SH+TjvCJAhxfQ=="],
+    "@decocms/bindings": ["@decocms/bindings@1.0.1-alpha.26", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.20.2", "zod": "^3.25.76", "zod-from-json-schema": "^0.0.5" } }, "sha512-i6WlXYKL61PDkxBbPaA1NNvezqxa7CW6wPaRBZueAuEUxBcDSeOTs4DE6LWjzWz7TpsUg4fD72Ov3IEk7S1nVA=="],
 
     "@decocms/mcps-shared": ["@decocms/mcps-shared@workspace:shared"],
 
@@ -2839,6 +2833,8 @@
     "log-symbols/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "mcp-studio/@decocms/runtime/@deco/mcp": ["@jsr/deco__mcp@0.7.8", "https://npm.jsr.io/~/11/@jsr/deco__mcp/0.7.8.tgz", { "dependencies": { "@jsr/deco__deco": "^1.112.1", "@jsr/hono__hono": "^4.5.4", "@modelcontextprotocol/sdk": "^1.11.4", "fetch-to-node": "^2.1.0", "zod": "^3.24.2" } }, "sha512-NcDGuKv2ZxId8ZHCD3zGZhHNLzrExn+DL11yDo60mZ44zbbRwuLRRmAYTwrdtZ6A45fVWYmEIloPY93tKrtimw=="],
+
+    "mcp-studio/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.0.1-alpha.17", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.20.2", "zod": "^3.25.76", "zod-from-json-schema": "^0.0.5" } }, "sha512-lFIqOQm8/9yhXIvRq5pETTuzZaEMtMsMbz5noPi+lVZ+6VRykLULsGCpEYT0rP1IlgFjGgXv7SH+TjvCJAhxfQ=="],
 
     "mcp-template-with-view/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 

--- a/mcp-studio/package.json
+++ b/mcp-studio/package.json
@@ -14,7 +14,7 @@
     "publish": "cat app.json | deco registry publish -w /shared/deco -y"
   },
   "dependencies": {
-    "@decocms/bindings": "1.0.1-alpha.17",
+    "@decocms/bindings": "1.0.1-alpha.26",
     "@decocms/runtime": "1.0.0-alpha.31",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-popover": "^1.1.15",

--- a/mcp-studio/server/lib/postgres.ts
+++ b/mcp-studio/server/lib/postgres.ts
@@ -2,7 +2,7 @@
  * PostgreSQL Database Module
  *
  * This module provides PostgreSQL connectivity using the DATABASE binding
- * and handles automatic table creation for the agents collection.
+ * and handles automatic table creation for the assistants collection.
  */
 
 import type { Env } from "../main.ts";
@@ -19,22 +19,28 @@ export async function runSQL<T = unknown>(
   sql: string,
   params: unknown[] = [],
 ): Promise<T[]> {
+  // Defensive: some DATABASE bindings may interpolate params into SQL literals.
+  // Ensure single quotes inside string params don't break the query.
+  const sanitizedParams = params.map((p) => {
+    if (typeof p === "string") return p.replaceAll("'", "''");
+    return p;
+  });
   const response = await env.DATABASE.DATABASES_RUN_SQL({
     sql,
-    params,
+    params: sanitizedParams,
   });
   return (response.result[0]?.results ?? []) as T[];
 }
 
 /**
- * Ensure the agents table exists, creating it if necessary
+ * Ensure the assistants table exists, creating it if necessary
  */
-export async function ensureAgentsTable(env: Env) {
+export async function ensureAssistantsTable(env: Env) {
   try {
     await runSQL(
       env,
       `
-			CREATE TABLE IF NOT EXISTS agents (
+			CREATE TABLE IF NOT EXISTS assistants (
 				id TEXT PRIMARY KEY,
 				title TEXT NOT NULL,
 				created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -44,7 +50,10 @@ export async function ensureAgentsTable(env: Env) {
 				description TEXT NOT NULL,
 				instructions TEXT NOT NULL,
 				tool_set JSONB NOT NULL DEFAULT '{}',
-				avatar TEXT NOT NULL DEFAULT ''
+				avatar TEXT NOT NULL DEFAULT '',
+        system_prompt TEXT NOT NULL DEFAULT '',
+        gateway_id TEXT NOT NULL DEFAULT '',
+        model JSONB NOT NULL DEFAULT '{"id":"","connectionId":""}'::jsonb
 			)
 		`,
     );
@@ -52,26 +61,50 @@ export async function ensureAgentsTable(env: Env) {
     // Add avatar column if it doesn't exist (migration for existing tables)
     await runSQL(
       env,
-      `ALTER TABLE agents ADD COLUMN IF NOT EXISTS avatar TEXT NOT NULL DEFAULT ''`,
+      `ALTER TABLE assistants ADD COLUMN IF NOT EXISTS avatar TEXT NOT NULL DEFAULT ''`,
+    );
+
+    // Migrations for new AssistantSchema required fields
+    await runSQL(
+      env,
+      `ALTER TABLE assistants ADD COLUMN IF NOT EXISTS system_prompt TEXT NOT NULL DEFAULT ''`,
+    );
+    await runSQL(
+      env,
+      `ALTER TABLE assistants ADD COLUMN IF NOT EXISTS gateway_id TEXT NOT NULL DEFAULT ''`,
+    );
+    await runSQL(
+      env,
+      `ALTER TABLE assistants ADD COLUMN IF NOT EXISTS model JSONB NOT NULL DEFAULT '{"id":"","connectionId":""}'::jsonb`,
+    );
+
+    // Ensure defaults match current AssistantSchema expectations even if columns already existed
+    await runSQL(
+      env,
+      `ALTER TABLE assistants ALTER COLUMN gateway_id SET DEFAULT ''`,
+    );
+    await runSQL(
+      env,
+      `ALTER TABLE assistants ALTER COLUMN model SET DEFAULT '{"id":"","connectionId":""}'::jsonb`,
     );
 
     // Create indexes for better query performance
     await runSQL(
       env,
-      `CREATE INDEX IF NOT EXISTS idx_agents_created_at ON agents(created_at DESC)`,
+      `CREATE INDEX IF NOT EXISTS idx_assistants_created_at ON assistants(created_at DESC)`,
     );
 
     await runSQL(
       env,
-      `CREATE INDEX IF NOT EXISTS idx_agents_updated_at ON agents(updated_at DESC)`,
+      `CREATE INDEX IF NOT EXISTS idx_assistants_updated_at ON assistants(updated_at DESC)`,
     );
 
     await runSQL(
       env,
-      `CREATE INDEX IF NOT EXISTS idx_agents_title ON agents(title)`,
+      `CREATE INDEX IF NOT EXISTS idx_assistants_title ON assistants(title)`,
     );
   } catch (error) {
-    console.error("Error ensuring agents table exists:", error);
+    console.error("Error ensuring assistants table exists:", error);
     throw error;
   }
 }

--- a/mcp-studio/server/main.ts
+++ b/mcp-studio/server/main.ts
@@ -11,7 +11,7 @@ import {
   Scopes,
   StateSchema,
 } from "../shared/deco.gen.ts";
-import { ensureAgentsTable } from "./lib/postgres.ts";
+import { ensureAssistantsTable } from "./lib/postgres.ts";
 import { tools } from "./tools/index.ts";
 
 /**
@@ -26,7 +26,7 @@ export type Env = DefaultEnv<typeof StateSchema> & DecoEnv;
 const runtime = withRuntime<Env, typeof StateSchema>({
   configuration: {
     onChange: async (env) => {
-      await ensureAgentsTable(env);
+      await ensureAssistantsTable(env);
     },
     /**
      * These scopes define the asking permissions of your

--- a/mcp-studio/server/tools/index.ts
+++ b/mcp-studio/server/tools/index.ts
@@ -5,7 +5,7 @@
  * export, making it easy to import all tools in main.ts while keeping
  * the domain separation.
  */
-import { agentTools } from "./agent.ts";
+import { assistantTools } from "./assistant.ts";
 
 // Export all tools from all domains
-export const tools = [...agentTools];
+export const tools = [...assistantTools];


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed “agents” to “assistants” across mcp-studio and upgraded @decocms/bindings to 1.0.1-alpha.26. Adds new assistant fields and safer SQL handling, with automatic database migration.

- **Refactors**
  - Switched to ASSISTANTS_BINDING and new tool IDs (LIST/GET/CREATE/UPDATE/DELETE).
  - Replaced the agents table with assistants; added system_prompt, gateway_id, and model; updated defaults and indexes.
  - Added row mapping and model normalization; when DATABASE is missing, LIST returns an empty array.
  - Escapes single quotes in SQL params to avoid query issues.

- **Migration**
  - ensureAssistantsTable runs on config changes to create/migrate the assistants table and set defaults. No manual steps needed.

<sup>Written for commit c388acaf98859d35025f0ff80ab42f21d1d90db1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

