### PR TITLE
Add local file system MCP server to mount files to local MCP mesh

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "@decocms/mcps",
@@ -94,6 +93,21 @@
         "wrangler": "^4.28.0",
       },
     },
+    "local-fs": {
+      "name": "@decocms/mcp-local-fs",
+      "version": "1.0.2",
+      "bin": {
+        "mcp-local-fs": "./dist/cli.js",
+      },
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.20.2",
+        "zod": "^3.24.0",
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0",
+      },
+    },
     "mcp-studio": {
       "name": "mcp-studio",
       "version": "1.0.0",
@@ -142,7 +156,7 @@
       },
       "devDependencies": {
         "@decocms/mcps-shared": "workspace:*",
-        "@modelcontextprotocol/sdk": "1.20.2",
+        "@modelcontextprotocol/sdk": "1.25.1",
         "deco-cli": "^0.28.0",
         "typescript": "^5.7.2",
       },
@@ -228,7 +242,7 @@
         "@cloudflare/workers-types": "^4.20251014.0",
         "@decocms/mcps-shared": "1.0.0",
         "@mastra/core": "^0.24.0",
-        "@modelcontextprotocol/sdk": "1.20.2",
+        "@modelcontextprotocol/sdk": "1.25.1",
         "@types/mime-db": "^1.43.6",
         "deco-cli": "^0.28.0",
         "typescript": "^5.7.2",
