### PR TITLE
use prompts binding on deps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
       "name": "mcp-studio",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/bindings": "1.0.1-alpha.26",
+        "@decocms/bindings": "1.0.1-alpha.27",
         "@decocms/mcps-shared": "1.0.0",
         "@decocms/runtime": "1.0.0-alpha.42",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -650,7 +650,7 @@
 
     "@deco/mcp": ["@jsr/deco__mcp@0.5.5", "https://npm.jsr.io/~/11/@jsr/deco__mcp/0.5.5.tgz", { "dependencies": { "@jsr/deco__deco": "^1.112.1", "@jsr/hono__hono": "^4.5.4", "@modelcontextprotocol/sdk": "^1.11.4", "fetch-to-node": "^2.1.0", "zod": "^3.24.2" } }, "sha512-46TaWGu7lbsPleHjCVrG6afhQjv3muBTNRFBkIhLrSzlQ+9d21UeukpYs19z0AGpOlmjSSK9qIRFTf8SlH2B6Q=="],
 
-    "@decocms/bindings": ["@decocms/bindings@1.0.1-alpha.26", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.20.2", "zod": "^3.25.76", "zod-from-json-schema": "^0.0.5" } }, "sha512-i6WlXYKL61PDkxBbPaA1NNvezqxa7CW6wPaRBZueAuEUxBcDSeOTs4DE6LWjzWz7TpsUg4fD72Ov3IEk7S1nVA=="],
+    "@decocms/bindings": ["@decocms/bindings@1.0.1-alpha.27", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.20.2", "zod": "^3.25.76", "zod-from-json-schema": "^0.0.5" } }, "sha512-0usZaDC5wKMT+aoLV/H8jDLJkuT0lVHWrXGR7AoAJ0A6eEZCCuXu3G4/Yoo8xR5uYjv2MjEw2Xbf4GnVS2Rttg=="],
 
     "@decocms/mcps-shared": ["@decocms/mcps-shared@workspace:shared"],
 

--- a/mcp-studio/package.json
+++ b/mcp-studio/package.json
@@ -14,7 +14,7 @@
     "publish": "cat app.json | deco registry publish -w /shared/deco -y"
   },
   "dependencies": {
-    "@decocms/bindings": "1.0.1-alpha.26",
+    "@decocms/bindings": "1.0.1-alpha.27",
     "@decocms/runtime": "1.0.0-alpha.42",
     "@decocms/mcps-shared": "1.0.0",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/mcp-studio/server/tools/prompt.ts
+++ b/mcp-studio/server/tools/prompt.ts
@@ -10,11 +10,13 @@
  */
 
 import {
-  BaseCollectionEntitySchema,
   CollectionGetInputSchema,
-  createCollectionBindings,
   createCollectionGetOutputSchema,
 } from "@decocms/bindings/collections";
+import {
+  PROMPTS_COLLECTION_BINDING,
+  PromptSchema,
+} from "@decocms/bindings/prompt";
 import { createPrivateTool } from "@decocms/runtime/tools";
 import { z, type ZodType } from "zod";
 import { runSQL } from "../lib/postgres.ts";
@@ -29,75 +31,6 @@ import type { Env } from "../main.ts";
 // ============================================================================
 // Schemas (following MCP Prompts specification)
 // ============================================================================
-
-/**
- * Schema for prompt arguments that can be passed when getting a prompt
- */
-const PromptArgumentSchema = z.object({
-  name: z.string().describe("Argument name"),
-  description: z.string().optional().describe("Argument description"),
-  required: z.boolean().optional().describe("Whether argument is required"),
-});
-
-/**
- * Schema for prompt icons for display in user interfaces
- */
-const PromptIconSchema = z.object({
-  src: z.string().url().describe("Icon URL"),
-  mimeType: z.string().optional().describe("Icon MIME type"),
-  sizes: z.array(z.string()).optional().describe("Icon sizes"),
-});
-
-/**
- * Schema for content within a prompt message
- */
-const PromptMessageContentSchema = z.object({
-  type: z.enum(["text", "image", "audio", "resource"]).describe("Content type"),
-  text: z.string().optional().describe("Text content"),
-  data: z.string().optional().describe("Base64-encoded data for image/audio"),
-  mimeType: z
-    .string()
-    .optional()
-    .describe("MIME type for image/audio/resource"),
-  resource: z
-    .object({
-      uri: z.string().describe("Resource URI"),
-      mimeType: z.string().optional().describe("Resource MIME type"),
-      text: z.string().optional().describe("Resource text content"),
-      blob: z.string().optional().describe("Base64-encoded resource blob"),
-    })
-    .optional()
-    .describe("Embedded resource"),
-});
-
-/**
- * Schema for a message in a prompt
- */
-const PromptMessageSchema = z.object({
-  role: z.enum(["user", "assistant"]).describe("Message role"),
-  content: PromptMessageContentSchema.describe("Message content"),
-});
-
-/**
- * Full prompt entity schema extending base collection fields
- */
-export const PromptSchema = BaseCollectionEntitySchema.extend({
-  arguments: z
-    .array(PromptArgumentSchema)
-    .optional()
-    .describe("Arguments that can be passed when getting this prompt"),
-  icons: z
-    .array(PromptIconSchema)
-    .optional()
-    .describe("Icons for display in user interfaces"),
-  messages: z.array(PromptMessageSchema).describe("Prompt messages template"),
-});
-
-// Create collection bindings
-const PROMPTS_COLLECTION_BINDING = createCollectionBindings(
-  "prompt",
-  PromptSchema,
-);
 
 // Extract binding schemas
 const LIST_BINDING = PROMPTS_COLLECTION_BINDING.find(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the prompt tool to use the official bindings from @decocms/bindings, removing local prompt schemas and collection binding to stay aligned with upstream and reduce maintenance.

- **Dependencies**
  - Bumped @decocms/bindings to 1.0.1-alpha.27.

- **Refactors**
  - Replaced local PromptSchema and collection binding with PROMPTS_COLLECTION_BINDING and PromptSchema from @decocms/bindings/prompt.

<sup>Written for commit 91aa8920a4b5752b34468117b36c61f4d37a87d2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