@@ -309,7 +323,7 @@
       "devDependencies": {
         "@decocms/mcps-shared": "workspace:*",
         "@decocms/vite-plugin": "1.0.0-alpha.1",
-        "@modelcontextprotocol/sdk": "1.20.2",
+        "@modelcontextprotocol/sdk": "1.25.1",
         "@types/mime-db": "^1.43.6",
         "@types/node": "^22.0.0",
         "deco-cli": "^0.28.0",
@@ -475,7 +489,7 @@
 
     "@ai-sdk/anthropic-v5": ["@ai-sdk/anthropic@2.0.33", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.12" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-egqr9PHqqX2Am5mn/Xs1C3+1/wphVKiAjpsVpW85eLc2WpW7AgiAg52DCBr4By9bw3UVVuMeR4uEO1X0dKDUDA=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.4", "", { "dependencies": { "@ai-sdk/provider": "3.0.1", "@ai-sdk/provider-utils": "4.0.2", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-OlccjNYZ5+4FaNyvs0kb3N5H6U/QCKlKPTGsgUo8IZkqfMQu8ALI1XD6l/BCuTKto+OO9xUPObT/W7JhbqJ5nA=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.2", "", { "dependencies": { "@ai-sdk/provider": "3.0.0", "@ai-sdk/provider-utils": "4.0.1", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-giJEg9ob45htbu3iautK+2kvplY2JnTj7ir4wZzYSQWvqGatWfBBfDuNCU5wSJt9BCGjymM5ZS9ziD42JGCZBw=="],
 
     "@ai-sdk/google-v5": ["@ai-sdk/google@2.0.40", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-E7MTVE6vhWXQJzXQDvojwA9t5xlhWpxttCH3R/kUyiE6y0tT8Ay2dmZLO+bLpFBQ5qrvBMrjKWpDVQMoo6TJZg=="],
 
@@ -489,9 +503,9 @@
 
     "@ai-sdk/openai-v5": ["@ai-sdk/openai@2.0.53", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.12" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-GIkR3+Fyif516ftXv+YPSPstnAHhcZxNoR2s8uSHhQ1yBT7I7aQYTVwpjAuYoT3GR+TeP50q7onj2/nDRbT2FQ=="],
 
-    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-2lR4w7mr9XrydzxBSjir4N6YMGdXD+Np1Sh0RXABh7tWdNFFwIeRI1Q+SaYZMbfL8Pg8RRLcrxQm51yxTLhokg=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.2", "", { "dependencies": { "@ai-sdk/provider": "3.0.1", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-KaykkuRBdF/ffpI5bwpL4aSCmO/99p8/ci+VeHwJO8tmvXtiVAb99QeyvvvXmL61e9Zrvv4GBGoajW19xdjkVQ=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.1", "", { "dependencies": { "@ai-sdk/provider": "3.0.0", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-de2v8gH9zj47tRI38oSxhQIewmNc+OZjYIOOaMoVWKL65ERSav2PYYZHPSPCrfOeLMkv+Dyh8Y0QGwkO29wMWQ=="],
 
     "@ai-sdk/provider-utils-v5": ["@ai-sdk/provider-utils@3.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZtbdvYxdMoria+2SlNarEk6Hlgyf+zzcznlD55EAl+7VZvJaSg2sqPvwArY7L6TfDEDJsnCq0fdhBSkYo0Xqdg=="],
 
@@ -645,7 +659,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20251210.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Uaz6/9XE+D6E7pCY4OvkCuJHu7HcSDzeGcCGY1HLhojXhHd7yL52c3yfiyJdS8hPatiAa0nn5qSI/42+aTdDSw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20251231.0", "", {}, "sha512-XOP7h2y9Nu3ECuZM9S7w3g4GSliTgj6SEEkYj6G6d3TEQtOiV/cHXuI/fKiLj8Z9+qJK/RLLcKkX14NxajrXCw=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20251230.0", "", {}, "sha512-mTpeOLyC088fqC0hDMFFErq0C/4tLFTDgYgkBhpbM7YeoASVErhnR5irvnHFarvJ5NWXa8jY08bSaRIG8V8PAA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -654,6 +668,8 @@
     "@deco/mcp": ["@jsr/deco__mcp@0.5.5", "https://npm.jsr.io/~/11/@jsr/deco__mcp/0.5.5.tgz", { "dependencies": { "@jsr/deco__deco": "^1.112.1", "@jsr/hono__hono": "^4.5.4", "@modelcontextprotocol/sdk": "^1.11.4", "fetch-to-node": "^2.1.0", "zod": "^3.24.2" } }, "sha512-46TaWGu7lbsPleHjCVrG6afhQjv3muBTNRFBkIhLrSzlQ+9d21UeukpYs19z0AGpOlmjSSK9qIRFTf8SlH2B6Q=="],
 
     "@decocms/bindings": ["@decocms/bindings@1.0.3", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.1", "zod": "^3.25.76", "zod-from-json-schema": "^0.0.5" } }, "sha512-0qGrAcH74Td9Ruhx7SI31o9mvKlMeQGtiRf5BzDcSgG0cvgJhaMMSvz72tvbUVl77GLu93v02NlKupui8yeiMw=="],
+
+    "@decocms/mcp-local-fs": ["@decocms/mcp-local-fs@workspace:local-fs"],
 
     "@decocms/mcps-shared": ["@decocms/mcps-shared@workspace:shared"],
 
@@ -805,7 +821,7 @@
 
     "@jsr/deco__codemod-toolkit": ["@jsr/deco__codemod-toolkit@0.3.4", "https://npm.jsr.io/~/11/@jsr/deco__codemod-toolkit/0.3.4.tgz", { "dependencies": { "@jsr/std__flags": "^0.224.0", "@jsr/std__fmt": "^1.0.0", "@jsr/std__fs": "^1.0.1", "@jsr/std__path": "^1.0.2", "@jsr/std__semver": "^1.0.1", "diff": "5.1.0", "ts-morph": "^21.0" } }, "sha512-ykI472we3cPyP1bDJ9TCfAqFu2CYMghLNx+UVVuByEvkRikMGfffQpRl18yqQnQ0elVYJtyr7InJVzlzuw1sRA=="],
 
-    "@jsr/deco__deco": ["@jsr/deco__deco@1.133.2", "https://npm.jsr.io/~/11/@jsr/deco__deco/1.133.2.tgz", { "dependencies": { "@jsr/core__asyncutil": "^1.0.2", "@jsr/deco__codemod-toolkit": "^0.3.4", "@jsr/deco__deno-ast-wasm": "^0.5.5", "@jsr/deco__durable": "^0.5.3", "@jsr/deco__inspect-vscode": "0.2.1", "@jsr/deco__warp": "^0.3.8", "@jsr/deno__cache-dir": "0.10.1", "@jsr/hono__hono": "^4.5.4", "@jsr/std__assert": "^1.0.2", "@jsr/std__async": "^0.224.1", "@jsr/std__cli": "^1.0.3", "@jsr/std__crypto": "1.0.0-rc.1", "@jsr/std__encoding": "^1.0.0-rc.1", "@jsr/std__flags": "^0.224.0", "@jsr/std__fmt": "^0.225.3", "@jsr/std__fs": "^0.229.1", "@jsr/std__http": "^1.0.0", "@jsr/std__io": "^0.224.4", "@jsr/std__log": "^0.224.5", "@jsr/std__media-types": "^1.0.0-rc.1", "@jsr/std__path": "^0.225.2", "@jsr/std__semver": "^0.224.3", "@jsr/zaubrik__djwt": "^3.0.2", "@opentelemetry/api": "1.9.0", "@opentelemetry/api-logs": "0.52.1", "@opentelemetry/exporter-logs-otlp-http": "0.52.1", "@opentelemetry/exporter-metrics-otlp-http": "0.52.1", "@opentelemetry/exporter-trace-otlp-proto": "0.52.1", "@opentelemetry/instrumentation": "0.52.1", "@opentelemetry/instrumentation-fetch": "0.52.1", "@opentelemetry/otlp-exporter-base": "0.52.1", "@opentelemetry/resources": "1.25.1", "@opentelemetry/sdk-logs": "0.52.1", "@opentelemetry/sdk-metrics": "1.25.1", "@opentelemetry/sdk-trace-base": "1.25.1", "@opentelemetry/sdk-trace-node": "1.25.1", "@opentelemetry/semantic-conventions": "1.25.1", "@redis/client": "^1.6.0", "@types/json-schema": "7.0.11", "brotli": "1.3.3", "fast-json-patch": "^3.1.1", "lru-cache": "10.2.0", "preact": "10.23.1", "preact-render-to-string": "6.4.0", "simple-git": "^3.25.0", "terser": "5.34.0", "ua-parser-js": "2.0.0-beta.2", "unique-names-generator": "4.7.1", "utility-types": "3.10.0", "weak-lru-cache": "1.0.0" } }, "sha512-qoudkjNvEAsPIgdgB9RKp8WD29ZU6+1m8w4QA6ku0v3QnUVOGlSkNiNEHLKqTpg1d5ByKIC3ePFKPVrXOqES/w=="],
+    "@jsr/deco__deco": ["@jsr/deco__deco@1.133.1", "https://npm.jsr.io/~/11/@jsr/deco__deco/1.133.1.tgz", { "dependencies": { "@jsr/core__asyncutil": "^1.0.2", "@jsr/deco__codemod-toolkit": "^0.3.4", "@jsr/deco__deno-ast-wasm": "^0.5.5", "@jsr/deco__durable": "^0.5.3", "@jsr/deco__inspect-vscode": "0.2.1", "@jsr/deco__warp": "^0.3.8", "@jsr/deno__cache-dir": "0.10.1", "@jsr/hono__hono": "^4.5.4", "@jsr/std__assert": "^1.0.2", "@jsr/std__async": "^0.224.1", "@jsr/std__cli": "^1.0.3", "@jsr/std__crypto": "1.0.0-rc.1", "@jsr/std__encoding": "^1.0.0-rc.1", "@jsr/std__flags": "^0.224.0", "@jsr/std__fmt": "^0.225.3", "@jsr/std__fs": "^0.229.1", "@jsr/std__http": "^1.0.0", "@jsr/std__io": "^0.224.4", "@jsr/std__log": "^0.224.5", "@jsr/std__media-types": "^1.0.0-rc.1", "@jsr/std__path": "^0.225.2", "@jsr/std__semver": "^0.224.3", "@jsr/zaubrik__djwt": "^3.0.2", "@opentelemetry/api": "1.9.0", "@opentelemetry/api-logs": "0.52.1", "@opentelemetry/exporter-logs-otlp-http": "0.52.1", "@opentelemetry/exporter-metrics-otlp-http": "0.52.1", "@opentelemetry/exporter-trace-otlp-proto": "0.52.1", "@opentelemetry/instrumentation": "0.52.1", "@opentelemetry/instrumentation-fetch": "0.52.1", "@opentelemetry/otlp-exporter-base": "0.52.1", "@opentelemetry/resources": "1.25.1", "@opentelemetry/sdk-logs": "0.52.1", "@opentelemetry/sdk-metrics": "1.25.1", "@opentelemetry/sdk-trace-base": "1.25.1", "@opentelemetry/sdk-trace-node": "1.25.1", "@opentelemetry/semantic-conventions": "1.25.1", "@redis/client": "^1.6.0", "@types/json-schema": "7.0.11", "brotli": "1.3.3", "fast-json-patch": "^3.1.1", "lru-cache": "10.2.0", "preact": "10.23.1", "preact-render-to-string": "6.4.0", "simple-git": "^3.25.0", "terser": "5.34.0", "ua-parser-js": "2.0.0-beta.2", "unique-names-generator": "4.7.1", "utility-types": "3.10.0", "weak-lru-cache": "1.0.0" } }, "sha512-aLQk/sYlkPlUYrGCHEjJPfG8AmON2QahqRCw4Pc4gOFZA/vHOH+RYs/cOJsJGwZittUC/GcEssQqdgDvaaFB/A=="],
 
     "@jsr/deco__deno-ast-wasm": ["@jsr/deco__deno-ast-wasm@0.5.5", "https://npm.jsr.io/~/11/@jsr/deco__deno-ast-wasm/0.5.5.tgz", {}, "sha512-weeOVf6cddt6hGDUNlMYbCAxV2nCnj3fm7Pb7pdqvKus9Wqo9NmcWKyZqu5P5Q0ai9xOFURFa+GGEZP0pRfIwg=="],
 
@@ -1359,9 +1375,9 @@
 
     "@tanstack/history": ["@tanstack/history@1.141.0", "", {}, "sha512-LS54XNyxyTs5m/pl1lkwlg7uZM3lvsv2FIIV1rsJgnfwVCnI+n4ZGZ2CcjNT13BPu/3hPP+iHmliBSscJxW5FQ=="],
 
-    "@tanstack/query-core": ["@tanstack/query-core@5.90.16", "", {}, "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww=="],
+    "@tanstack/query-core": ["@tanstack/query-core@5.90.15", "", {}, "sha512-mInIZNUZftbERE+/Hbtswfse49uUQwch46p+27gP9DWJL927UjnaWEF2t3RMOqBcXbfMdcNkPe06VyUIAZTV1g=="],
 
-    "@tanstack/react-query": ["@tanstack/react-query@5.90.16", "", { "dependencies": { "@tanstack/query-core": "5.90.16" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-bpMGOmV4OPmif7TNMteU/Ehf/hoC0Kf98PDc0F4BZkFrEapRMEqI/V6YS0lyzwSV6PQpY1y4xxArUIfBW5LVxQ=="],
+    "@tanstack/react-query": ["@tanstack/react-query@5.90.15", "", { "dependencies": { "@tanstack/query-core": "5.90.15" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-uQvnDDcTOgJouNtAyrgRej+Azf0U5WDov3PXmHFUBc+t1INnAYhIlpZtCGNBLwCN41b43yO7dPNZu8xWkUFBwQ=="],
 
     "@tanstack/react-router": ["@tanstack/react-router@1.144.0", "", { "dependencies": { "@tanstack/history": "1.141.0", "@tanstack/react-store": "^0.8.0", "@tanstack/router-core": "1.144.0", "isbot": "^5.1.22", "tiny-invariant": "^1.3.3", "tiny-warning": "^1.0.3" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-GmRyIGmHtGj3VLTHXepIwXAxTcHyL5W7Vw7O1CnVEtFxQQWKMVOnWgI7tPY6FhlNwMKVb3n0mPFWz9KMYyd2GA=="],
 
@@ -1459,7 +1475,7 @@
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
-    "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+    "acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
 
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
 
@@ -1469,7 +1485,7 @@
 
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
-    "ai": ["ai@6.0.5", "", { "dependencies": { "@ai-sdk/gateway": "3.0.4", "@ai-sdk/provider": "3.0.1", "@ai-sdk/provider-utils": "4.0.2", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CKL3dDHedWskC6EY67LrULonZBU9vL+Bwa+xQEcprBhJfxpogntG3utjiAkYuy5ZQatyWk+SmWG8HLvcnhvbRg=="],
+    "ai": ["ai@6.0.3", "", { "dependencies": { "@ai-sdk/gateway": "3.0.2", "@ai-sdk/provider": "3.0.0", "@ai-sdk/provider-utils": "4.0.1", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-OOo+/C+sEyscoLnbY3w42vjQDICioVNyS+F+ogwq6O5RJL/vgWGuiLzFwuP7oHTeni/MkmX8tIge48GTdaV7QQ=="],
 
     "ai-v5": ["ai@5.0.97", "", { "dependencies": { "@ai-sdk/gateway": "2.0.12", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-8zBx0b/owis4eJI2tAlV8a1Rv0BANmLxontcAelkLNwEHhgfgXeKpDkhNB6OgV+BJSwboIUDkgd9312DdJnCOQ=="],
 
@@ -2381,6 +2397,10 @@
 
     "@ai-sdk/google-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
 
+    "@ai-sdk/mcp/@ai-sdk/provider": ["@ai-sdk/provider@3.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-2lR4w7mr9XrydzxBSjir4N6YMGdXD+Np1Sh0RXABh7tWdNFFwIeRI1Q+SaYZMbfL8Pg8RRLcrxQm51yxTLhokg=="],
+
+    "@ai-sdk/mcp/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.2", "", { "dependencies": { "@ai-sdk/provider": "3.0.1", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-KaykkuRBdF/ffpI5bwpL4aSCmO/99p8/ci+VeHwJO8tmvXtiVAb99QeyvvvXmL61e9Zrvv4GBGoajW19xdjkVQ=="],
+
     "@ai-sdk/mistral-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
 
     "@ai-sdk/mistral-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.16", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-lsWQY9aDXHitw7C1QRYIbVGmgwyT98TF3MfM8alNIXKpdJdi+W782Rzd9f1RyOfgRmZ08gJ2EYNDhWNK7RqpEA=="],
@@ -2425,13 +2445,11 @@
 
     "@deco-cx/warp-node/undici": ["undici@6.22.0", "", {}, "sha512-hU/10obOIu62MGYjdskASR3CUAiYaFTtC9Pa6vHyf//mAipSvSQg6od2CnJswq7fvzNS3zJhxoRkgNVaHurWKw=="],
 
-    "@deco/mcp/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
-
     "@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
 
-    "@decocms/runtime/@mastra/core": ["@mastra/core@0.20.2", "", { "dependencies": { "@a2a-js/sdk": "~0.2.4", "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.23", "@ai-sdk/google-v5": "npm:@ai-sdk/google@2.0.17", "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.19", "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.42", "@ai-sdk/provider": "^1.1.3", "@ai-sdk/provider-utils": "^2.2.8", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.10", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.0", "@ai-sdk/ui-utils": "^1.2.11", "@ai-sdk/xai-v5": "npm:@ai-sdk/xai@2.0.23", "@isaacs/ttlcache": "^1.4.1", "@mastra/schema-compat": "0.11.4", "@openrouter/ai-sdk-provider-v5": "npm:@openrouter/ai-sdk-provider@1.2.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/auto-instrumentations-node": "^0.62.1", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0", "@opentelemetry/exporter-trace-otlp-http": "^0.203.0", "@opentelemetry/otlp-exporter-base": "^0.203.0", "@opentelemetry/otlp-transformer": "^0.203.0", "@opentelemetry/resources": "^2.0.1", "@opentelemetry/sdk-metrics": "^2.0.1", "@opentelemetry/sdk-node": "^0.203.0", "@opentelemetry/sdk-trace-base": "^2.0.1", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/semantic-conventions": "^1.36.0", "@sindresorhus/slugify": "^2.2.1", "ai": "^4.3.19", "ai-v5": "npm:ai@5.0.60", "date-fns": "^3.6.0", "dotenv": "^16.6.1", "hono": "^4.9.7", "hono-openapi": "^0.4.8", "js-tiktoken": "^1.0.20", "json-schema": "^0.4.0", "json-schema-to-zod": "^2.6.1", "p-map": "^7.0.3", "pino": "^9.7.0", "pino-pretty": "^13.0.0", "radash": "^12.1.1", "sift": "^17.1.3", "xstate": "^5.20.1", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-RbwuLwOVrcLbbjLFEBSlGTBA3mzGAy4bXp4JeXg2miJWDR/7WbXtxKIU+sTZGw5LpzlvvEFtj7JtHI1l+gKMVg=="],
+    "@decocms/mcp-local-fs/@types/node": ["@types/node@22.19.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA=="],
 
-    "@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
+    "@decocms/runtime/@mastra/core": ["@mastra/core@0.20.2", "", { "dependencies": { "@a2a-js/sdk": "~0.2.4", "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.23", "@ai-sdk/google-v5": "npm:@ai-sdk/google@2.0.17", "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.19", "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.42", "@ai-sdk/provider": "^1.1.3", "@ai-sdk/provider-utils": "^2.2.8", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.10", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.0", "@ai-sdk/ui-utils": "^1.2.11", "@ai-sdk/xai-v5": "npm:@ai-sdk/xai@2.0.23", "@isaacs/ttlcache": "^1.4.1", "@mastra/schema-compat": "0.11.4", "@openrouter/ai-sdk-provider-v5": "npm:@openrouter/ai-sdk-provider@1.2.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/auto-instrumentations-node": "^0.62.1", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0", "@opentelemetry/exporter-trace-otlp-http": "^0.203.0", "@opentelemetry/otlp-exporter-base": "^0.203.0", "@opentelemetry/otlp-transformer": "^0.203.0", "@opentelemetry/resources": "^2.0.1", "@opentelemetry/sdk-metrics": "^2.0.1", "@opentelemetry/sdk-node": "^0.203.0", "@opentelemetry/sdk-trace-base": "^2.0.1", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/semantic-conventions": "^1.36.0", "@sindresorhus/slugify": "^2.2.1", "ai": "^4.3.19", "ai-v5": "npm:ai@5.0.60", "date-fns": "^3.6.0", "dotenv": "^16.6.1", "hono": "^4.9.7", "hono-openapi": "^0.4.8", "js-tiktoken": "^1.0.20", "json-schema": "^0.4.0", "json-schema-to-zod": "^2.6.1", "p-map": "^7.0.3", "pino": "^9.7.0", "pino-pretty": "^13.0.0", "radash": "^12.1.1", "sift": "^17.1.3", "xstate": "^5.20.1", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-RbwuLwOVrcLbbjLFEBSlGTBA3mzGAy4bXp4JeXg2miJWDR/7WbXtxKIU+sTZGw5LpzlvvEFtj7JtHI1l+gKMVg=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
@@ -2637,7 +2655,7 @@
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" }, "bundled": true }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.0", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" }, "bundled": true }, "sha512-Fq6DJW+Bb5jaWE69/qOE0D1TUN9+6uWhCeZpdnSBk14pjLcCWR7Q8n49PTSPHazM37JqrsdpEthXy2xn6jWWiA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
@@ -2697,17 +2715,19 @@
 
     "meta-ads/@decocms/runtime": ["@decocms/runtime@1.0.3", "", { "dependencies": { "@ai-sdk/provider": "^2.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "1.0.3", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^3.25.76", "zod-to-json-schema": "3.25.0" } }, "sha512-uAM3TLsJh7oxyT1CUQckxZbPiKUqqM3zER31EZ3n8azyShsiCKukGLz46bbJSgjajPf8TysaplH9ARR17s7a1Q=="],
 
+    "meta-ads/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
+
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "miniflare/acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
 
     "miniflare/zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
 
     "object-storage/lucide-react": ["lucide-react@0.476.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-x6cLTk8gahdUPje0hSgLN1/MgiJH+Xl90Xoxy9bkPAsMPOUiyRSKR4JCDPGVCEpyqnZXH3exFWNItcvra9WzUQ=="],
 
     "openrouter/@decocms/runtime": ["@decocms/runtime@1.0.3", "", { "dependencies": { "@ai-sdk/provider": "^2.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "1.0.3", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^3.25.76", "zod-to-json-schema": "3.25.0" } }, "sha512-uAM3TLsJh7oxyT1CUQckxZbPiKUqqM3zER31EZ3n8azyShsiCKukGLz46bbJSgjajPf8TysaplH9ARR17s7a1Q=="],
+
+    "openrouter/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
 
     "ora/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -2720,6 +2740,8 @@
     "pino-pretty/secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
     "registry/@decocms/runtime": ["@decocms/runtime@1.0.3", "", { "dependencies": { "@ai-sdk/provider": "^2.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "1.0.3", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^3.25.76", "zod-to-json-schema": "3.25.0" } }, "sha512-uAM3TLsJh7oxyT1CUQckxZbPiKUqqM3zER31EZ3n8azyShsiCKukGLz46bbJSgjajPf8TysaplH9ARR17s7a1Q=="],
+
+    "registry/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
 
     "registry/@types/node": ["@types/node@22.19.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA=="],
 
@@ -2777,9 +2799,11 @@
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "@deco/mcp/@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
     "@decocms/bindings/@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "@decocms/bindings/@modelcontextprotocol/sdk/zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
+
+    "@decocms/mcp-local-fs/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5": ["@ai-sdk/anthropic@2.0.23", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZEBiiv1UhjGjBwUU63pFhLK5LCSlNDb1idY9K1oZHm5/Fda1cuTojf32tOp0opH0RPbPAN/F8fyyNjbU33n9Kw=="],
 
@@ -2804,8 +2828,6 @@
     "@decocms/runtime/@mastra/core/ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
 
     "@decocms/runtime/@mastra/core/ai-v5": ["ai@5.0.60", "", { "dependencies": { "@ai-sdk/gateway": "1.0.33", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-80U/3kmdBW6g+JkLXpz/P2EwkyEaWlPlYtuLUpx/JYK9F7WZh9NnkYoh1KvUi1Sbpo0NyurBTvX0a2AG9mmbDA=="],
-
-    "@decocms/runtime/@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -2865,7 +2887,7 @@
 
     "@mastra/schema-compat/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
 
-    "@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.3.2", "", {}, "sha512-b8L8yn4rIVfiXyHAmnr52/ZEpDumlT0bmxiq3Ws1ybrinhflGpt12Hvv54kYnEsGPRs6o/Ka3/ppA2OWY21IVg=="],
+    "@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
 
     "@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W+cB1sOWvPcz9qiIsNtD+HxUrBUva2vWv2K1EFukuImX+HA0uZx3EyyOjhYQ9gtf/teqEG80M6OvJ7xx/VLV2A=="],
 
@@ -2889,19 +2911,13 @@
 
     "apify/@decocms/runtime/@mastra/core": ["@mastra/core@0.20.2", "", { "dependencies": { "@a2a-js/sdk": "~0.2.4", "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.23", "@ai-sdk/google-v5": "npm:@ai-sdk/google@2.0.17", "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.19", "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.42", "@ai-sdk/provider": "^1.1.3", "@ai-sdk/provider-utils": "^2.2.8", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.10", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.0", "@ai-sdk/ui-utils": "^1.2.11", "@ai-sdk/xai-v5": "npm:@ai-sdk/xai@2.0.23", "@isaacs/ttlcache": "^1.4.1", "@mastra/schema-compat": "0.11.4", "@openrouter/ai-sdk-provider-v5": "npm:@openrouter/ai-sdk-provider@1.2.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/auto-instrumentations-node": "^0.62.1", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0", "@opentelemetry/exporter-trace-otlp-http": "^0.203.0", "@opentelemetry/otlp-exporter-base": "^0.203.0", "@opentelemetry/otlp-transformer": "^0.203.0", "@opentelemetry/resources": "^2.0.1", "@opentelemetry/sdk-metrics": "^2.0.1", "@opentelemetry/sdk-node": "^0.203.0", "@opentelemetry/sdk-trace-base": "^2.0.1", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/semantic-conventions": "^1.36.0", "@sindresorhus/slugify": "^2.2.1", "ai": "^4.3.19", "ai-v5": "npm:ai@5.0.60", "date-fns": "^3.6.0", "dotenv": "^16.6.1", "hono": "^4.9.7", "hono-openapi": "^0.4.8", "js-tiktoken": "^1.0.20", "json-schema": "^0.4.0", "json-schema-to-zod": "^2.6.1", "p-map": "^7.0.3", "pino": "^9.7.0", "pino-pretty": "^13.0.0", "radash": "^12.1.1", "sift": "^17.1.3", "xstate": "^5.20.1", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-RbwuLwOVrcLbbjLFEBSlGTBA3mzGAy4bXp4JeXg2miJWDR/7WbXtxKIU+sTZGw5LpzlvvEFtj7JtHI1l+gKMVg=="],
 
-    "apify/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
-
     "cloudflare/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "concurrently/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "data-for-seo/@decocms/runtime/@mastra/core": ["@mastra/core@0.20.2", "", { "dependencies": { "@a2a-js/sdk": "~0.2.4", "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.23", "@ai-sdk/google-v5": "npm:@ai-sdk/google@2.0.17", "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.19", "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.42", "@ai-sdk/provider": "^1.1.3", "@ai-sdk/provider-utils": "^2.2.8", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.10", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.0", "@ai-sdk/ui-utils": "^1.2.11", "@ai-sdk/xai-v5": "npm:@ai-sdk/xai@2.0.23", "@isaacs/ttlcache": "^1.4.1", "@mastra/schema-compat": "0.11.4", "@openrouter/ai-sdk-provider-v5": "npm:@openrouter/ai-sdk-provider@1.2.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/auto-instrumentations-node": "^0.62.1", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0", "@opentelemetry/exporter-trace-otlp-http": "^0.203.0", "@opentelemetry/otlp-exporter-base": "^0.203.0", "@opentelemetry/otlp-transformer": "^0.203.0", "@opentelemetry/resources": "^2.0.1", "@opentelemetry/sdk-metrics": "^2.0.1", "@opentelemetry/sdk-node": "^0.203.0", "@opentelemetry/sdk-trace-base": "^2.0.1", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/semantic-conventions": "^1.36.0", "@sindresorhus/slugify": "^2.2.1", "ai": "^4.3.19", "ai-v5": "npm:ai@5.0.60", "date-fns": "^3.6.0", "dotenv": "^16.6.1", "hono": "^4.9.7", "hono-openapi": "^0.4.8", "js-tiktoken": "^1.0.20", "json-schema": "^0.4.0", "json-schema-to-zod": "^2.6.1", "p-map": "^7.0.3", "pino": "^9.7.0", "pino-pretty": "^13.0.0", "radash": "^12.1.1", "sift": "^17.1.3", "xstate": "^5.20.1", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-RbwuLwOVrcLbbjLFEBSlGTBA3mzGAy4bXp4JeXg2miJWDR/7WbXtxKIU+sTZGw5LpzlvvEFtj7JtHI1l+gKMVg=="],
 
-    "data-for-seo/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
-
     "gemini-pro-vision/@decocms/runtime/@mastra/core": ["@mastra/core@0.20.2", "", { "dependencies": { "@a2a-js/sdk": "~0.2.4", "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.23", "@ai-sdk/google-v5": "npm:@ai-sdk/google@2.0.17", "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.19", "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.42", "@ai-sdk/provider": "^1.1.3", "@ai-sdk/provider-utils": "^2.2.8", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.10", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.0", "@ai-sdk/ui-utils": "^1.2.11", "@ai-sdk/xai-v5": "npm:@ai-sdk/xai@2.0.23", "@isaacs/ttlcache": "^1.4.1", "@mastra/schema-compat": "0.11.4", "@openrouter/ai-sdk-provider-v5": "npm:@openrouter/ai-sdk-provider@1.2.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/auto-instrumentations-node": "^0.62.1", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0", "@opentelemetry/exporter-trace-otlp-http": "^0.203.0", "@opentelemetry/otlp-exporter-base": "^0.203.0", "@opentelemetry/otlp-transformer": "^0.203.0", "@opentelemetry/resources": "^2.0.1", "@opentelemetry/sdk-metrics": "^2.0.1", "@opentelemetry/sdk-node": "^0.203.0", "@opentelemetry/sdk-trace-base": "^2.0.1", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/semantic-conventions": "^1.36.0", "@sindresorhus/slugify": "^2.2.1", "ai": "^4.3.19", "ai-v5": "npm:ai@5.0.60", "date-fns": "^3.6.0", "dotenv": "^16.6.1", "hono": "^4.9.7", "hono-openapi": "^0.4.8", "js-tiktoken": "^1.0.20", "json-schema": "^0.4.0", "json-schema-to-zod": "^2.6.1", "p-map": "^7.0.3", "pino": "^9.7.0", "pino-pretty": "^13.0.0", "radash": "^12.1.1", "sift": "^17.1.3", "xstate": "^5.20.1", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-RbwuLwOVrcLbbjLFEBSlGTBA3mzGAy4bXp4JeXg2miJWDR/7WbXtxKIU+sTZGw5LpzlvvEFtj7JtHI1l+gKMVg=="],
-
-    "gemini-pro-vision/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
 
     "inquirer-search-checkbox/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
 
@@ -2945,41 +2961,45 @@
 
     "log-symbols/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "mcp-studio/@decocms/runtime/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+    "mcp-studio/@decocms/runtime/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
 
     "mcp-studio/@decocms/runtime/zod-to-json-schema": ["zod-to-json-schema@3.25.0", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ=="],
 
     "mcp-studio/@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
-    "meta-ads/@decocms/runtime/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+    "mcp-studio/@modelcontextprotocol/sdk/zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
 
-    "meta-ads/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
+    "meta-ads/@decocms/runtime/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
 
     "meta-ads/@decocms/runtime/zod-to-json-schema": ["zod-to-json-schema@3.25.0", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ=="],
 
-    "openrouter/@decocms/runtime/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+    "meta-ads/@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
-    "openrouter/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
+    "meta-ads/@modelcontextprotocol/sdk/zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
+
+    "openrouter/@decocms/runtime/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
 
     "openrouter/@decocms/runtime/zod-to-json-schema": ["zod-to-json-schema@3.25.0", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ=="],
+
+    "openrouter/@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "openrouter/@modelcontextprotocol/sdk/zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
 
     "ora/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "perplexity/@decocms/runtime/@mastra/core": ["@mastra/core@0.20.2", "", { "dependencies": { "@a2a-js/sdk": "~0.2.4", "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.23", "@ai-sdk/google-v5": "npm:@ai-sdk/google@2.0.17", "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.19", "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.42", "@ai-sdk/provider": "^1.1.3", "@ai-sdk/provider-utils": "^2.2.8", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.10", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.0", "@ai-sdk/ui-utils": "^1.2.11", "@ai-sdk/xai-v5": "npm:@ai-sdk/xai@2.0.23", "@isaacs/ttlcache": "^1.4.1", "@mastra/schema-compat": "0.11.4", "@openrouter/ai-sdk-provider-v5": "npm:@openrouter/ai-sdk-provider@1.2.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/auto-instrumentations-node": "^0.62.1", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0", "@opentelemetry/exporter-trace-otlp-http": "^0.203.0", "@opentelemetry/otlp-exporter-base": "^0.203.0", "@opentelemetry/otlp-transformer": "^0.203.0", "@opentelemetry/resources": "^2.0.1", "@opentelemetry/sdk-metrics": "^2.0.1", "@opentelemetry/sdk-node": "^0.203.0", "@opentelemetry/sdk-trace-base": "^2.0.1", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/semantic-conventions": "^1.36.0", "@sindresorhus/slugify": "^2.2.1", "ai": "^4.3.19", "ai-v5": "npm:ai@5.0.60", "date-fns": "^3.6.0", "dotenv": "^16.6.1", "hono": "^4.9.7", "hono-openapi": "^0.4.8", "js-tiktoken": "^1.0.20", "json-schema": "^0.4.0", "json-schema-to-zod": "^2.6.1", "p-map": "^7.0.3", "pino": "^9.7.0", "pino-pretty": "^13.0.0", "radash": "^12.1.1", "sift": "^17.1.3", "xstate": "^5.20.1", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-RbwuLwOVrcLbbjLFEBSlGTBA3mzGAy4bXp4JeXg2miJWDR/7WbXtxKIU+sTZGw5LpzlvvEFtj7JtHI1l+gKMVg=="],
 
-    "perplexity/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
-
-    "registry/@decocms/runtime/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
-
-    "registry/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
+    "registry/@decocms/runtime/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
 
     "registry/@decocms/runtime/zod-to-json-schema": ["zod-to-json-schema@3.25.0", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ=="],
+
+    "registry/@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "registry/@modelcontextprotocol/sdk/zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
 
     "registry/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "whisper/@decocms/runtime/@mastra/core": ["@mastra/core@0.20.2", "", { "dependencies": { "@a2a-js/sdk": "~0.2.4", "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.23", "@ai-sdk/google-v5": "npm:@ai-sdk/google@2.0.17", "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.19", "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.42", "@ai-sdk/provider": "^1.1.3", "@ai-sdk/provider-utils": "^2.2.8", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.10", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.0", "@ai-sdk/ui-utils": "^1.2.11", "@ai-sdk/xai-v5": "npm:@ai-sdk/xai@2.0.23", "@isaacs/ttlcache": "^1.4.1", "@mastra/schema-compat": "0.11.4", "@openrouter/ai-sdk-provider-v5": "npm:@openrouter/ai-sdk-provider@1.2.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/auto-instrumentations-node": "^0.62.1", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0", "@opentelemetry/exporter-trace-otlp-http": "^0.203.0", "@opentelemetry/otlp-exporter-base": "^0.203.0", "@opentelemetry/otlp-transformer": "^0.203.0", "@opentelemetry/resources": "^2.0.1", "@opentelemetry/sdk-metrics": "^2.0.1", "@opentelemetry/sdk-node": "^0.203.0", "@opentelemetry/sdk-trace-base": "^2.0.1", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/semantic-conventions": "^1.36.0", "@sindresorhus/slugify": "^2.2.1", "ai": "^4.3.19", "ai-v5": "npm:ai@5.0.60", "date-fns": "^3.6.0", "dotenv": "^16.6.1", "hono": "^4.9.7", "hono-openapi": "^0.4.8", "js-tiktoken": "^1.0.20", "json-schema": "^0.4.0", "json-schema-to-zod": "^2.6.1", "p-map": "^7.0.3", "pino": "^9.7.0", "pino-pretty": "^13.0.0", "radash": "^12.1.1", "sift": "^17.1.3", "xstate": "^5.20.1", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-RbwuLwOVrcLbbjLFEBSlGTBA3mzGAy4bXp4JeXg2miJWDR/7WbXtxKIU+sTZGw5LpzlvvEFtj7JtHI1l+gKMVg=="],
-
-    "whisper/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
 
     "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
 
@@ -3055,8 +3075,6 @@
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
-    "@deco/mcp/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
     "@decocms/bindings/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
@@ -3093,8 +3111,6 @@
 
     "@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
 
-    "@decocms/runtime/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
     "apify/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5": ["@ai-sdk/anthropic@2.0.23", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZEBiiv1UhjGjBwUU63pFhLK5LCSlNDb1idY9K1oZHm5/Fda1cuTojf32tOp0opH0RPbPAN/F8fyyNjbU33n9Kw=="],
 
     "apify/@decocms/runtime/@mastra/core/@ai-sdk/google-v5": ["@ai-sdk/google@2.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-6LyuUrCZuiULg0rUV+kT4T2jG19oUntudorI4ttv1ARkSbwl8A39ue3rA487aDDy6fUScdbGFiV5Yv/o4gidVA=="],
@@ -3118,8 +3134,6 @@
     "apify/@decocms/runtime/@mastra/core/ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
 
     "apify/@decocms/runtime/@mastra/core/ai-v5": ["ai@5.0.60", "", { "dependencies": { "@ai-sdk/gateway": "1.0.33", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-80U/3kmdBW6g+JkLXpz/P2EwkyEaWlPlYtuLUpx/JYK9F7WZh9NnkYoh1KvUi1Sbpo0NyurBTvX0a2AG9mmbDA=="],
-
-    "apify/@decocms/runtime/@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "data-for-seo/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5": ["@ai-sdk/anthropic@2.0.23", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZEBiiv1UhjGjBwUU63pFhLK5LCSlNDb1idY9K1oZHm5/Fda1cuTojf32tOp0opH0RPbPAN/F8fyyNjbU33n9Kw=="],
 
@@ -3145,8 +3159,6 @@
 
     "data-for-seo/@decocms/runtime/@mastra/core/ai-v5": ["ai@5.0.60", "", { "dependencies": { "@ai-sdk/gateway": "1.0.33", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-80U/3kmdBW6g+JkLXpz/P2EwkyEaWlPlYtuLUpx/JYK9F7WZh9NnkYoh1KvUi1Sbpo0NyurBTvX0a2AG9mmbDA=="],
 
-    "data-for-seo/@decocms/runtime/@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
     "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5": ["@ai-sdk/anthropic@2.0.23", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZEBiiv1UhjGjBwUU63pFhLK5LCSlNDb1idY9K1oZHm5/Fda1cuTojf32tOp0opH0RPbPAN/F8fyyNjbU33n9Kw=="],
 
     "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/google-v5": ["@ai-sdk/google@2.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-6LyuUrCZuiULg0rUV+kT4T2jG19oUntudorI4ttv1ARkSbwl8A39ue3rA487aDDy6fUScdbGFiV5Yv/o4gidVA=="],
@@ -3171,8 +3183,6 @@
 
     "gemini-pro-vision/@decocms/runtime/@mastra/core/ai-v5": ["ai@5.0.60", "", { "dependencies": { "@ai-sdk/gateway": "1.0.33", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-80U/3kmdBW6g+JkLXpz/P2EwkyEaWlPlYtuLUpx/JYK9F7WZh9NnkYoh1KvUi1Sbpo0NyurBTvX0a2AG9mmbDA=="],
 
-    "gemini-pro-vision/@decocms/runtime/@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
     "inquirer-search-checkbox/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
 
     "inquirer-search-checkbox/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
@@ -3195,13 +3205,9 @@
 
     "mcp-studio/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "meta-ads/@decocms/runtime/@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+    "meta-ads/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "meta-ads/@decocms/runtime/@modelcontextprotocol/sdk/zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
-
-    "openrouter/@decocms/runtime/@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
-    "openrouter/@decocms/runtime/@modelcontextprotocol/sdk/zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+    "openrouter/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "perplexity/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5": ["@ai-sdk/anthropic@2.0.23", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZEBiiv1UhjGjBwUU63pFhLK5LCSlNDb1idY9K1oZHm5/Fda1cuTojf32tOp0opH0RPbPAN/F8fyyNjbU33n9Kw=="],
 
@@ -3227,11 +3233,7 @@
 
     "perplexity/@decocms/runtime/@mastra/core/ai-v5": ["ai@5.0.60", "", { "dependencies": { "@ai-sdk/gateway": "1.0.33", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-80U/3kmdBW6g+JkLXpz/P2EwkyEaWlPlYtuLUpx/JYK9F7WZh9NnkYoh1KvUi1Sbpo0NyurBTvX0a2AG9mmbDA=="],
 
-    "perplexity/@decocms/runtime/@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
-    "registry/@decocms/runtime/@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
-    "registry/@decocms/runtime/@modelcontextprotocol/sdk/zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+    "registry/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "whisper/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5": ["@ai-sdk/anthropic@2.0.23", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZEBiiv1UhjGjBwUU63pFhLK5LCSlNDb1idY9K1oZHm5/Fda1cuTojf32tOp0opH0RPbPAN/F8fyyNjbU33n9Kw=="],
 
@@ -3257,9 +3259,7 @@
 
     "whisper/@decocms/runtime/@mastra/core/ai-v5": ["ai@5.0.60", "", { "dependencies": { "@ai-sdk/gateway": "1.0.33", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-80U/3kmdBW6g+JkLXpz/P2EwkyEaWlPlYtuLUpx/JYK9F7WZh9NnkYoh1KvUi1Sbpo0NyurBTvX0a2AG9mmbDA=="],
 
-    "whisper/@decocms/runtime/@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
-
-    "@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.3.2", "", {}, "sha512-b8L8yn4rIVfiXyHAmnr52/ZEpDumlT0bmxiq3Ws1ybrinhflGpt12Hvv54kYnEsGPRs6o/Ka3/ppA2OWY21IVg=="],
+    "@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
 
     "@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W+cB1sOWvPcz9qiIsNtD+HxUrBUva2vWv2K1EFukuImX+HA0uZx3EyyOjhYQ9gtf/teqEG80M6OvJ7xx/VLV2A=="],
 
@@ -3301,8 +3301,6 @@
 
     "apify/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
 
-    "apify/@decocms/runtime/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
     "data-for-seo/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
 
     "data-for-seo/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
@@ -3336,8 +3334,6 @@
     "data-for-seo/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
 
     "data-for-seo/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "data-for-seo/@decocms/runtime/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
 
@@ -3373,8 +3369,6 @@
 
     "gemini-pro-vision/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
 
-    "gemini-pro-vision/@decocms/runtime/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
     "inquirer-search-checkbox/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
     "inquirer-search-checkbox/inquirer/cli-cursor/restore-cursor/onetime": ["onetime@2.0.1", "", { "dependencies": { "mimic-fn": "^1.0.0" } }, "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ=="],
@@ -3386,10 +3380,6 @@
     "inquirer-search-list/inquirer/cli-cursor/restore-cursor/onetime": ["onetime@2.0.1", "", { "dependencies": { "mimic-fn": "^1.0.0" } }, "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ=="],
 
     "inquirer-search-list/inquirer/cli-cursor/restore-cursor/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
-    "meta-ads/@decocms/runtime/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "openrouter/@decocms/runtime/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "perplexity/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
 
@@ -3425,10 +3415,6 @@
 
     "perplexity/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
 
-    "perplexity/@decocms/runtime/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "registry/@decocms/runtime/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
     "whisper/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
 
     "whisper/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
@@ -3463,9 +3449,7 @@
 
     "whisper/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
 
-    "whisper/@decocms/runtime/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "apify/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.3.2", "", {}, "sha512-b8L8yn4rIVfiXyHAmnr52/ZEpDumlT0bmxiq3Ws1ybrinhflGpt12Hvv54kYnEsGPRs6o/Ka3/ppA2OWY21IVg=="],
+    "apify/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
 
     "apify/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W+cB1sOWvPcz9qiIsNtD+HxUrBUva2vWv2K1EFukuImX+HA0uZx3EyyOjhYQ9gtf/teqEG80M6OvJ7xx/VLV2A=="],
 
@@ -3473,7 +3457,7 @@
 
     "apify/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
 
-    "data-for-seo/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.3.2", "", {}, "sha512-b8L8yn4rIVfiXyHAmnr52/ZEpDumlT0bmxiq3Ws1ybrinhflGpt12Hvv54kYnEsGPRs6o/Ka3/ppA2OWY21IVg=="],
+    "data-for-seo/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
 
     "data-for-seo/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W+cB1sOWvPcz9qiIsNtD+HxUrBUva2vWv2K1EFukuImX+HA0uZx3EyyOjhYQ9gtf/teqEG80M6OvJ7xx/VLV2A=="],
 
@@ -3481,7 +3465,7 @@
 
     "data-for-seo/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
 
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.3.2", "", {}, "sha512-b8L8yn4rIVfiXyHAmnr52/ZEpDumlT0bmxiq3Ws1ybrinhflGpt12Hvv54kYnEsGPRs6o/Ka3/ppA2OWY21IVg=="],
+    "gemini-pro-vision/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
 
     "gemini-pro-vision/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W+cB1sOWvPcz9qiIsNtD+HxUrBUva2vWv2K1EFukuImX+HA0uZx3EyyOjhYQ9gtf/teqEG80M6OvJ7xx/VLV2A=="],
 
@@ -3493,7 +3477,7 @@
 
     "inquirer-search-list/inquirer/cli-cursor/restore-cursor/onetime/mimic-fn": ["mimic-fn@1.2.0", "", {}, "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="],
 
-    "perplexity/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.3.2", "", {}, "sha512-b8L8yn4rIVfiXyHAmnr52/ZEpDumlT0bmxiq3Ws1ybrinhflGpt12Hvv54kYnEsGPRs6o/Ka3/ppA2OWY21IVg=="],
+    "perplexity/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
 
     "perplexity/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W+cB1sOWvPcz9qiIsNtD+HxUrBUva2vWv2K1EFukuImX+HA0uZx3EyyOjhYQ9gtf/teqEG80M6OvJ7xx/VLV2A=="],
 
@@ -3501,7 +3485,7 @@
 
     "perplexity/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
 
-    "whisper/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.3.2", "", {}, "sha512-b8L8yn4rIVfiXyHAmnr52/ZEpDumlT0bmxiq3Ws1ybrinhflGpt12Hvv54kYnEsGPRs6o/Ka3/ppA2OWY21IVg=="],
+    "whisper/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
 
     "whisper/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W+cB1sOWvPcz9qiIsNtD+HxUrBUva2vWv2K1EFukuImX+HA0uZx3EyyOjhYQ9gtf/teqEG80M6OvJ7xx/VLV2A=="],
 

--- a/local-fs/README.md
+++ b/local-fs/README.md
@@ -1,0 +1,171 @@
+# @decocms/mcp-local-fs
+
+Mount any local filesystem path as an MCP server. **Drop-in replacement** for the official MCP filesystem server, with additional MCP Mesh collection bindings.
+
+## Features
+
+- 📁 Mount any filesystem path dynamically
+- 🔌 **Stdio transport** (default) - works with Claude Desktop, Cursor, and other MCP clients
+- 🌐 **HTTP transport** - for MCP Mesh integration
+- 🛠️ **Full MCP filesystem compatibility** - same tools as the official server
+- 📋 **Collection bindings** for Files and Folders (Mesh-compatible)
+- 🔄 **Backward compatible** - supports both official and Mesh tool names
+- ⚡ Zero config needed
+
+## Quick Start
+
+### Using npx (stdio mode - recommended for Claude Desktop)
+
+```bash
+# Mount current directory
+npx @decocms/mcp-local-fs
+
+# Mount specific path
+npx @decocms/mcp-local-fs /path/to/folder
+
+# Or with --path flag
+npx @decocms/mcp-local-fs --path /path/to/folder
+```
+
+### Claude Desktop Configuration
+
+Add to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "local-fs": {
+      "command": "npx",
+      "args": ["@decocms/mcp-local-fs", "/path/to/folder"]
+    }
+  }
+}
+```
+
+### Cursor Configuration
+
+Add to your Cursor MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "local-fs": {
+      "command": "npx",
+      "args": ["@decocms/mcp-local-fs", "/path/to/folder"]
+    }
+  }
+}
+```
+
+### HTTP Mode (for MCP Mesh)
+
+```bash
+# Start HTTP server on port 3456
+npx @decocms/mcp-local-fs --http
+
+# With custom port
+npx @decocms/mcp-local-fs --http --port 8080
+
+# Mount specific path
+npx @decocms/mcp-local-fs --http --path /your/folder
+```
+
+Then connect using:
+- `http://localhost:3456/mcp?path=/your/folder`
+- `http://localhost:3456/mcp/your/folder`
+
+## Adding to MCP Mesh
+
+Add a new connection with:
+- **Transport**: HTTP  
+- **URL**: `http://localhost:3456/mcp?path=/your/folder`
+
+Or use the path in URL format:
+- **URL**: `http://localhost:3456/mcp/home/user/documents`
+
+## Available Tools
+
+### Official MCP Filesystem Tools
+
+These tools follow the exact same schema as the [official MCP filesystem server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem):
+
+| Tool | Description |
+|------|-------------|
+| `read_file` | Read a file (deprecated, use `read_text_file`) |
+| `read_text_file` | Read a text file with optional head/tail params |
+| `read_media_file` | Read binary/media files as base64 |
+| `read_multiple_files` | Read multiple files at once |
+| `write_file` | Write content to a file |
+| `edit_file` | Search/replace edits with diff preview |
+| `create_directory` | Create a directory (with nested support) |
+| `list_directory` | List files and directories |
+| `list_directory_with_sizes` | List with file sizes |
+| `directory_tree` | Recursive tree view as JSON |
+| `move_file` | Move or rename files/directories |
+| `search_files` | Search files by glob pattern |
+| `get_file_info` | Get detailed file/directory metadata |
+| `list_allowed_directories` | Show allowed directories |
+
+### Additional Tools
+
+| Tool | Description |
+|------|-------------|
+| `delete_file` | Delete a file or directory (with recursive option) |
+| `copy_file` | Copy a file to a new location |
+
+### MCP Mesh Collection Bindings
+
+These tools provide standard collection bindings for MCP Mesh compatibility:
+
+| Tool | Description |
+|------|-------------|
+| `COLLECTION_FILES_LIST` | List files with pagination |
+| `COLLECTION_FILES_GET` | Get file metadata and content by path |
+| `COLLECTION_FOLDERS_LIST` | List folders with pagination |
+| `COLLECTION_FOLDERS_GET` | Get folder metadata by path |
+
+### MCP Mesh Compatibility Aliases
+
+For backward compatibility with existing Mesh connections, these aliases are also available:
+
+| Mesh Tool | Maps To |
+|-----------|---------|
+| `FILE_READ` | `read_text_file` |
+| `FILE_WRITE` | `write_file` |
+| `FILE_DELETE` | `delete_file` |
+| `FILE_MOVE` | `move_file` |
+| `FILE_COPY` | `copy_file` |
+| `FILE_MKDIR` | `create_directory` |
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `MCP_LOCAL_FS_PATH` | Default path to mount |
+| `PORT` | HTTP server port (default: 3456) |
+
+## Development
+
+```bash
+# Install dependencies
+npm install
+
+# Run in stdio mode (development)
+npm run dev:stdio
+
+# Run in http mode (development)
+npm run dev
+
+# Run tests
+npm test
+
+# Type check
+npm run check
+
+# Build for distribution
+npm run build
+```
+
+## License
+
+MIT

--- a/local-fs/bun.lock
+++ b/local-fs/bun.lock
@@ -1,0 +1,206 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@decocms/mcp-local-fs",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.20.2",
+        "kill-my-port": "^1.1.2",
+        "zod": "^3.24.0",
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0",
+      },
+    },
+  },
+  "packages": {
+    "@hono/node-server": ["@hono/node-server@1.19.7", "", { "peerDependencies": { "hono": "^4" } }, ""],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
+
+    "@types/node": ["@types/node@22.19.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, ""],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" }, "peerDependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.2.1", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.11.3", "", {}, ""],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.1", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "kill-my-port": ["kill-my-port@1.1.2", "", { "bin": { "kill-my-port": "index.js" } }, "sha512-8T/8GdIGL1Ia1BbKykztZZigVQ7gRckGYQ2bnCOPZ+V+QrpCEAxz4rtVSRZRUZwr+50fBnitIMM8qEtUS8ZWfQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, ""],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, ""],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@3.25.76", "", {}, ""],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, ""],
+  }
+}

--- a/local-fs/package.json
+++ b/local-fs/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@decocms/mcp-local-fs",
+  "version": "1.0.2",
+  "description": "MCP server that mounts any local filesystem path. Supports stdio (default) and HTTP transports.",
+  "type": "module",
+  "main": "./dist/cli.js",
+  "bin": {
+    "mcp-local-fs": "./dist/cli.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "bun run server/http.ts",
+    "dev:stdio": "bun run server/stdio.ts",
+    "start": "node dist/cli.js",
+    "start:http": "node dist/cli.js --http",
+    "check": "tsc --noEmit",
+    "test": "bun test",
+    "test:watch": "bun test --watch",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.20.2",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "filesystem",
+    "local-fs",
+    "ai",
+    "claude",
+    "mesh",
+    "stdio"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/decocms/mcps.git",
+    "directory": "local-fs"
+  },
+  "author": "DecoCMS",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/local-fs/server/cli.ts
+++ b/local-fs/server/cli.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * MCP Local FS - CLI Entry Point
+ *
+ * Unified CLI that supports both stdio (default) and http transports.
+ *
+ * Usage:
+ *   npx @decocms/mcp-local-fs /path/to/mount          # stdio mode (default)
+ *   npx @decocms/mcp-local-fs --http /path/to/mount   # http mode
+ *   npx @decocms/mcp-local-fs --http --port 8080      # http mode with custom port
+ */
+
+const args = process.argv.slice(2);
+
+// Check for --http flag
+const httpIndex = args.indexOf("--http");
+const isHttpMode = httpIndex !== -1;
+
+if (isHttpMode) {
+  // Remove --http flag from args before passing to http module
+  args.splice(httpIndex, 1);
+  process.argv = [process.argv[0], process.argv[1], ...args];
+
+  // Dynamic import of http module
+  import("./http.js");
+} else {
+  // Default to stdio mode
+  import("./stdio.js");
+}

--- a/local-fs/server/http.ts
+++ b/local-fs/server/http.ts
@@ -1,0 +1,335 @@
+#!/usr/bin/env node
+/**
+ * MCP Local FS - HTTP Entry Point
+ *
+ * Usage:
+ *   npx @decocms/mcp-local-fs --http --path /path/to/mount
+ *   curl http://localhost:3456/mcp?path=/my/folder
+ *
+ * The path can be provided via:
+ *   1. Query string: ?path=/my/folder
+ *   2. --path CLI flag
+ *   3. MCP_LOCAL_FS_PATH environment variable
+ */
+
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { spawn } from "node:child_process";
+import { platform } from "node:os";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { LocalFileStorage } from "./storage.js";
+import { registerTools } from "./tools.js";
+import { resolve } from "node:path";
+
+/**
+ * Copy text to clipboard (cross-platform)
+ */
+function copyToClipboard(text: string): Promise<boolean> {
+  return new Promise((resolvePromise) => {
+    const os = platform();
+    let cmd: string;
+    let args: string[];
+
+    if (os === "darwin") {
+      cmd = "pbcopy";
+      args = [];
+    } else if (os === "win32") {
+      cmd = "clip";
+      args = [];
+    } else {
+      // Linux - try xclip first, then xsel
+      cmd = "xclip";
+      args = ["-selection", "clipboard"];
+    }
+
+    try {
+      const proc = spawn(cmd, args, { stdio: ["pipe", "ignore", "ignore"] });
+      proc.stdin?.write(text);
+      proc.stdin?.end();
+      proc.on("close", (code) => resolvePromise(code === 0));
+      proc.on("error", () => resolvePromise(false));
+    } catch {
+      resolvePromise(false);
+    }
+  });
+}
+
+/**
+ * Create an MCP server for a given filesystem path
+ */
+function createMcpServerForPath(rootPath: string): McpServer {
+  const storage = new LocalFileStorage(rootPath);
+
+  const server = new McpServer({
+    name: "local-fs",
+    version: "1.0.0",
+  });
+
+  // Register all tools from shared module
+  registerTools(server, storage);
+
+  return server;
+}
+
+// Parse CLI args for port and path
+function getPort(): number {
+  const args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--port" || args[i] === "-p") {
+      const port = parseInt(args[i + 1], 10);
+      if (!isNaN(port)) return port;
+    }
+  }
+  return parseInt(process.env.PORT || "3456", 10);
+}
+
+function getDefaultPath(): string {
+  const args = process.argv.slice(2);
+
+  // Check for explicit --path flag
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--path" || args[i] === "-d") {
+      const path = args[i + 1];
+      if (path && !path.startsWith("-")) return path;
+    }
+  }
+
+  // Check for positional argument (skip flags and their values)
+  const skipNext = new Set<number>();
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    // Skip flag values
+    if (skipNext.has(i)) continue;
+    // Mark next arg to skip if this is a flag with value
+    if (arg === "--port" || arg === "-p" || arg === "--path" || arg === "-d") {
+      skipNext.add(i + 1);
+      continue;
+    }
+    // Skip flags
+    if (arg.startsWith("-")) continue;
+    // This is a positional argument - use it as path
+    return arg;
+  }
+
+  return process.env.MCP_LOCAL_FS_PATH || process.cwd();
+}
+
+const port = getPort();
+const defaultPath = resolve(getDefaultPath());
+
+// Session TTL in milliseconds (30 minutes)
+const SESSION_TTL_MS = 30 * 60 * 1000;
+
+// Store active transports for session management with timestamps
+const transports = new Map<
+  string,
+  { transport: StreamableHTTPServerTransport; lastAccess: number }
+>();
+
+// Cleanup stale sessions periodically (every 5 minutes)
+const cleanupInterval = setInterval(
+  () => {
+    const now = Date.now();
+    for (const [sessionId, session] of transports) {
+      if (now - session.lastAccess > SESSION_TTL_MS) {
+        transports.delete(sessionId);
+        console.log(`[mcp-local-fs] Session expired: ${sessionId}`);
+      }
+    }
+  },
+  5 * 60 * 1000,
+);
+
+// Cleanup on process exit
+process.on("SIGINT", () => {
+  clearInterval(cleanupInterval);
+  process.exit(0);
+});
+process.on("SIGTERM", () => {
+  clearInterval(cleanupInterval);
+  process.exit(0);
+});
+
+// Create HTTP server
+const httpServer = createServer(
+  async (req: IncomingMessage, res: ServerResponse) => {
+    try {
+      const url = new URL(req.url || "/", `http://localhost:${port}`);
+
+      // CORS headers
+      res.setHeader("Access-Control-Allow-Origin", "*");
+      res.setHeader(
+        "Access-Control-Allow-Methods",
+        "GET, POST, DELETE, OPTIONS",
+      );
+      res.setHeader(
+        "Access-Control-Allow-Headers",
+        "Content-Type, mcp-session-id",
+      );
+
+      if (req.method === "OPTIONS") {
+        res.writeHead(204);
+        res.end();
+        return;
+      }
+
+      // Info endpoint
+      if (url.pathname === "/" && req.method === "GET") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            name: "mcp-local-fs",
+            version: "1.0.0",
+            description: "MCP server that mounts any local filesystem path",
+            endpoints: {
+              mcp: "/mcp?path=/your/path",
+              mcpWithPath: "/mcp/your/path",
+              health: "/health",
+            },
+            defaultPath,
+          }),
+        );
+        return;
+      }
+
+      // Health check
+      if (url.pathname === "/health" && req.method === "GET") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ status: "ok" }));
+        return;
+      }
+
+      // MCP endpoint
+      if (url.pathname.startsWith("/mcp")) {
+        // Get path from query string or URL path
+        let mountPath = defaultPath;
+        const queryPath = url.searchParams.get("path");
+        if (queryPath) {
+          mountPath = resolve(queryPath);
+        } else if (
+          url.pathname !== "/mcp" &&
+          url.pathname.startsWith("/mcp/")
+        ) {
+          const pathFromUrl = url.pathname.replace("/mcp/", "");
+          mountPath = resolve("/" + decodeURIComponent(pathFromUrl));
+        }
+
+        console.log(`[mcp-local-fs] Request for path: ${mountPath}`);
+
+        // Get or create session
+        const sessionId = req.headers["mcp-session-id"] as string | undefined;
+
+        if (req.method === "POST") {
+          // Check for existing session
+          let session = sessionId ? transports.get(sessionId) : undefined;
+
+          if (!session) {
+            // Create new transport and server for this session
+            const mcpServer = createMcpServerForPath(mountPath);
+            const newTransport = new StreamableHTTPServerTransport({
+              sessionIdGenerator: () => crypto.randomUUID(),
+              onsessioninitialized: (newSessionId) => {
+                transports.set(newSessionId, {
+                  transport: newTransport,
+                  lastAccess: Date.now(),
+                });
+                console.log(
+                  `[mcp-local-fs] Session initialized: ${newSessionId}`,
+                );
+              },
+            });
+
+            // Connect server to transport
+            await mcpServer.connect(newTransport);
+
+            // Handle the request
+            await newTransport.handleRequest(req, res);
+            return;
+          }
+
+          // Update last access time
+          session.lastAccess = Date.now();
+
+          // Handle the request
+          await session.transport.handleRequest(req, res);
+          return;
+        }
+
+        if (req.method === "GET") {
+          // SSE connection for server-sent events
+          const session = sessionId ? transports.get(sessionId) : undefined;
+          if (session) {
+            session.lastAccess = Date.now();
+            await session.transport.handleRequest(req, res);
+            return;
+          }
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "No session found" }));
+          return;
+        }
+
+        if (req.method === "DELETE") {
+          // Session termination
+          const session = sessionId ? transports.get(sessionId) : undefined;
+          if (session) {
+            await session.transport.handleRequest(req, res);
+            transports.delete(sessionId!);
+            console.log(`[mcp-local-fs] Session terminated: ${sessionId}`);
+            return;
+          }
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Session not found" }));
+          return;
+        }
+      }
+
+      // 404 for unknown routes
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Not found" }));
+    } catch (error) {
+      // Top-level error handler
+      console.error("[mcp-local-fs] Request error:", error);
+      if (!res.headersSent) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            error: "Internal server error",
+            message: error instanceof Error ? error.message : "Unknown error",
+          }),
+        );
+      }
+    }
+  },
+);
+
+// Build the full MCP URL
+const mcpUrl = `http://localhost:${port}/mcp${defaultPath}`;
+
+// Copy to clipboard and show startup banner
+(async () => {
+  const copied = await copyToClipboard(mcpUrl);
+
+  console.log(`
+╔════════════════════════════════════════════════════════════╗
+║                    MCP Local FS Server                     ║
+╠════════════════════════════════════════════════════════════╣
+║  HTTP server running on port ${port.toString().padEnd(27)}║
+║  Default path: ${defaultPath.slice(0, 41).padEnd(41)}║
+║                                                            ║
+║  MCP URL (${copied ? "copied to clipboard ✓" : "copy this"}):
+║  ${mcpUrl}
+║                                                            ║
+║  Endpoints:                                                ║
+║    GET  /           Server info                            ║
+║    GET  /health     Health check                           ║
+║    POST /mcp        MCP endpoint (use ?path=...)           ║
+║    POST /mcp/*      MCP endpoint with path in URL          ║
+╚════════════════════════════════════════════════════════════╝
+`);
+})();
+
+httpServer.listen(port);

--- a/local-fs/server/logger.ts
+++ b/local-fs/server/logger.ts
@@ -1,0 +1,168 @@
+/**
+ * MCP Local FS - Logger
+ *
+ * Nice formatted logging that goes to stderr (to not interfere with stdio protocol)
+ * but uses colors/formatting that indicate it's informational, not an error.
+ */
+
+// ANSI color codes
+const colors = {
+  reset: "\x1b[0m",
+  dim: "\x1b[2m",
+  bold: "\x1b[1m",
+
+  // Foreground colors
+  cyan: "\x1b[36m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  blue: "\x1b[34m",
+  magenta: "\x1b[35m",
+  gray: "\x1b[90m",
+  white: "\x1b[37m",
+};
+
+// Operation type colors
+const opColors: Record<string, string> = {
+  READ: colors.cyan,
+  WRITE: colors.green,
+  DELETE: colors.yellow,
+  MOVE: colors.magenta,
+  COPY: colors.blue,
+  MKDIR: colors.blue,
+  LIST: colors.gray,
+  STAT: colors.gray,
+  EDIT: colors.green,
+  SEARCH: colors.cyan,
+};
+
+function timestamp(): string {
+  const now = new Date();
+  return `${colors.dim}${now.toLocaleTimeString("en-US", { hour12: false })}${colors.reset}`;
+}
+
+function formatPath(path: string): string {
+  return `${colors.white}${path}${colors.reset}`;
+}
+
+function formatOp(op: string): string {
+  const color = opColors[op] || colors.white;
+  return `${color}${colors.bold}${op.padEnd(6)}${colors.reset}`;
+}
+
+function formatSize(bytes: number): string {
+  const units = ["B", "KB", "MB", "GB"];
+  let size = bytes;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+
+  return `${colors.dim}(${size.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]})${colors.reset}`;
+}
+
+const prefix = `${colors.cyan}◆${colors.reset}`;
+
+/**
+ * Log a file operation
+ */
+export function logOp(
+  op: string,
+  path: string,
+  extra?: {
+    size?: number;
+    to?: string;
+    count?: number;
+    recursive?: boolean;
+    error?: string;
+  },
+): void {
+  let msg = `${prefix} ${timestamp()} ${formatOp(op)} ${formatPath(path)}`;
+
+  if (extra?.to) {
+    msg += ` ${colors.dim}→${colors.reset} ${formatPath(extra.to)}`;
+  }
+
+  if (extra?.size !== undefined) {
+    msg += ` ${formatSize(extra.size)}`;
+  }
+
+  if (extra?.count !== undefined) {
+    const recursiveLabel = extra.recursive ? " recursive" : "";
+    msg += ` ${colors.dim}(${extra.count}${recursiveLabel} items)${colors.reset}`;
+  }
+
+  if (extra?.error) {
+    msg += ` ${colors.yellow}[${extra.error}]${colors.reset}`;
+  }
+
+  console.error(msg);
+}
+
+/**
+ * Log server startup
+ */
+export function logStart(rootPath: string): void {
+  console.error(
+    `\n${prefix} ${colors.cyan}${colors.bold}mcp-local-fs${colors.reset} ${colors.dim}started${colors.reset}`,
+  );
+  console.error(
+    `${prefix} ${colors.dim}root:${colors.reset} ${colors.white}${rootPath}${colors.reset}\n`,
+  );
+}
+
+/**
+ * Log an error (still uses red, but with the prefix)
+ */
+export function logError(op: string, path: string, error: Error): void {
+  console.error(
+    `${prefix} ${timestamp()} ${colors.yellow}${colors.bold}ERR${colors.reset} ${formatOp(op)} ${formatPath(path)} ${colors.dim}${error.message}${colors.reset}`,
+  );
+}
+
+/**
+ * Log a tool call
+ */
+export function logTool(
+  toolName: string,
+  args: Record<string, unknown>,
+  result?: { isError?: boolean },
+): void {
+  const argsStr = formatArgs(args);
+  const status = result?.isError
+    ? `${colors.yellow}✗${colors.reset}`
+    : `${colors.green}✓${colors.reset}`;
+
+  if (result) {
+    console.error(
+      `${prefix} ${timestamp()} ${colors.magenta}${colors.bold}TOOL${colors.reset}  ${colors.white}${toolName}${colors.reset}${argsStr} ${status}`,
+    );
+  } else {
+    console.error(
+      `${prefix} ${timestamp()} ${colors.magenta}${colors.bold}TOOL${colors.reset}  ${colors.white}${toolName}${colors.reset}${argsStr}`,
+    );
+  }
+}
+
+function formatArgs(args: Record<string, unknown>): string {
+  const entries = Object.entries(args);
+  if (entries.length === 0) return "";
+
+  const parts = entries.map(([key, value]) => {
+    let valStr: string;
+    if (typeof value === "string") {
+      // Truncate long strings
+      valStr = value.length > 50 ? `"${value.slice(0, 47)}..."` : `"${value}"`;
+    } else if (Array.isArray(value)) {
+      valStr = `[${value.length} items]`;
+    } else if (typeof value === "object" && value !== null) {
+      valStr = "{...}";
+    } else {
+      valStr = String(value);
+    }
+    return `${colors.dim}${key}=${colors.reset}${valStr}`;
+  });
+
+  return ` ${parts.join(" ")}`;
+}

--- a/local-fs/server/mcp.test.ts
+++ b/local-fs/server/mcp.test.ts
@@ -1,0 +1,631 @@
+/**
+ * MCP Server Integration Tests
+ *
+ * Tests for the MCP server tools and protocol integration.
+ * Uses the actual registerTools function to test the real implementation.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { LocalFileStorage } from "./storage.js";
+import { registerTools } from "./tools.js";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("MCP Server Integration", () => {
+  let tempDir: string;
+  let storage: LocalFileStorage;
+  let server: McpServer;
+  let client: Client;
+
+  beforeAll(async () => {
+    // Create temp directory
+    tempDir = await mkdtemp(join(tmpdir(), "mcp-server-test-"));
+    storage = new LocalFileStorage(tempDir);
+
+    // Create MCP server with shared tools
+    server = new McpServer({
+      name: "local-fs",
+      version: "1.0.0",
+    });
+    registerTools(server, storage);
+
+    // Create in-memory transport pair
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    // Connect server and client
+    await server.connect(serverTransport);
+
+    client = new Client({
+      name: "test-client",
+      version: "1.0.0",
+    });
+    await client.connect(clientTransport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    // Clean the temp directory before each test
+    const entries = await storage.list("");
+    for (const entry of entries) {
+      await rm(join(tempDir, entry.path), { recursive: true, force: true });
+    }
+  });
+
+  describe("tools/list", () => {
+    test("should list all official MCP filesystem tools", async () => {
+      const result = await client.listTools();
+
+      expect(result.tools.length).toBeGreaterThan(0);
+
+      const toolNames = result.tools.map((t) => t.name);
+
+      // Official MCP filesystem tools
+      expect(toolNames).toContain("read_file");
+      expect(toolNames).toContain("read_text_file");
+      expect(toolNames).toContain("read_media_file");
+      expect(toolNames).toContain("read_multiple_files");
+      expect(toolNames).toContain("write_file");
+      expect(toolNames).toContain("edit_file");
+      expect(toolNames).toContain("create_directory");
+      expect(toolNames).toContain("list_directory");
+      expect(toolNames).toContain("list_directory_with_sizes");
+      expect(toolNames).toContain("directory_tree");
+      expect(toolNames).toContain("move_file");
+      expect(toolNames).toContain("search_files");
+      expect(toolNames).toContain("get_file_info");
+      expect(toolNames).toContain("list_allowed_directories");
+
+      // Additional tools
+      expect(toolNames).toContain("delete_file");
+      expect(toolNames).toContain("copy_file");
+
+      // Mesh collection bindings
+      expect(toolNames).toContain("COLLECTION_FILES_LIST");
+      expect(toolNames).toContain("COLLECTION_FILES_GET");
+      expect(toolNames).toContain("COLLECTION_FOLDERS_LIST");
+      expect(toolNames).toContain("COLLECTION_FOLDERS_GET");
+    });
+
+    test("each tool should have a description", async () => {
+      const result = await client.listTools();
+
+      for (const tool of result.tools) {
+        expect(tool.description).toBeDefined();
+        expect(tool.description!.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("write_file tool", () => {
+    test("should write a file successfully", async () => {
+      const result = await client.callTool({
+        name: "write_file",
+        arguments: {
+          path: "test-write.txt",
+          content: "Hello from MCP!",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.content).toBeDefined();
+
+      // Verify file was written
+      const readResult = await storage.read("test-write.txt");
+      expect(readResult.content).toBe("Hello from MCP!");
+    });
+
+    test("should create nested directories", async () => {
+      const result = await client.callTool({
+        name: "write_file",
+        arguments: {
+          path: "nested/path/file.txt",
+          content: "Nested content",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const readResult = await storage.read("nested/path/file.txt");
+      expect(readResult.content).toBe("Nested content");
+    });
+  });
+
+  describe("read_text_file tool", () => {
+    test("should read a file successfully", async () => {
+      await storage.write("read-test.txt", "Content to read");
+
+      const result = await client.callTool({
+        name: "read_text_file",
+        arguments: {
+          path: "read-test.txt",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const textContent = result.content as Array<{
+        type: string;
+        text: string;
+      }>;
+      expect(textContent[0].text).toBe("Content to read");
+    });
+
+    test("should return error for non-existent file", async () => {
+      const result = await client.callTool({
+        name: "read_text_file",
+        arguments: {
+          path: "does-not-exist.txt",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const textContent = result.content as Array<{
+        type: string;
+        text: string;
+      }>;
+      expect(textContent[0].text).toContain("Error:");
+    });
+
+    test("should support head parameter", async () => {
+      await storage.write(
+        "lines.txt",
+        "Line 1\nLine 2\nLine 3\nLine 4\nLine 5",
+      );
+
+      const result = await client.callTool({
+        name: "read_text_file",
+        arguments: {
+          path: "lines.txt",
+          head: 2,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const textContent = result.content as Array<{
+        type: string;
+        text: string;
+      }>;
+      expect(textContent[0].text).toBe("Line 1\nLine 2");
+    });
+
+    test("should support tail parameter", async () => {
+      await storage.write(
+        "lines.txt",
+        "Line 1\nLine 2\nLine 3\nLine 4\nLine 5",
+      );
+
+      const result = await client.callTool({
+        name: "read_text_file",
+        arguments: {
+          path: "lines.txt",
+          tail: 2,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const textContent = result.content as Array<{
+        type: string;
+        text: string;
+      }>;
+      expect(textContent[0].text).toBe("Line 4\nLine 5");
+    });
+  });
+
+  describe("read_multiple_files tool", () => {
+    test("should read multiple files at once", async () => {
+      await storage.write("file1.txt", "Content 1");
+      await storage.write("file2.txt", "Content 2");
+
+      const result = await client.callTool({
+        name: "read_multiple_files",
+        arguments: {
+          paths: ["file1.txt", "file2.txt"],
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const textContent = result.content as Array<{
+        type: string;
+        text: string;
+      }>;
+      expect(textContent[0].text).toContain("file1.txt:");
+      expect(textContent[0].text).toContain("Content 1");
+      expect(textContent[0].text).toContain("file2.txt:");
+      expect(textContent[0].text).toContain("Content 2");
+    });
+  });
+
+  describe("delete_file tool", () => {
+    test("should delete a file", async () => {
+      await storage.write("to-delete.txt", "Delete me");
+
+      const result = await client.callTool({
+        name: "delete_file",
+        arguments: {
+          path: "to-delete.txt",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      // Verify file was deleted
+      await expect(storage.getMetadata("to-delete.txt")).rejects.toThrow();
+    });
+
+    test("should delete directory recursively", async () => {
+      await storage.write("dir-delete/file.txt", "content");
+
+      const result = await client.callTool({
+        name: "delete_file",
+        arguments: {
+          path: "dir-delete",
+          recursive: true,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      await expect(storage.getMetadata("dir-delete")).rejects.toThrow();
+    });
+  });
+
+  describe("list_directory tool", () => {
+    test("should list files and directories", async () => {
+      await storage.write("file.txt", "content");
+      await storage.mkdir("subdir");
+
+      const result = await client.callTool({
+        name: "list_directory",
+        arguments: {
+          path: "",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const textContent = result.content as Array<{
+        type: string;
+        text: string;
+      }>;
+      expect(textContent[0].text).toContain("[FILE] file.txt");
+      expect(textContent[0].text).toContain("[DIR] subdir");
+    });
+  });
+
+  describe("create_directory tool", () => {
+    test("should create a directory", async () => {
+      const result = await client.callTool({
+        name: "create_directory",
+        arguments: {
+          path: "new-dir",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const meta = await storage.getMetadata("new-dir");
+      expect(meta.isDirectory).toBe(true);
+    });
+
+    test("should create nested directories", async () => {
+      const result = await client.callTool({
+        name: "create_directory",
+        arguments: {
+          path: "deep/nested/dir",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const meta = await storage.getMetadata("deep/nested/dir");
+      expect(meta.isDirectory).toBe(true);
+    });
+  });
+
+  describe("move_file tool", () => {
+    test("should move a file", async () => {
+      await storage.write("original.txt", "content");
+
+      const result = await client.callTool({
+        name: "move_file",
+        arguments: {
+          source: "original.txt",
+          destination: "moved.txt",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      await expect(storage.getMetadata("original.txt")).rejects.toThrow();
+      const content = await storage.read("moved.txt");
+      expect(content.content).toBe("content");
+    });
+  });
+
+  describe("copy_file tool", () => {
+    test("should copy a file", async () => {
+      await storage.write("original.txt", "content");
+
+      const result = await client.callTool({
+        name: "copy_file",
+        arguments: {
+          source: "original.txt",
+          destination: "copy.txt",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const original = await storage.read("original.txt");
+      const copy = await storage.read("copy.txt");
+      expect(original.content).toBe("content");
+      expect(copy.content).toBe("content");
+    });
+  });
+
+  describe("get_file_info tool", () => {
+    test("should return file metadata", async () => {
+      await storage.write("info-test.txt", "some content");
+
+      const result = await client.callTool({
+        name: "get_file_info",
+        arguments: {
+          path: "info-test.txt",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const textContent = result.content as Array<{
+        type: string;
+        text: string;
+      }>;
+      expect(textContent[0].text).toContain("type: file");
+      expect(textContent[0].text).toContain("size:");
+    });
+  });
+
+  describe("search_files tool", () => {
+    test("should find files matching pattern", async () => {
+      await storage.write("test.txt", "content");
+      await storage.write("test.js", "content");
+      await storage.write("other.md", "content");
+
+      const result = await client.callTool({
+        name: "search_files",
+        arguments: {
+          path: "",
+          pattern: "*.txt",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const textContent = result.content as Array<{
+        type: string;
+        text: string;
+      }>;
+      expect(textContent[0].text).toContain("test.txt");
+      expect(textContent[0].text).not.toContain("test.js");
+    });
+  });
+
+  describe("edit_file tool", () => {
+    test("should edit file with search and replace", async () => {
+      await storage.write("edit-test.txt", "Hello World");
+
+      const result = await client.callTool({
+        name: "edit_file",
+        arguments: {
+          path: "edit-test.txt",
+          edits: [{ oldText: "World", newText: "MCP" }],
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const content = await storage.read("edit-test.txt");
+      expect(content.content).toBe("Hello MCP");
+    });
+
+    test("should support dry run", async () => {
+      await storage.write("edit-test.txt", "Hello World");
+
+      const result = await client.callTool({
+        name: "edit_file",
+        arguments: {
+          path: "edit-test.txt",
+          edits: [{ oldText: "World", newText: "MCP" }],
+          dryRun: true,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      // File should not be changed
+      const content = await storage.read("edit-test.txt");
+      expect(content.content).toBe("Hello World");
+
+      // Response should include diff preview
+      const textContent = result.content as Array<{
+        type: string;
+        text: string;
+      }>;
+      expect(textContent[0].text).toContain("Dry run");
+    });
+  });
+
+  describe("COLLECTION_FILES_LIST tool", () => {
+    test("should list files in root", async () => {
+      await storage.write("file1.txt", "content1");
+      await storage.write("file2.txt", "content2");
+
+      const result = await client.callTool({
+        name: "COLLECTION_FILES_LIST",
+        arguments: {},
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const textContent = result.content as Array<{
+        type: string;
+        text: string;
+      }>;
+      const parsed = JSON.parse(textContent[0].text);
+
+      expect(parsed.items.length).toBe(2);
+      expect(parsed.totalCount).toBe(2);
+    });
+
+    test("should list files recursively", async () => {
+      await storage.write("root.txt", "root");
+      await storage.write("sub/nested.txt", "nested");
+
+      const result = await client.callTool({
+        name: "COLLECTION_FILES_LIST",
+        arguments: {
+          recursive: true,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const textContent = result.content as Array<{
+        type: string;
+        text: string;
+      }>;
+      const parsed = JSON.parse(textContent[0].text);
+
+      expect(parsed.items.length).toBe(2);
+      const paths = parsed.items.map((i: { path: string }) => i.path);
+      expect(paths).toContain("root.txt");
+      expect(paths).toContain("sub/nested.txt");
+    });
+
+    test("should respect limit parameter", async () => {
+      await storage.write("file1.txt", "1");
+      await storage.write("file2.txt", "2");
+      await storage.write("file3.txt", "3");
+
+      const result = await client.callTool({
+        name: "COLLECTION_FILES_LIST",
+        arguments: {
+          limit: 2,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const textContent = result.content as Array<{
+        type: string;
+        text: string;
+      }>;
+      const parsed = JSON.parse(textContent[0].text);
+
+      expect(parsed.items.length).toBe(2);
+      expect(parsed.totalCount).toBe(3);
+      expect(parsed.hasMore).toBe(true);
+    });
+  });
+
+  describe("COLLECTION_FOLDERS_LIST tool", () => {
+    test("should list folders", async () => {
+      await storage.mkdir("folder1");
+      await storage.mkdir("folder2");
+      await storage.write("file.txt", "content");
+
+      const result = await client.callTool({
+        name: "COLLECTION_FOLDERS_LIST",
+        arguments: {},
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const textContent = result.content as Array<{
+        type: string;
+        text: string;
+      }>;
+      const parsed = JSON.parse(textContent[0].text);
+
+      expect(parsed.items.length).toBe(2);
+      expect(
+        parsed.items.every((i: { isDirectory: boolean }) => i.isDirectory),
+      ).toBe(true);
+    });
+  });
+
+  describe("COLLECTION_FILES_GET tool", () => {
+    test("should return file metadata and content", async () => {
+      await storage.write("get-test.txt", "Hello from GET test!");
+
+      const result = await client.callTool({
+        name: "COLLECTION_FILES_GET",
+        arguments: { id: "get-test.txt" },
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const textContent = result.content as Array<{
+        type: string;
+        text: string;
+      }>;
+      const parsed = JSON.parse(textContent[0].text);
+
+      expect(parsed.item).toBeDefined();
+      expect(parsed.item.path).toBe("get-test.txt");
+      expect(parsed.item.content).toBe("Hello from GET test!");
+      expect(parsed.item.isDirectory).toBe(false);
+    });
+  });
+
+  describe("list_allowed_directories tool", () => {
+    test("should return the root directory", async () => {
+      const result = await client.callTool({
+        name: "list_allowed_directories",
+        arguments: {},
+      });
+
+      expect(result.isError).toBeFalsy();
+
+      const textContent = result.content as Array<{
+        type: string;
+        text: string;
+      }>;
+      expect(textContent[0].text).toContain(tempDir);
+    });
+  });
+
+  describe("error handling", () => {
+    test("should handle invalid file paths gracefully", async () => {
+      const result = await client.callTool({
+        name: "read_text_file",
+        arguments: {
+          path: "",
+        },
+      });
+
+      // Should return an error response, not throw
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/local-fs/server/stdio.ts
+++ b/local-fs/server/stdio.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * MCP Local FS - Stdio Entry Point
+ *
+ * This is the main entry point for running the MCP server via stdio,
+ * which is the standard transport for CLI-based MCP servers.
+ *
+ * Usage:
+ *   npx @decocms/mcp-local-fs /path/to/mount
+ *   npx @decocms/mcp-local-fs --path /path/to/mount
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { LocalFileStorage } from "./storage.js";
+import { registerTools } from "./tools.js";
+import { logStart } from "./logger.js";
+import { resolve } from "node:path";
+
+/**
+ * Parse CLI arguments to get the path to mount
+ */
+function getPathFromArgs(): string {
+  const args = process.argv.slice(2);
+
+  // Check for --path flag
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--path" || args[i] === "-p") {
+      const path = args[i + 1];
+      if (path && !path.startsWith("-")) {
+        return path;
+      }
+    }
+  }
+
+  // Check for positional argument (first non-flag argument)
+  for (const arg of args) {
+    if (!arg.startsWith("-")) {
+      return arg;
+    }
+  }
+
+  // Check environment variable
+  if (process.env.MCP_LOCAL_FS_PATH) {
+    return process.env.MCP_LOCAL_FS_PATH;
+  }
+
+  // Default to current working directory
+  return process.cwd();
+}
+
+/**
+ * Create and start the MCP server with stdio transport
+ */
+async function main() {
+  const mountPath = getPathFromArgs();
+  const resolvedPath = resolve(mountPath);
+
+  // Create storage instance
+  const storage = new LocalFileStorage(resolvedPath);
+
+  // Create MCP server
+  const server = new McpServer({
+    name: "local-fs",
+    version: "1.0.0",
+  });
+
+  // Register all tools
+  registerTools(server, storage);
+
+  // Connect to stdio transport
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  // Log startup (goes to stderr, nicely formatted)
+  logStart(resolvedPath);
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/local-fs/server/storage.test.ts
+++ b/local-fs/server/storage.test.ts
@@ -1,0 +1,525 @@
+/**
+ * Storage Layer Tests
+ *
+ * Tests for the LocalFileStorage class - file system operations.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from "bun:test";
+import { LocalFileStorage, getExtensionFromMimeType } from "./storage.js";
+import { Readable } from "node:stream";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("LocalFileStorage", () => {
+  let tempDir: string;
+  let storage: LocalFileStorage;
+
+  beforeAll(async () => {
+    // Create a temp directory for tests
+    tempDir = await mkdtemp(join(tmpdir(), "mcp-local-fs-test-"));
+    storage = new LocalFileStorage(tempDir);
+  });
+
+  afterAll(async () => {
+    // Clean up temp directory
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    // Clean the temp directory before each test
+    const entries = await storage.list("");
+    for (const entry of entries) {
+      await rm(join(tempDir, entry.path), { recursive: true, force: true });
+    }
+  });
+
+  describe("root property", () => {
+    test("should return the resolved root directory", () => {
+      expect(storage.root).toBe(tempDir);
+    });
+  });
+
+  describe("write and read", () => {
+    test("should write and read a text file", async () => {
+      const content = "Hello, World!";
+      await storage.write("test.txt", content);
+
+      const result = await storage.read("test.txt");
+      expect(result.content).toBe(content);
+      expect(result.metadata.path).toBe("test.txt");
+      expect(result.metadata.mimeType).toBe("text/plain");
+    });
+
+    test("should write and read a file with utf-8 encoding", async () => {
+      const content = "こんにちは世界 🌍";
+      await storage.write("unicode.txt", content, { encoding: "utf-8" });
+
+      const result = await storage.read("unicode.txt", "utf-8");
+      expect(result.content).toBe(content);
+    });
+
+    test("should write and read a file with base64 encoding", async () => {
+      const originalContent = "Binary test content";
+      const base64Content = Buffer.from(originalContent).toString("base64");
+
+      await storage.write("binary.bin", base64Content, { encoding: "base64" });
+
+      const result = await storage.read("binary.bin", "base64");
+      const decodedContent = Buffer.from(result.content, "base64").toString(
+        "utf-8",
+      );
+      expect(decodedContent).toBe(originalContent);
+    });
+
+    test("should create parent directories when writing", async () => {
+      const content = "Nested file";
+      await storage.write("nested/deep/file.txt", content, {
+        createParents: true,
+      });
+
+      const result = await storage.read("nested/deep/file.txt");
+      expect(result.content).toBe(content);
+    });
+
+    test("should fail to overwrite when overwrite is false", async () => {
+      await storage.write("existing.txt", "original");
+
+      await expect(
+        storage.write("existing.txt", "new content", { overwrite: false }),
+      ).rejects.toThrow("File already exists");
+    });
+
+    test("should overwrite when overwrite is true", async () => {
+      await storage.write("overwrite.txt", "original");
+      await storage.write("overwrite.txt", "updated", { overwrite: true });
+
+      const result = await storage.read("overwrite.txt");
+      expect(result.content).toBe("updated");
+    });
+  });
+
+  describe("getMetadata", () => {
+    test("should return metadata for a file", async () => {
+      await storage.write("meta-test.txt", "content");
+
+      const metadata = await storage.getMetadata("meta-test.txt");
+      expect(metadata.id).toBe("meta-test.txt");
+      expect(metadata.title).toBe("meta-test.txt");
+      expect(metadata.isDirectory).toBe(false);
+      expect(metadata.mimeType).toBe("text/plain");
+      expect(metadata.size).toBeGreaterThan(0);
+      expect(metadata.created_at).toBeDefined();
+      expect(metadata.updated_at).toBeDefined();
+    });
+
+    test("should return metadata for a directory", async () => {
+      await storage.mkdir("test-dir");
+
+      const metadata = await storage.getMetadata("test-dir");
+      expect(metadata.isDirectory).toBe(true);
+      expect(metadata.mimeType).toBe("inode/directory");
+    });
+
+    test("should throw for non-existent path", async () => {
+      await expect(storage.getMetadata("does-not-exist.txt")).rejects.toThrow();
+    });
+  });
+
+  describe("list", () => {
+    test("should list files in root directory", async () => {
+      await storage.write("file1.txt", "content1");
+      await storage.write("file2.txt", "content2");
+
+      const items = await storage.list("");
+      expect(items.length).toBe(2);
+      expect(items.map((i) => i.title)).toContain("file1.txt");
+      expect(items.map((i) => i.title)).toContain("file2.txt");
+    });
+
+    test("should list files in subdirectory", async () => {
+      await storage.mkdir("subdir");
+      await storage.write("subdir/nested.txt", "nested content");
+
+      const items = await storage.list("subdir");
+      expect(items.length).toBe(1);
+      expect(items[0].title).toBe("subdir/nested.txt");
+    });
+
+    test("should list recursively when recursive=true", async () => {
+      await storage.write("root.txt", "root");
+      await storage.write("level1/file1.txt", "level1");
+      await storage.write("level1/level2/file2.txt", "level2");
+
+      const items = await storage.list("", { recursive: true });
+      const paths = items.map((i) => i.path);
+
+      expect(paths).toContain("root.txt");
+      expect(paths).toContain("level1/file1.txt");
+      expect(paths).toContain("level1/level2/file2.txt");
+    });
+
+    test("should filter to files only when filesOnly=true", async () => {
+      await storage.mkdir("dir-only");
+      await storage.write("file-only.txt", "content");
+
+      const items = await storage.list("", { filesOnly: true });
+      expect(items.every((i) => !i.isDirectory)).toBe(true);
+      expect(items.map((i) => i.title)).toContain("file-only.txt");
+    });
+
+    test("should return empty array for non-existent directory", async () => {
+      const items = await storage.list("non-existent");
+      expect(items).toEqual([]);
+    });
+
+    test("should skip hidden files (starting with .)", async () => {
+      await writeFile(join(tempDir, ".hidden"), "hidden content");
+      await storage.write("visible.txt", "visible content");
+
+      const items = await storage.list("");
+      expect(items.map((i) => i.title)).not.toContain(".hidden");
+      expect(items.map((i) => i.title)).toContain("visible.txt");
+    });
+  });
+
+  describe("mkdir", () => {
+    test("should create a directory", async () => {
+      const result = await storage.mkdir("new-dir");
+
+      expect(result.folder.isDirectory).toBe(true);
+      expect(result.folder.path).toBe("new-dir");
+    });
+
+    test("should create nested directories with recursive=true", async () => {
+      const result = await storage.mkdir("a/b/c", true);
+
+      expect(result.folder.path).toBe("a/b/c");
+
+      const metadata = await storage.getMetadata("a/b/c");
+      expect(metadata.isDirectory).toBe(true);
+    });
+  });
+
+  describe("delete", () => {
+    test("should delete a file", async () => {
+      await storage.write("to-delete.txt", "content");
+      const result = await storage.delete("to-delete.txt");
+
+      expect(result.success).toBe(true);
+      await expect(storage.getMetadata("to-delete.txt")).rejects.toThrow();
+    });
+
+    test("should delete an empty directory", async () => {
+      await storage.mkdir("empty-dir");
+      const result = await storage.delete("empty-dir", true);
+
+      expect(result.success).toBe(true);
+    });
+
+    test("should delete directory recursively", async () => {
+      await storage.write("dir-to-delete/file.txt", "content");
+      const result = await storage.delete("dir-to-delete", true);
+
+      expect(result.success).toBe(true);
+      await expect(storage.getMetadata("dir-to-delete")).rejects.toThrow();
+    });
+
+    test("should fail to delete non-empty directory without recursive flag", async () => {
+      await storage.write("non-empty/file.txt", "content");
+
+      await expect(storage.delete("non-empty", false)).rejects.toThrow();
+    });
+  });
+
+  describe("move", () => {
+    test("should move a file", async () => {
+      await storage.write("source.txt", "content");
+      const result = await storage.move("source.txt", "destination.txt");
+
+      expect(result.file.path).toBe("destination.txt");
+      await expect(storage.getMetadata("source.txt")).rejects.toThrow();
+
+      const content = await storage.read("destination.txt");
+      expect(content.content).toBe("content");
+    });
+
+    test("should move a file to a subdirectory", async () => {
+      await storage.write("move-me.txt", "content");
+      await storage.mkdir("target-dir");
+      await storage.move("move-me.txt", "target-dir/moved.txt");
+
+      const content = await storage.read("target-dir/moved.txt");
+      expect(content.content).toBe("content");
+    });
+
+    test("should fail to overwrite without overwrite flag", async () => {
+      await storage.write("existing-dest.txt", "existing");
+      await storage.write("new-source.txt", "new");
+
+      await expect(
+        storage.move("new-source.txt", "existing-dest.txt", false),
+      ).rejects.toThrow("Destination already exists");
+    });
+
+    test("should overwrite with overwrite flag", async () => {
+      await storage.write("old.txt", "old content");
+      await storage.write("new.txt", "new content");
+      await storage.move("new.txt", "old.txt", true);
+
+      const result = await storage.read("old.txt");
+      expect(result.content).toBe("new content");
+    });
+  });
+
+  describe("copy", () => {
+    test("should copy a file", async () => {
+      await storage.write("original.txt", "content");
+      const result = await storage.copy("original.txt", "copied.txt");
+
+      expect(result.file.path).toBe("copied.txt");
+
+      // Both files should exist
+      const original = await storage.read("original.txt");
+      const copied = await storage.read("copied.txt");
+      expect(original.content).toBe("content");
+      expect(copied.content).toBe("content");
+    });
+
+    test("should fail to overwrite without overwrite flag", async () => {
+      await storage.write("src.txt", "source");
+      await storage.write("dst.txt", "destination");
+
+      await expect(storage.copy("src.txt", "dst.txt", false)).rejects.toThrow(
+        "Destination already exists",
+      );
+    });
+
+    test("should overwrite with overwrite flag", async () => {
+      await storage.write("src.txt", "source content");
+      await storage.write("dst.txt", "destination content");
+      await storage.copy("src.txt", "dst.txt", true);
+
+      const result = await storage.read("dst.txt");
+      expect(result.content).toBe("source content");
+    });
+  });
+
+  describe("path sanitization", () => {
+    test("should prevent path traversal with ..", async () => {
+      await storage.write("safe.txt", "safe content");
+
+      // Attempting to traverse should be sanitized
+      const result = await storage.read("../safe.txt");
+      // This should still find the file since .. is stripped
+      expect(result.content).toBe("safe content");
+    });
+
+    test("should handle leading slashes", async () => {
+      await storage.write("leading-slash.txt", "content");
+
+      const result = await storage.read("/leading-slash.txt");
+      expect(result.content).toBe("content");
+    });
+  });
+
+  describe("path normalization (stripping root prefix)", () => {
+    test("should strip root directory prefix from path", async () => {
+      await storage.write("normalize-test.txt", "normalized content");
+
+      // AI agents sometimes pass the full path including root
+      const fullPath = `${tempDir}/normalize-test.txt`;
+      const result = await storage.read(fullPath);
+      expect(result.content).toBe("normalized content");
+    });
+
+    test("should strip root with colon separator", async () => {
+      await storage.write("colon-test.txt", "colon content");
+
+      // Some tools format paths as "root:filename"
+      const colonPath = `${tempDir}:colon-test.txt`;
+      const result = await storage.read(colonPath);
+      expect(result.content).toBe("colon content");
+    });
+
+    test("normalizePath should return relative path", () => {
+      const relPath = storage.normalizePath(`${tempDir}/some/file.txt`);
+      expect(relPath).toBe("some/file.txt");
+    });
+
+    test("normalizePath should handle already-relative paths", () => {
+      const relPath = storage.normalizePath("some/file.txt");
+      expect(relPath).toBe("some/file.txt");
+    });
+
+    test("normalizePath should handle colon separator", () => {
+      const relPath = storage.normalizePath(`${tempDir}:file.txt`);
+      expect(relPath).toBe("file.txt");
+    });
+
+    test("normalizePath should strip leading slashes", () => {
+      const relPath = storage.normalizePath("/file.txt");
+      expect(relPath).toBe("file.txt");
+    });
+
+    test("normalizePath should NOT match paths that share prefix but are not inside root", () => {
+      // If rootDir is /tmp/root, a path like /tmp/rootEvil/file.txt should NOT
+      // be treated as inside the root directory
+      const relPath = storage.normalizePath(`${tempDir}Evil/file.txt`);
+      // Should return the full path unchanged (minus leading slash stripping)
+      expect(relPath).not.toBe("Evil/file.txt");
+      // Instead it should be the original path with leading slash stripped
+      expect(relPath).toContain("Evil/file.txt");
+    });
+  });
+
+  describe("MIME type detection", () => {
+    const testCases = [
+      { ext: ".txt", expected: "text/plain" },
+      { ext: ".json", expected: "application/json" },
+      { ext: ".html", expected: "text/html" },
+      { ext: ".css", expected: "text/css" },
+      { ext: ".js", expected: "application/javascript" },
+      { ext: ".ts", expected: "text/typescript" },
+      { ext: ".md", expected: "text/markdown" },
+      { ext: ".png", expected: "image/png" },
+      { ext: ".jpg", expected: "image/jpeg" },
+      { ext: ".pdf", expected: "application/pdf" },
+      { ext: ".unknown", expected: "application/octet-stream" },
+    ];
+
+    for (const { ext, expected } of testCases) {
+      test(`should detect ${expected} for ${ext} files`, async () => {
+        await storage.write(`file${ext}`, "content");
+        const metadata = await storage.getMetadata(`file${ext}`);
+        expect(metadata.mimeType).toBe(expected);
+      });
+    }
+  });
+
+  describe("writeStream", () => {
+    test("should stream content to file", async () => {
+      const content = "Hello from stream!";
+      const chunks = [Buffer.from(content)];
+
+      const stream = new Readable({
+        read() {
+          const chunk = chunks.shift();
+          this.push(chunk ?? null);
+        },
+      });
+
+      const result = await storage.writeStream("stream-test.txt", stream);
+
+      expect(result.bytesWritten).toBe(content.length);
+      expect(result.file.path).toBe("stream-test.txt");
+
+      const readBack = await storage.read("stream-test.txt");
+      expect(readBack.content).toBe(content);
+    });
+
+    test("should stream large content without buffering", async () => {
+      // Create a 1MB stream in chunks
+      const chunkSize = 64 * 1024; // 64KB chunks
+      const totalSize = 1024 * 1024; // 1MB
+      let bytesGenerated = 0;
+
+      const stream = new Readable({
+        read() {
+          if (bytesGenerated >= totalSize) {
+            this.push(null);
+            return;
+          }
+          const size = Math.min(chunkSize, totalSize - bytesGenerated);
+          const chunk = Buffer.alloc(size, "x");
+          bytesGenerated += size;
+          this.push(chunk);
+        },
+      });
+
+      const result = await storage.writeStream("large-stream.bin", stream);
+
+      expect(result.bytesWritten).toBe(totalSize);
+
+      const metadata = await storage.getMetadata("large-stream.bin");
+      expect(metadata.size).toBe(totalSize);
+    });
+
+    test("should create parent directories", async () => {
+      const stream = Readable.from([Buffer.from("nested content")]);
+
+      const result = await storage.writeStream(
+        "deep/nested/path/file.txt",
+        stream,
+        { createParents: true },
+      );
+
+      expect(result.file.path).toBe("deep/nested/path/file.txt");
+
+      const readBack = await storage.read("deep/nested/path/file.txt");
+      expect(readBack.content).toBe("nested content");
+    });
+
+    test("should fail if file exists and overwrite is false", async () => {
+      await storage.write("existing-stream.txt", "existing");
+
+      const stream = Readable.from([Buffer.from("new content")]);
+
+      await expect(
+        storage.writeStream("existing-stream.txt", stream, {
+          overwrite: false,
+        }),
+      ).rejects.toThrow("File already exists");
+    });
+
+    test("should overwrite if overwrite is true", async () => {
+      await storage.write("overwrite-stream.txt", "old");
+
+      const stream = Readable.from([Buffer.from("new content")]);
+      await storage.writeStream("overwrite-stream.txt", stream, {
+        overwrite: true,
+      });
+
+      const readBack = await storage.read("overwrite-stream.txt");
+      expect(readBack.content).toBe("new content");
+    });
+  });
+});
+
+describe("getExtensionFromMimeType", () => {
+  test("should return extension for known MIME types", () => {
+    expect(getExtensionFromMimeType("application/json")).toBe(".json");
+    expect(getExtensionFromMimeType("image/png")).toBe(".png");
+    expect(getExtensionFromMimeType("text/plain")).toBe(".txt");
+    // .htm is shorter than .html so it's preferred
+    expect(getExtensionFromMimeType("text/html")).toBe(".htm");
+    expect(getExtensionFromMimeType("application/pdf")).toBe(".pdf");
+  });
+
+  test("should handle MIME types with charset", () => {
+    expect(getExtensionFromMimeType("application/json; charset=utf-8")).toBe(
+      ".json",
+    );
+    expect(getExtensionFromMimeType("text/html; charset=UTF-8")).toBe(".htm");
+  });
+
+  test("should return .ndjson for newline-delimited JSON", () => {
+    expect(getExtensionFromMimeType("application/x-ndjson")).toBe(".ndjson");
+    expect(getExtensionFromMimeType("application/jsonl")).toBe(".jsonl");
+  });
+
+  test("should return empty string for unknown MIME types", () => {
+    expect(getExtensionFromMimeType("application/x-unknown-format")).toBe("");
+  });
+
+  test("should return .bin for octet-stream", () => {
+    expect(getExtensionFromMimeType("application/octet-stream")).toBe(".bin");
+  });
+});

--- a/local-fs/server/storage.ts
+++ b/local-fs/server/storage.ts
@@ -1,0 +1,483 @@
+/**
+ * Local File Storage Implementation
+ *
+ * Portable filesystem operations that work with any mounted path.
+ */
+
+import {
+  mkdir,
+  readFile,
+  writeFile,
+  unlink,
+  stat,
+  readdir,
+  rename,
+  copyFile,
+  rm,
+  open,
+} from "node:fs/promises";
+import { dirname, basename, extname, resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { logOp } from "./logger.js";
+
+/**
+ * File entity returned by listing/metadata operations
+ */
+export interface FileEntity {
+  id: string;
+  title: string;
+  path: string;
+  parent: string;
+  mimeType: string;
+  size: number;
+  isDirectory: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * MIME type lookup based on file extension
+ */
+const MIME_TYPES: Record<string, string> = {
+  // Text
+  ".txt": "text/plain",
+  ".html": "text/html",
+  ".htm": "text/html",
+  ".css": "text/css",
+  ".csv": "text/csv",
+  // JavaScript/TypeScript
+  ".js": "application/javascript",
+  ".mjs": "application/javascript",
+  ".jsx": "text/javascript",
+  ".ts": "text/typescript",
+  ".tsx": "text/typescript",
+  // Data formats
+  ".json": "application/json",
+  ".xml": "application/xml",
+  ".yaml": "text/yaml",
+  ".yml": "text/yaml",
+  ".toml": "text/toml",
+  // Markdown
+  ".md": "text/markdown",
+  ".mdx": "text/mdx",
+  ".markdown": "text/markdown",
+  // Images
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".avif": "image/avif",
+  // Documents
+  ".pdf": "application/pdf",
+  ".doc": "application/msword",
+  ".docx":
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".xls": "application/vnd.ms-excel",
+  ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  // Archives
+  ".zip": "application/zip",
+  ".tar": "application/x-tar",
+  ".gz": "application/gzip",
+  // Audio
+  ".mp3": "audio/mpeg",
+  ".wav": "audio/wav",
+  ".ogg": "audio/ogg",
+  // Video
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+  ".mov": "video/quicktime",
+};
+
+function getMimeType(filename: string): string {
+  const ext = extname(filename).toLowerCase();
+  return MIME_TYPES[ext] || "application/octet-stream";
+}
+
+/**
+ * Reverse MIME type lookup - get extension from MIME type
+ */
+const MIME_TO_EXT: Record<string, string> = Object.entries(MIME_TYPES).reduce(
+  (acc, [ext, mime]) => {
+    // Don't overwrite if already set (prefer shorter extensions)
+    if (!acc[mime] || ext.length < acc[mime].length) {
+      acc[mime] = ext;
+    }
+    return acc;
+  },
+  {} as Record<string, string>,
+);
+
+// Add common MIME types that might not have extensions in our map
+Object.assign(MIME_TO_EXT, {
+  "application/octet-stream": ".bin",
+  "text/plain": ".txt",
+  "application/x-ndjson": ".ndjson",
+  "application/jsonl": ".jsonl",
+  "application/x-jsonlines": ".jsonl",
+});
+
+export function getExtensionFromMimeType(mimeType: string): string {
+  // Handle charset suffix (e.g., "application/json; charset=utf-8")
+  const baseMime = mimeType.split(";")[0].trim().toLowerCase();
+  return MIME_TO_EXT[baseMime] || "";
+}
+
+function sanitizePath(path: string): string {
+  // Normalize backslashes to forward slashes (Windows compatibility)
+  return path
+    .replace(/\\/g, "/")
+    .split("/")
+    .filter((segment) => segment !== ".." && segment !== ".")
+    .join("/")
+    .replace(/^\/+/, "");
+}
+
+/**
+ * Local File Storage class
+ */
+export class LocalFileStorage {
+  private rootDir: string;
+
+  constructor(rootDir: string) {
+    this.rootDir = resolve(rootDir);
+  }
+
+  get root(): string {
+    return this.rootDir;
+  }
+
+  /**
+   * Normalize a path by stripping the root directory prefix if present.
+   * This handles cases where AI agents mistakenly include the full root path.
+   */
+  normalizePath(path: string): string {
+    let normalizedPath = path;
+
+    // Strip root directory prefix if the path starts with it
+    // Must check for trailing slash, colon, or exact match to avoid matching paths like
+    // /tmp/rootEvil when root is /tmp/root
+    const rootWithSlash = this.rootDir + "/";
+    const rootWithColon = this.rootDir + ":";
+    if (normalizedPath.startsWith(rootWithSlash)) {
+      normalizedPath = normalizedPath.slice(rootWithSlash.length);
+    } else if (normalizedPath.startsWith(rootWithColon)) {
+      // Handle colon separator (e.g., "/path/to/root:filename.png")
+      normalizedPath = normalizedPath.slice(rootWithColon.length);
+    } else if (normalizedPath === this.rootDir) {
+      // Exact match - return root
+      normalizedPath = "";
+    }
+
+    // Handle standalone colon at start (edge case)
+    if (normalizedPath.startsWith(":")) {
+      normalizedPath = normalizedPath.slice(1);
+    }
+
+    // Strip leading slashes
+    normalizedPath = normalizedPath.replace(/^\/+/, "");
+
+    return normalizedPath;
+  }
+
+  private resolvePath(path: string): string {
+    const normalizedPath = this.normalizePath(path);
+    const sanitized = sanitizePath(normalizedPath);
+    const resolved = resolve(this.rootDir, sanitized);
+
+    // Defense-in-depth: verify resolved path is within rootDir
+    if (!resolved.startsWith(this.rootDir)) {
+      throw new Error("Path traversal attempt detected");
+    }
+
+    return resolved;
+  }
+
+  private async ensureDir(dir: string): Promise<void> {
+    if (!existsSync(dir)) {
+      await mkdir(dir, { recursive: true });
+    }
+  }
+
+  async getMetadata(path: string): Promise<FileEntity> {
+    const fullPath = this.resolvePath(path);
+    const stats = await stat(fullPath);
+    const name = basename(path) || path;
+    const parentPath = dirname(path);
+    const parent = parentPath === "." || parentPath === "/" ? "" : parentPath;
+    const isDirectory = stats.isDirectory();
+    const mimeType = isDirectory ? "inode/directory" : getMimeType(name);
+
+    return {
+      id: path || "/",
+      title: parent ? path : name || "Root",
+      path: path || "/",
+      parent,
+      mimeType,
+      size: stats.size,
+      isDirectory,
+      created_at: stats.birthtime.toISOString(),
+      updated_at: stats.mtime.toISOString(),
+    };
+  }
+
+  async read(
+    path: string,
+    encoding: "utf-8" | "base64" = "utf-8",
+  ): Promise<{ content: string; metadata: FileEntity }> {
+    const fullPath = this.resolvePath(path);
+    const buffer = await readFile(fullPath);
+    const content =
+      encoding === "base64"
+        ? buffer.toString("base64")
+        : buffer.toString("utf-8");
+    const metadata = await this.getMetadata(path);
+    logOp("READ", path, { size: buffer.length });
+    return { content, metadata };
+  }
+
+  async write(
+    path: string,
+    content: string,
+    options: {
+      encoding?: "utf-8" | "base64";
+      createParents?: boolean;
+      overwrite?: boolean;
+    } = {},
+  ): Promise<{ file: FileEntity }> {
+    const fullPath = this.resolvePath(path);
+
+    if (options.createParents !== false) {
+      await this.ensureDir(dirname(fullPath));
+    }
+
+    if (options.overwrite === false && existsSync(fullPath)) {
+      throw new Error(`File already exists: ${path}`);
+    }
+
+    const buffer =
+      options.encoding === "base64"
+        ? Buffer.from(content, "base64")
+        : Buffer.from(content, "utf-8");
+
+    await writeFile(fullPath, buffer);
+    const file = await this.getMetadata(path);
+    logOp("WRITE", path, { size: buffer.length });
+    return { file };
+  }
+
+  async delete(
+    path: string,
+    recursive = false,
+  ): Promise<{ success: boolean; path: string }> {
+    const fullPath = this.resolvePath(path);
+    const stats = await stat(fullPath);
+
+    if (stats.isDirectory()) {
+      if (!recursive) {
+        throw new Error("Cannot delete directory without recursive flag");
+      }
+      await rm(fullPath, { recursive: true, force: true });
+    } else {
+      await unlink(fullPath);
+    }
+
+    logOp("DELETE", path);
+    return { success: true, path };
+  }
+
+  async list(
+    folder = "",
+    options: { recursive?: boolean; filesOnly?: boolean } = {},
+  ): Promise<FileEntity[]> {
+    const fullPath = this.resolvePath(folder);
+
+    if (!existsSync(fullPath)) {
+      return [];
+    }
+
+    if (options.recursive) {
+      const files = await this.listRecursive(folder, options.filesOnly);
+      logOp("LIST", folder || "/", { count: files.length, recursive: true });
+      return files;
+    }
+
+    const entries = await readdir(fullPath, { withFileTypes: true });
+    let files: FileEntity[] = [];
+
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) continue;
+
+      // Skip directories if filesOnly is true
+      if (options.filesOnly && entry.isDirectory()) continue;
+
+      const entryPath = folder ? `${folder}/${entry.name}` : entry.name;
+      try {
+        const metadata = await this.getMetadata(entryPath);
+        files.push(metadata);
+      } catch {
+        continue;
+      }
+    }
+
+    // Sort: directories first, then by name (only relevant if not filesOnly)
+    files = files.sort((a, b) => {
+      if (a.isDirectory && !b.isDirectory) return -1;
+      if (!a.isDirectory && b.isDirectory) return 1;
+      return a.title.localeCompare(b.title);
+    });
+
+    logOp("LIST", folder || "/", { count: files.length });
+    return files;
+  }
+
+  private async listRecursive(
+    folder = "",
+    filesOnly = false,
+  ): Promise<FileEntity[]> {
+    const fullPath = this.resolvePath(folder);
+
+    if (!existsSync(fullPath)) {
+      return [];
+    }
+
+    const entries = await readdir(fullPath, { withFileTypes: true });
+    const files: FileEntity[] = [];
+
+    for (const entry of entries) {
+      if (entry.name.startsWith(".")) continue;
+
+      const entryPath = folder ? `${folder}/${entry.name}` : entry.name;
+
+      try {
+        const metadata = await this.getMetadata(entryPath);
+
+        if (entry.isDirectory()) {
+          if (!filesOnly) {
+            files.push(metadata);
+          }
+          const subFiles = await this.listRecursive(entryPath, filesOnly);
+          files.push(...subFiles);
+        } else {
+          files.push(metadata);
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    return files;
+  }
+
+  async mkdir(path: string, recursive = true): Promise<{ folder: FileEntity }> {
+    const fullPath = this.resolvePath(path);
+    await mkdir(fullPath, { recursive });
+    const metadata = await this.getMetadata(path);
+    logOp("MKDIR", path);
+    return { folder: metadata };
+  }
+
+  async move(
+    from: string,
+    to: string,
+    overwrite = false,
+  ): Promise<{ file: FileEntity }> {
+    const fromPath = this.resolvePath(from);
+    const toPath = this.resolvePath(to);
+
+    if (!overwrite && existsSync(toPath)) {
+      throw new Error(`Destination already exists: ${to}`);
+    }
+
+    await this.ensureDir(dirname(toPath));
+    await rename(fromPath, toPath);
+    const file = await this.getMetadata(to);
+    logOp("MOVE", from, { to });
+    return { file };
+  }
+
+  async copy(
+    from: string,
+    to: string,
+    overwrite = false,
+  ): Promise<{ file: FileEntity }> {
+    const fromPath = this.resolvePath(from);
+    const toPath = this.resolvePath(to);
+
+    if (!overwrite && existsSync(toPath)) {
+      throw new Error(`Destination already exists: ${to}`);
+    }
+
+    await this.ensureDir(dirname(toPath));
+    await copyFile(fromPath, toPath);
+    const file = await this.getMetadata(to);
+    logOp("COPY", from, { to });
+    return { file };
+  }
+
+  /**
+   * Write a readable stream directly to disk without buffering in memory.
+   * Used for streaming large downloads directly to filesystem.
+   */
+  async writeStream(
+    path: string,
+    stream: ReadableStream<Uint8Array> | NodeJS.ReadableStream,
+    options: {
+      createParents?: boolean;
+      overwrite?: boolean;
+    } = {},
+  ): Promise<{ file: FileEntity; bytesWritten: number }> {
+    const fullPath = this.resolvePath(path);
+
+    if (options.createParents !== false) {
+      await this.ensureDir(dirname(fullPath));
+    }
+
+    if (options.overwrite === false && existsSync(fullPath)) {
+      throw new Error(`File already exists: ${path}`);
+    }
+
+    // Convert Web ReadableStream to Node.js Readable if needed
+    const nodeStream =
+      stream instanceof Readable
+        ? stream
+        : Readable.fromWeb(
+            stream as unknown as import("stream/web").ReadableStream,
+          );
+
+    // Track bytes written
+    let bytesWritten = 0;
+
+    // Create write stream
+    const fileHandle = await open(fullPath, "w");
+    const writeStream = fileHandle.createWriteStream();
+
+    // Create a passthrough that counts bytes
+    const countingStream = new Readable({
+      read() {},
+    });
+
+    nodeStream.on("data", (chunk: Buffer) => {
+      bytesWritten += chunk.length;
+      countingStream.push(chunk);
+    });
+
+    nodeStream.on("end", () => {
+      countingStream.push(null);
+    });
+
+    nodeStream.on("error", (err) => {
+      countingStream.destroy(err);
+    });
+
+    await pipeline(countingStream, writeStream);
+
+    const file = await this.getMetadata(path);
+    logOp("WRITE_STREAM", path, { size: bytesWritten });
+    return { file, bytesWritten };
+  }
+}

--- a/local-fs/server/tools.ts
+++ b/local-fs/server/tools.ts
@@ -1,0 +1,1590 @@
+/**
+ * MCP Local FS - Tool Definitions
+ *
+ * This module contains all tool definitions following the official
+ * MCP filesystem server schema, plus collection bindings for Mesh.
+ *
+ * Uses registerTool() for proper annotation/hint support.
+ *
+ * @see https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import {
+  LocalFileStorage,
+  type FileEntity,
+  getExtensionFromMimeType,
+} from "./storage.js";
+import { logTool } from "./logger.js";
+
+/**
+ * Wrap a tool handler with logging
+ */
+function withLogging<T extends Record<string, unknown>>(
+  toolName: string,
+  handler: (args: T) => Promise<CallToolResult>,
+): (args: T) => Promise<CallToolResult> {
+  return async (args: T) => {
+    logTool(toolName, args as Record<string, unknown>);
+    const result = await handler(args);
+    return result;
+  };
+}
+
+/**
+ * Register all filesystem tools on an MCP server
+ */
+export function registerTools(server: McpServer, storage: LocalFileStorage) {
+  // ============================================================
+  // OFFICIAL MCP FILESYSTEM TOOLS
+  // Following exact schema from modelcontextprotocol/servers
+  // ============================================================
+
+  // read_file (deprecated alias for read_text_file)
+  server.registerTool(
+    "read_file",
+    {
+      title: "Read File (Deprecated)",
+      description:
+        "Read the complete contents of a file as text. DEPRECATED: Use read_text_file instead.",
+      inputSchema: {
+        path: z.string().describe("Path to the file to read"),
+        tail: z
+          .number()
+          .optional()
+          .describe("If provided, returns only the last N lines of the file"),
+        head: z
+          .number()
+          .optional()
+          .describe("If provided, returns only the first N lines of the file"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging("read_file", async (args) =>
+      readTextFileHandler(storage, args),
+    ),
+  );
+
+  // read_text_file - primary text file reading tool
+  server.registerTool(
+    "read_text_file",
+    {
+      title: "Read Text File",
+      description:
+        "Read the complete contents of a file from the file system as text. " +
+        "Handles various text encodings and provides detailed error messages " +
+        "if the file cannot be read. Use this tool when you need to examine " +
+        "the contents of a single file. Use the 'head' parameter to read only " +
+        "the first N lines of a file, or the 'tail' parameter to read only " +
+        "the last N lines of a file. Only works within allowed directories.",
+      inputSchema: {
+        path: z.string().describe("Path to the file to read"),
+        tail: z
+          .number()
+          .optional()
+          .describe("If provided, returns only the last N lines of the file"),
+        head: z
+          .number()
+          .optional()
+          .describe("If provided, returns only the first N lines of the file"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging("read_text_file", async (args) =>
+      readTextFileHandler(storage, args),
+    ),
+  );
+
+  // read_media_file - read binary files as base64
+  server.registerTool(
+    "read_media_file",
+    {
+      title: "Read Media File",
+      description:
+        "Read an image or audio file. Returns the base64 encoded data and MIME type. " +
+        "Only works within allowed directories.",
+      inputSchema: {
+        path: z.string().describe("Path to the media file to read"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging("read_media_file", async (args): Promise<CallToolResult> => {
+      try {
+        const result = await storage.read(args.path, "base64");
+        const mimeType = result.metadata.mimeType;
+        const type = mimeType.startsWith("image/")
+          ? "image"
+          : mimeType.startsWith("audio/")
+            ? "audio"
+            : "blob";
+
+        const contentItem = {
+          type: type as "image" | "audio",
+          data: result.content,
+          mimeType,
+        };
+
+        // NOTE: Do NOT include structuredContent for media files
+        // The base64 data would get serialized to JSON and cause token explosion
+        return {
+          content: [contentItem],
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // read_multiple_files - read multiple files at once
+  server.registerTool(
+    "read_multiple_files",
+    {
+      title: "Read Multiple Files",
+      description:
+        "Read the contents of multiple files simultaneously. This is more " +
+        "efficient than reading files one by one when you need to analyze " +
+        "or compare multiple files. Each file's content is returned with its " +
+        "path as a reference. Failed reads for individual files won't stop " +
+        "the entire operation. Only works within allowed directories.",
+      inputSchema: {
+        paths: z
+          .array(z.string())
+          .min(1)
+          .describe(
+            "Array of file paths to read. Each path must be a string pointing to a valid file.",
+          ),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging(
+      "read_multiple_files",
+      async (args): Promise<CallToolResult> => {
+        const results = await Promise.all(
+          args.paths.map(async (filePath: string) => {
+            try {
+              const result = await storage.read(filePath, "utf-8");
+              return `${filePath}:\n${result.content}\n`;
+            } catch (error) {
+              const errorMessage =
+                error instanceof Error ? error.message : String(error);
+              return `${filePath}: Error - ${errorMessage}`;
+            }
+          }),
+        );
+        const text = results.join("\n---\n");
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: { content: text },
+        };
+      },
+    ),
+  );
+
+  // write_file - write content to a file
+  server.registerTool(
+    "write_file",
+    {
+      title: "Write File",
+      description:
+        "Create a new file or completely overwrite an existing file with new content. " +
+        "Use with caution as it will overwrite existing files without warning. " +
+        "Handles text content with proper encoding. Only works within allowed directories.",
+      inputSchema: {
+        path: z.string().describe("Path where the file should be written"),
+        content: z.string().describe("Content to write to the file"),
+      },
+      annotations: {
+        readOnlyHint: false,
+        idempotentHint: true,
+        destructiveHint: true,
+      },
+    },
+    withLogging("write_file", async (args): Promise<CallToolResult> => {
+      try {
+        await storage.write(args.path, args.content, {
+          encoding: "utf-8",
+          createParents: true,
+          overwrite: true,
+        });
+        const text = `Successfully wrote to ${args.path}`;
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: { content: text },
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // edit_file - make search/replace edits with diff preview
+  server.registerTool(
+    "edit_file",
+    {
+      title: "Edit File",
+      description:
+        "Make line-based edits to a text file. Each edit replaces exact text sequences " +
+        "with new content. Returns a git-style diff showing the changes made. " +
+        "Only works within allowed directories.",
+      inputSchema: {
+        path: z.string().describe("Path to the file to edit"),
+        edits: z.array(
+          z.object({
+            oldText: z
+              .string()
+              .describe("Text to search for - must match exactly"),
+            newText: z.string().describe("Text to replace with"),
+          }),
+        ),
+        dryRun: z
+          .boolean()
+          .default(false)
+          .describe("Preview changes using git-style diff format"),
+      },
+      annotations: {
+        readOnlyHint: false,
+        idempotentHint: false,
+        destructiveHint: true,
+      },
+    },
+    withLogging("edit_file", async (args): Promise<CallToolResult> => {
+      try {
+        const result = await storage.read(args.path, "utf-8");
+        let content = result.content;
+        const originalContent = content;
+
+        // Apply all edits
+        for (const edit of args.edits) {
+          if (!content.includes(edit.oldText)) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Error: Could not find text to replace: "${edit.oldText.slice(0, 50)}..."`,
+                },
+              ],
+              isError: true,
+            };
+          }
+          content = content.replace(edit.oldText, edit.newText);
+        }
+
+        // Generate diff
+        const diff = generateDiff(args.path, originalContent, content);
+
+        if (args.dryRun) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Dry run - changes not applied:\n\n${diff}`,
+              },
+            ],
+            structuredContent: { content: diff, dryRun: true },
+          };
+        }
+
+        // Apply changes
+        await storage.write(args.path, content, {
+          encoding: "utf-8",
+          createParents: false,
+          overwrite: true,
+        });
+
+        return {
+          content: [{ type: "text", text: diff }],
+          structuredContent: { content: diff },
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // create_directory - create directories
+  server.registerTool(
+    "create_directory",
+    {
+      title: "Create Directory",
+      description:
+        "Create a new directory or ensure a directory exists. Can create multiple " +
+        "nested directories in one operation. If the directory already exists, " +
+        "this operation will succeed silently. Only works within allowed directories.",
+      inputSchema: {
+        path: z.string().describe("Path of the directory to create"),
+      },
+      annotations: {
+        readOnlyHint: false,
+        idempotentHint: true,
+        destructiveHint: false,
+      },
+    },
+    withLogging("create_directory", async (args): Promise<CallToolResult> => {
+      try {
+        await storage.mkdir(args.path, true);
+        const text = `Successfully created directory ${args.path}`;
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: { content: text },
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // list_directory - simple directory listing
+  server.registerTool(
+    "list_directory",
+    {
+      title: "List Directory",
+      description:
+        "Get a detailed listing of all files and directories in a specified path. " +
+        "Results clearly distinguish between files and directories with [FILE] and [DIR] " +
+        "prefixes. Only works within allowed directories.",
+      inputSchema: {
+        path: z.string().describe("Path of the directory to list"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging("list_directory", async (args): Promise<CallToolResult> => {
+      try {
+        const items = await storage.list(args.path);
+        const formatted = items
+          .map(
+            (entry) =>
+              `${entry.isDirectory ? "[DIR]" : "[FILE]"} ${entry.title}`,
+          )
+          .join("\n");
+        return {
+          content: [{ type: "text", text: formatted || "Empty directory" }],
+          structuredContent: { content: formatted },
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // list_directory_with_sizes - listing with file sizes
+  server.registerTool(
+    "list_directory_with_sizes",
+    {
+      title: "List Directory with Sizes",
+      description:
+        "Get a detailed listing of all files and directories in a specified path, including sizes. " +
+        "Results clearly distinguish between files and directories. " +
+        "Only works within allowed directories.",
+      inputSchema: {
+        path: z.string().describe("Path of the directory to list"),
+        sortBy: z
+          .enum(["name", "size"])
+          .optional()
+          .default("name")
+          .describe("Sort entries by name or size"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging(
+      "list_directory_with_sizes",
+      async (args): Promise<CallToolResult> => {
+        try {
+          const items = await storage.list(args.path);
+
+          // Sort entries
+          const sortedItems = [...items].sort((a, b) => {
+            if (args.sortBy === "size") {
+              return b.size - a.size;
+            }
+            return a.title.localeCompare(b.title);
+          });
+
+          // Format output
+          const formatted = sortedItems
+            .map(
+              (entry) =>
+                `${entry.isDirectory ? "[DIR]" : "[FILE]"} ${entry.title.padEnd(30)} ${
+                  entry.isDirectory ? "" : formatSize(entry.size).padStart(10)
+                }`,
+            )
+            .join("\n");
+
+          // Summary
+          const totalFiles = items.filter((e) => !e.isDirectory).length;
+          const totalDirs = items.filter((e) => e.isDirectory).length;
+          const totalSize = items.reduce(
+            (sum, entry) => sum + (entry.isDirectory ? 0 : entry.size),
+            0,
+          );
+
+          const summary = `\nTotal: ${totalFiles} files, ${totalDirs} directories\nCombined size: ${formatSize(totalSize)}`;
+          const text = formatted + summary;
+
+          return {
+            content: [{ type: "text", text }],
+            structuredContent: { content: text },
+          };
+        } catch (error) {
+          return {
+            content: [
+              { type: "text", text: `Error: ${(error as Error).message}` },
+            ],
+            isError: true,
+          };
+        }
+      },
+    ),
+  );
+
+  // directory_tree - recursive tree view as JSON
+  server.registerTool(
+    "directory_tree",
+    {
+      title: "Directory Tree",
+      description:
+        "Get a recursive tree view of files and directories as a JSON structure. " +
+        "Each entry includes 'name', 'type' (file/directory), and 'children' for directories. " +
+        "Only works within allowed directories.",
+      inputSchema: {
+        path: z.string().describe("Path of the root directory for the tree"),
+        excludePatterns: z
+          .array(z.string())
+          .optional()
+          .default([])
+          .describe("Glob patterns to exclude from the tree"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging("directory_tree", async (args): Promise<CallToolResult> => {
+      try {
+        const tree = await buildDirectoryTree(
+          storage,
+          args.path,
+          args.excludePatterns,
+        );
+        const text = JSON.stringify(tree, null, 2);
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: { content: text },
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // move_file - move or rename files
+  server.registerTool(
+    "move_file",
+    {
+      title: "Move File",
+      description:
+        "Move or rename files and directories. Can move files between directories " +
+        "and rename them in a single operation. If the destination exists, the " +
+        "operation will fail. Only works within allowed directories.",
+      inputSchema: {
+        source: z.string().describe("Source path of the file or directory"),
+        destination: z.string().describe("Destination path"),
+      },
+      annotations: {
+        readOnlyHint: false,
+        idempotentHint: false,
+        destructiveHint: false,
+      },
+    },
+    withLogging("move_file", async (args): Promise<CallToolResult> => {
+      try {
+        await storage.move(args.source, args.destination, false);
+        const text = `Successfully moved ${args.source} to ${args.destination}`;
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: { content: text },
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // search_files - search with glob patterns
+  server.registerTool(
+    "search_files",
+    {
+      title: "Search Files",
+      description:
+        "Recursively search for files and directories matching a pattern. " +
+        "Searches file names (not content). Returns full paths to all matching items. " +
+        "Only searches within allowed directories.",
+      inputSchema: {
+        path: z.string().describe("Starting directory for the search"),
+        pattern: z
+          .string()
+          .describe("Search pattern (supports * and ** wildcards)"),
+        excludePatterns: z
+          .array(z.string())
+          .optional()
+          .default([])
+          .describe("Patterns to exclude from search"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging("search_files", async (args): Promise<CallToolResult> => {
+      try {
+        const results = await searchFiles(
+          storage,
+          args.path,
+          args.pattern,
+          args.excludePatterns,
+        );
+        const text =
+          results.length > 0 ? results.join("\n") : "No matches found";
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: { content: text, matches: results },
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // get_file_info - get detailed file metadata
+  server.registerTool(
+    "get_file_info",
+    {
+      title: "Get File Info",
+      description:
+        "Retrieve detailed metadata about a file or directory. Returns comprehensive " +
+        "information including size, creation time, last modified time, and type. " +
+        "Only works within allowed directories.",
+      inputSchema: {
+        path: z.string().describe("Path to the file or directory"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging("get_file_info", async (args): Promise<CallToolResult> => {
+      try {
+        const metadata = await storage.getMetadata(args.path);
+        const info = {
+          path: metadata.path,
+          type: metadata.isDirectory ? "directory" : "file",
+          size: metadata.size,
+          sizeFormatted: formatSize(metadata.size),
+          mimeType: metadata.mimeType,
+          created: metadata.created_at,
+          modified: metadata.updated_at,
+        };
+        const text = Object.entries(info)
+          .map(([key, value]) => `${key}: ${value}`)
+          .join("\n");
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: info,
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // list_allowed_directories - show the root directory
+  server.registerTool(
+    "list_allowed_directories",
+    {
+      title: "List Allowed Directories",
+      description:
+        "Returns the list of directories that this server is allowed to access. " +
+        "Use this to understand which directories are available.",
+      inputSchema: {},
+      annotations: { readOnlyHint: true },
+    },
+    withLogging(
+      "list_allowed_directories",
+      async (): Promise<CallToolResult> => {
+        const text = `Allowed directories:\n${storage.root}`;
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: { directories: [storage.root] },
+        };
+      },
+    ),
+  );
+
+  // ============================================================
+  // ADDITIONAL TOOLS (not in official, but useful)
+  // ============================================================
+
+  // delete_file - delete files or directories (official doesn't have this!)
+  server.registerTool(
+    "delete_file",
+    {
+      title: "Delete File",
+      description:
+        "Delete a file or directory. Use recursive=true to delete non-empty directories. " +
+        "Use with caution as this operation cannot be undone. Only works within allowed directories.",
+      inputSchema: {
+        path: z.string().describe("Path to the file or directory to delete"),
+        recursive: z
+          .boolean()
+          .default(false)
+          .describe(
+            "If true, recursively delete directories and their contents",
+          ),
+      },
+      annotations: {
+        readOnlyHint: false,
+        idempotentHint: false,
+        destructiveHint: true,
+      },
+    },
+    withLogging("delete_file", async (args): Promise<CallToolResult> => {
+      try {
+        await storage.delete(args.path, args.recursive);
+        const text = `Successfully deleted ${args.path}`;
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: { content: text },
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // copy_file - copy files (official doesn't have this!)
+  server.registerTool(
+    "copy_file",
+    {
+      title: "Copy File",
+      description:
+        "Copy a file to a new location. The destination must not exist unless overwrite is true. " +
+        "Only works within allowed directories.",
+      inputSchema: {
+        source: z.string().describe("Source path of the file to copy"),
+        destination: z.string().describe("Destination path for the copy"),
+        overwrite: z
+          .boolean()
+          .default(false)
+          .describe("If true, overwrite the destination if it exists"),
+      },
+      annotations: {
+        readOnlyHint: false,
+        idempotentHint: true,
+        destructiveHint: false,
+      },
+    },
+    withLogging("copy_file", async (args): Promise<CallToolResult> => {
+      try {
+        await storage.copy(args.source, args.destination, args.overwrite);
+        const text = `Successfully copied ${args.source} to ${args.destination}`;
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: { content: text },
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // fetch_to_file - fetch URL and stream directly to disk
+  server.registerTool(
+    "fetch_to_file",
+    {
+      title: "Fetch URL to File",
+      description:
+        "Fetch content from a URL and save it directly to disk using streaming. " +
+        "Content is streamed without loading into memory, making it efficient for large files. " +
+        "Filename is extracted from URL path or Content-Disposition header. " +
+        "File extension is intelligently determined from Content-Type when not in filename. " +
+        "Perfect for downloading large datasets, images, or any remote content without " +
+        "consuming context window tokens. Only works within allowed directories.",
+      inputSchema: {
+        url: z.string().describe("The URL to fetch content from"),
+        filename: z
+          .string()
+          .optional()
+          .describe(
+            "Optional filename to save as. If not provided, extracted from URL or Content-Disposition header",
+          ),
+        directory: z
+          .string()
+          .default("")
+          .describe(
+            "Directory to save the file in (relative to storage root). Defaults to root.",
+          ),
+        overwrite: z
+          .boolean()
+          .default(false)
+          .describe("If true, overwrite existing file"),
+        headers: z
+          .record(z.string(), z.string())
+          .optional()
+          .describe(
+            "Optional HTTP headers to send with the request (e.g., Authorization)",
+          ),
+      },
+      annotations: {
+        readOnlyHint: false,
+        idempotentHint: false,
+        destructiveHint: false,
+      },
+    },
+    withLogging("fetch_to_file", async (args): Promise<CallToolResult> => {
+      try {
+        const fetchHeaders: Record<string, string> = {
+          "User-Agent": "MCP-LocalFS/1.0",
+          ...(args.headers || {}),
+        };
+
+        const response = await fetch(args.url, {
+          headers: fetchHeaders,
+        });
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
+        if (!response.body) {
+          throw new Error("Response has no body");
+        }
+
+        // Determine filename
+        let filename = args.filename;
+
+        if (!filename) {
+          // Try Content-Disposition header first
+          const disposition = response.headers.get("Content-Disposition");
+          if (disposition) {
+            const filenameMatch = disposition.match(
+              /filename[*]?=(?:UTF-8'')?["']?([^"';\n]+)["']?/i,
+            );
+            if (filenameMatch) {
+              filename = decodeURIComponent(filenameMatch[1].trim());
+            }
+          }
+
+          // Fall back to URL path
+          if (!filename) {
+            const urlObj = new URL(args.url);
+            const pathParts = urlObj.pathname.split("/").filter(Boolean);
+            filename =
+              pathParts.length > 0
+                ? pathParts[pathParts.length - 1]
+                : "download";
+          }
+        }
+
+        // Check if filename has extension, if not try to add from Content-Type
+        const hasExtension = filename.includes(".");
+        if (!hasExtension) {
+          const contentType = response.headers.get("Content-Type");
+          if (contentType) {
+            const ext = getExtensionFromMimeType(contentType);
+            if (ext) {
+              filename = filename + ext;
+            }
+          }
+        }
+
+        // Sanitize filename
+        filename = filename.replace(/[<>:"/\\|?*\x00-\x1f]/g, "_");
+
+        // Build full path
+        const directory = args.directory || "";
+        const fullPath = directory ? `${directory}/${filename}` : filename;
+
+        // Stream to disk
+        const result = await storage.writeStream(fullPath, response.body, {
+          createParents: true,
+          overwrite: args.overwrite,
+        });
+
+        const summary = {
+          path: result.file.path,
+          size: result.bytesWritten,
+          sizeFormatted: formatSize(result.bytesWritten),
+          mimeType: result.file.mimeType,
+          url: args.url,
+        };
+
+        const text =
+          `Successfully downloaded ${args.url}\n` +
+          `Saved to: ${result.file.path}\n` +
+          `Size: ${formatSize(result.bytesWritten)}`;
+
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: summary,
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // ============================================================
+  // MESH COLLECTION BINDINGS
+  // These follow the standard collection binding protocol for Mesh
+  // ============================================================
+
+  // COLLECTION_FILES_LIST - list files with pagination
+  server.registerTool(
+    "COLLECTION_FILES_LIST",
+    {
+      title: "List Files Collection",
+      description:
+        "List files in a folder with pagination support. " +
+        "Use recursive=true for full tree (may be slow for large directories). " +
+        "Supports both simple format and standard collection binding format.",
+      inputSchema: {
+        parent: z
+          .string()
+          .optional()
+          .default("")
+          .describe("Parent folder to list (empty for root)"),
+        recursive: z
+          .boolean()
+          .optional()
+          .default(false)
+          .describe("Recursively list all files"),
+        limit: z
+          .number()
+          .optional()
+          .default(100)
+          .describe("Maximum number of items to return"),
+        offset: z
+          .number()
+          .optional()
+          .default(0)
+          .describe("Number of items to skip"),
+        where: z
+          .unknown()
+          .optional()
+          .describe("Standard collection binding filter"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging(
+      "COLLECTION_FILES_LIST",
+      async (args): Promise<CallToolResult> => {
+        try {
+          // Extract parent from where clause if provided
+          let parent = args.parent || "";
+          if (args.where) {
+            const extracted = extractParentFromWhere(args.where);
+            if (extracted) parent = extracted;
+          }
+
+          const allItems = await storage.list(parent, {
+            recursive: args.recursive,
+            filesOnly: true,
+          });
+
+          const offset = args.offset || 0;
+          const limit = args.limit || 100;
+          const items = allItems.slice(offset, offset + limit);
+
+          const result = {
+            items,
+            totalCount: allItems.length,
+            hasMore: offset + limit < allItems.length,
+          };
+
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            structuredContent: result,
+          };
+        } catch (error) {
+          return {
+            content: [
+              { type: "text", text: `Error: ${(error as Error).message}` },
+            ],
+            isError: true,
+          };
+        }
+      },
+    ),
+  );
+
+  // COLLECTION_FILES_GET - get a single file's metadata and content
+  server.registerTool(
+    "COLLECTION_FILES_GET",
+    {
+      title: "Get File from Collection",
+      description: "Get file metadata and content by path (id).",
+      inputSchema: {
+        id: z.string().describe("File path (id)"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging(
+      "COLLECTION_FILES_GET",
+      async (args): Promise<CallToolResult> => {
+        try {
+          const metadata = await storage.getMetadata(args.id);
+
+          // For files, also include content
+          let content: string | undefined;
+          if (!metadata.isDirectory) {
+            try {
+              // Try to read as text for text-based files
+              const isTextFile =
+                metadata.mimeType.startsWith("text/") ||
+                metadata.mimeType === "application/json" ||
+                metadata.mimeType === "application/javascript" ||
+                metadata.mimeType === "application/xml" ||
+                metadata.mimeType === "application/x-yaml";
+
+              if (isTextFile) {
+                const fileResult = await storage.read(args.id, "utf-8");
+                content = fileResult.content;
+              } else {
+                // For binary files, return base64
+                const fileResult = await storage.read(args.id, "base64");
+                content = fileResult.content;
+              }
+            } catch {
+              // If we can't read content, just return metadata
+            }
+          }
+
+          const item = { ...metadata, content };
+          const result = { item };
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            structuredContent: result,
+          };
+        } catch {
+          const result = { item: null };
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            structuredContent: result,
+          };
+        }
+      },
+    ),
+  );
+
+  // COLLECTION_FOLDERS_LIST - list folders
+  server.registerTool(
+    "COLLECTION_FOLDERS_LIST",
+    {
+      title: "List Folders Collection",
+      description: "List folders in a directory with pagination support.",
+      inputSchema: {
+        parent: z
+          .string()
+          .optional()
+          .default("")
+          .describe("Parent folder to list (empty for root)"),
+        limit: z
+          .number()
+          .optional()
+          .default(100)
+          .describe("Maximum number of items to return"),
+        offset: z
+          .number()
+          .optional()
+          .default(0)
+          .describe("Number of items to skip"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging(
+      "COLLECTION_FOLDERS_LIST",
+      async (args): Promise<CallToolResult> => {
+        try {
+          const allItems = await storage.list(args.parent || "");
+          const folders = allItems.filter(
+            (item: FileEntity) => item.isDirectory,
+          );
+
+          const offset = args.offset || 0;
+          const limit = args.limit || 100;
+          const items = folders.slice(offset, offset + limit);
+
+          const result = {
+            items,
+            totalCount: folders.length,
+            hasMore: offset + limit < folders.length,
+          };
+
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            structuredContent: result,
+          };
+        } catch (error) {
+          return {
+            content: [
+              { type: "text", text: `Error: ${(error as Error).message}` },
+            ],
+            isError: true,
+          };
+        }
+      },
+    ),
+  );
+
+  // COLLECTION_FOLDERS_GET - get a single folder's metadata
+  server.registerTool(
+    "COLLECTION_FOLDERS_GET",
+    {
+      title: "Get Folder from Collection",
+      description: "Get folder metadata by path (id).",
+      inputSchema: {
+        id: z.string().describe("Folder path (id)"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging(
+      "COLLECTION_FOLDERS_GET",
+      async (args): Promise<CallToolResult> => {
+        try {
+          const item = await storage.getMetadata(args.id);
+          if (!item.isDirectory) {
+            const result = { item: null };
+            return {
+              content: [
+                { type: "text", text: JSON.stringify(result, null, 2) },
+              ],
+              structuredContent: result,
+            };
+          }
+          const result = { item };
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            structuredContent: result,
+          };
+        } catch {
+          const result = { item: null };
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            structuredContent: result,
+          };
+        }
+      },
+    ),
+  );
+
+  // ============================================================
+  // MCP Mesh COMPATIBILITY ALIASES
+  // These maintain compatibility with existing Mesh connections
+  // that use the Mesh tool names (FILE_READ, FILE_WRITE, etc.)
+  // ============================================================
+
+  // FILE_READ - alias for read_text_file with encoding support
+  server.registerTool(
+    "FILE_READ",
+    {
+      title: "Read File (Legacy)",
+      description: "Read file content. Legacy alias for read_text_file.",
+      inputSchema: {
+        path: z.string().describe("File path relative to storage root"),
+        encoding: z.enum(["utf-8", "base64"]).default("utf-8"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withLogging("FILE_READ", async (args): Promise<CallToolResult> => {
+      try {
+        const result = await storage.read(args.path, args.encoding);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // FILE_WRITE - alias for write_file with encoding support
+  server.registerTool(
+    "FILE_WRITE",
+    {
+      title: "Write File (Legacy)",
+      description: "Write content to a file. Legacy alias for write_file.",
+      inputSchema: {
+        path: z.string(),
+        content: z.string(),
+        encoding: z.enum(["utf-8", "base64"]).default("utf-8"),
+        createParents: z.boolean().default(true),
+        overwrite: z.boolean().default(true),
+      },
+      annotations: {
+        readOnlyHint: false,
+        idempotentHint: true,
+        destructiveHint: true,
+      },
+    },
+    withLogging("FILE_WRITE", async (args): Promise<CallToolResult> => {
+      try {
+        const result = await storage.write(args.path, args.content, {
+          encoding: args.encoding,
+          createParents: args.createParents,
+          overwrite: args.overwrite,
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // FILE_DELETE - alias for delete_file
+  server.registerTool(
+    "FILE_DELETE",
+    {
+      title: "Delete File (Legacy)",
+      description: "Delete a file or directory. Legacy alias for delete_file.",
+      inputSchema: {
+        path: z.string(),
+        recursive: z.boolean().default(false),
+      },
+      annotations: {
+        readOnlyHint: false,
+        idempotentHint: false,
+        destructiveHint: true,
+      },
+    },
+    withLogging("FILE_DELETE", async (args): Promise<CallToolResult> => {
+      try {
+        const result = await storage.delete(args.path, args.recursive);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // FILE_MOVE - alias for move_file
+  server.registerTool(
+    "FILE_MOVE",
+    {
+      title: "Move File (Legacy)",
+      description: "Move or rename a file. Legacy alias for move_file.",
+      inputSchema: {
+        source: z.string(),
+        destination: z.string(),
+        overwrite: z.boolean().default(false),
+      },
+      annotations: {
+        readOnlyHint: false,
+        idempotentHint: false,
+        destructiveHint: false,
+      },
+    },
+    withLogging("FILE_MOVE", async (args): Promise<CallToolResult> => {
+      try {
+        await storage.move(args.source, args.destination, args.overwrite);
+        const text = `Successfully moved ${args.source} to ${args.destination}`;
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: { content: text },
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // FILE_COPY - alias for copy_file
+  server.registerTool(
+    "FILE_COPY",
+    {
+      title: "Copy File (Legacy)",
+      description: "Copy a file. Legacy alias for copy_file.",
+      inputSchema: {
+        source: z.string(),
+        destination: z.string(),
+        overwrite: z.boolean().default(false),
+      },
+      annotations: {
+        readOnlyHint: false,
+        idempotentHint: true,
+        destructiveHint: false,
+      },
+    },
+    withLogging("FILE_COPY", async (args): Promise<CallToolResult> => {
+      try {
+        await storage.copy(args.source, args.destination, args.overwrite);
+        const text = `Successfully copied ${args.source} to ${args.destination}`;
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: { content: text },
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+
+  // FILE_MKDIR - alias for create_directory
+  server.registerTool(
+    "FILE_MKDIR",
+    {
+      title: "Create Directory (Legacy)",
+      description: "Create a directory. Legacy alias for create_directory.",
+      inputSchema: {
+        path: z.string(),
+        recursive: z.boolean().default(true),
+      },
+      annotations: {
+        readOnlyHint: false,
+        idempotentHint: true,
+        destructiveHint: false,
+      },
+    },
+    withLogging("FILE_MKDIR", async (args): Promise<CallToolResult> => {
+      try {
+        await storage.mkdir(args.path, args.recursive);
+        const text = `Successfully created directory ${args.path}`;
+        return {
+          content: [{ type: "text", text }],
+          structuredContent: { content: text },
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text", text: `Error: ${(error as Error).message}` },
+          ],
+          isError: true,
+        };
+      }
+    }),
+  );
+}
+
+// ============================================================
+// HELPER FUNCTIONS
+// ============================================================
+
+/**
+ * Handler for read_file and read_text_file
+ */
+async function readTextFileHandler(
+  storage: LocalFileStorage,
+  args: { path: string; head?: number; tail?: number },
+): Promise<CallToolResult> {
+  try {
+    if (args.head && args.tail) {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: "Error: Cannot specify both head and tail parameters simultaneously",
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const result = await storage.read(args.path, "utf-8");
+    let content = result.content;
+
+    if (args.tail) {
+      const lines = content.split("\n");
+      content = lines.slice(-args.tail).join("\n");
+    } else if (args.head) {
+      const lines = content.split("\n");
+      content = lines.slice(0, args.head).join("\n");
+    }
+
+    return {
+      content: [{ type: "text" as const, text: content }],
+      structuredContent: { content },
+    };
+  } catch (error) {
+    return {
+      content: [
+        { type: "text" as const, text: `Error: ${(error as Error).message}` },
+      ],
+      isError: true,
+    };
+  }
+}
+
+/**
+ * Format file size in human-readable format
+ */
+function formatSize(bytes: number): string {
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let size = bytes;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex++;
+  }
+
+  return `${size.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+/**
+ * Generate a simple diff between two strings
+ */
+function generateDiff(
+  path: string,
+  original: string,
+  modified: string,
+): string {
+  const originalLines = original.split("\n");
+  const modifiedLines = modified.split("\n");
+
+  const lines: string[] = [`--- a/${path}`, `+++ b/${path}`];
+
+  // Simple line-by-line diff
+  const maxLen = Math.max(originalLines.length, modifiedLines.length);
+  let inHunk = false;
+  let hunkStart = 0;
+  let hunkLines: string[] = [];
+
+  for (let i = 0; i < maxLen; i++) {
+    const orig = originalLines[i];
+    const mod = modifiedLines[i];
+
+    if (orig !== mod) {
+      if (!inHunk) {
+        inHunk = true;
+        hunkStart = i + 1;
+        // Add context before
+        if (i > 0) hunkLines.push(` ${originalLines[i - 1]}`);
+      }
+
+      if (orig !== undefined) {
+        hunkLines.push(`-${orig}`);
+      }
+      if (mod !== undefined) {
+        hunkLines.push(`+${mod}`);
+      }
+    } else if (inHunk) {
+      hunkLines.push(` ${orig}`);
+      // Close hunk after context
+      lines.push(
+        `@@ -${hunkStart},${hunkLines.length} +${hunkStart},${hunkLines.length} @@`,
+      );
+      lines.push(...hunkLines);
+      hunkLines = [];
+      inHunk = false;
+    }
+  }
+
+  if (hunkLines.length > 0) {
+    lines.push(
+      `@@ -${hunkStart},${hunkLines.length} +${hunkStart},${hunkLines.length} @@`,
+    );
+    lines.push(...hunkLines);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Build a recursive directory tree
+ */
+interface TreeEntry {
+  name: string;
+  type: "file" | "directory";
+  children?: TreeEntry[];
+}
+
+async function buildDirectoryTree(
+  storage: LocalFileStorage,
+  path: string,
+  excludePatterns: string[],
+): Promise<TreeEntry[]> {
+  const items = await storage.list(path);
+  const result: TreeEntry[] = [];
+
+  for (const item of items) {
+    // Check exclusions
+    const shouldExclude = excludePatterns.some((pattern) => {
+      if (pattern.includes("*")) {
+        return matchGlob(item.title, pattern);
+      }
+      return item.title === pattern;
+    });
+
+    if (shouldExclude) continue;
+
+    const entry: TreeEntry = {
+      name: item.title.split("/").pop() || item.title,
+      type: item.isDirectory ? "directory" : "file",
+    };
+
+    if (item.isDirectory) {
+      entry.children = await buildDirectoryTree(
+        storage,
+        item.path,
+        excludePatterns,
+      );
+    }
+
+    result.push(entry);
+  }
+
+  return result;
+}
+
+/**
+ * Search for files matching a pattern
+ */
+async function searchFiles(
+  storage: LocalFileStorage,
+  basePath: string,
+  pattern: string,
+  excludePatterns: string[],
+): Promise<string[]> {
+  const items = await storage.list(basePath, { recursive: true });
+  const results: string[] = [];
+
+  for (const item of items) {
+    // Check exclusions
+    const shouldExclude = excludePatterns.some((p) => matchGlob(item.path, p));
+    if (shouldExclude) continue;
+
+    // Check pattern match
+    if (matchGlob(item.path, pattern) || matchGlob(item.title, pattern)) {
+      results.push(item.path);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Simple glob pattern matching
+ */
+function matchGlob(str: string, pattern: string): boolean {
+  // Convert glob to regex
+  const regex = pattern
+    .replace(/\*\*/g, "<<<DOUBLESTAR>>>")
+    .replace(/\*/g, "[^/]*")
+    .replace(/<<<DOUBLESTAR>>>/g, ".*")
+    .replace(/\?/g, ".")
+    .replace(/\./g, "\\.");
+
+  return new RegExp(`^${regex}$`).test(str) || new RegExp(regex).test(str);
+}
+
+/**
+ * Extract parent from a where clause (for collection bindings)
+ */
+function extractParentFromWhere(where: unknown): string {
+  if (!where || typeof where !== "object") return "";
+  const w = where as Record<string, unknown>;
+
+  // Simple condition: { field: ["parent"], operator: "eq", value: "..." }
+  if (
+    Array.isArray(w.field) &&
+    w.field[0] === "parent" &&
+    w.operator === "eq"
+  ) {
+    return String(w.value ?? "");
+  }
+
+  // Compound condition: { operator: "and", conditions: [...] }
+  if (w.operator === "and" || w.operator === "or") {
+    if (Array.isArray(w.conditions)) {
+      for (const cond of w.conditions) {
+        const parent = extractParentFromWhere(cond);
+        if (parent) return parent;
+      }
+    }
+  }
+
+  return "";
+}

--- a/local-fs/tsconfig.json
+++ b/local-fs/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "server",
+    "declaration": true,
+    "resolveJsonModule": true
+  },
+  "include": ["server/**/*.ts"],
+  "exclude": ["node_modules", "dist", "server/**/*.test.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "data-for-seo",
     "datajud",
     "gemini-pro-vision",
+    "local-fs",
     "meta-ads",
     "nanobanana",
     "object-storage",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a local filesystem MCP server that mounts any folder and exposes file tools over stdio or HTTP. Includes a CLI, HTTP endpoint, collection bindings, docs, and tests.

- **New Features**
  - New package: @decocms/mcp-local-fs with stdio (default) and HTTP transports
  - CLI: npx @decocms/mcp-local-fs [--http] [--path PATH] [--port PORT]
  - Tools: read, write, delete, move, copy, mkdir; plus collection list/get with filters and pagination
  - HTTP: /mcp?path=/dir, plus GET / and /health; SSE supported
  - Docs and examples for Claude Desktop/Cursor
  - Tests for storage and MCP tools

<sup>Written for commit 85a540085c83c006ced9570e3b48cc05ef667a15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

