### PR TITLE
Adds safety checks when accessing database env

### DIFF
--- a/mcp-studio/server/db/postgres.ts
+++ b/mcp-studio/server/db/postgres.ts
@@ -19,7 +19,7 @@ export async function runSQL<T = unknown>(
   params: unknown[] = [],
 ): Promise<T[]> {
   const response =
-    await env.MESH_REQUEST_CONTEXT.state.DATABASE.DATABASES_RUN_SQL({
+    await env.MESH_REQUEST_CONTEXT?.state?.DATABASE.DATABASES_RUN_SQL({
       sql,
       params,
     });

--- a/mcp-studio/server/db/queries/executions.ts
+++ b/mcp-studio/server/db/queries/executions.ts
@@ -38,7 +38,7 @@ export async function claimExecution(
   // Atomic claim: only succeeds if status is 'enqueued'
   // Join with workflow table to get steps and gateway_id
   const result =
-    await env.MESH_REQUEST_CONTEXT.state.DATABASE.DATABASES_RUN_SQL({
+    await env.MESH_REQUEST_CONTEXT?.state?.DATABASE.DATABASES_RUN_SQL({
       sql: `
       UPDATE workflow_execution
       SET 
@@ -96,7 +96,7 @@ export async function getExecution(
   id: string,
 ): Promise<WorkflowExecution | null> {
   const result =
-    await env.MESH_REQUEST_CONTEXT.state.DATABASE.DATABASES_RUN_SQL({
+    await env.MESH_REQUEST_CONTEXT?.state?.DATABASE.DATABASES_RUN_SQL({
       sql: "SELECT * FROM workflow_execution WHERE id = ? LIMIT 1",
       params: [id],
     });
@@ -332,7 +332,7 @@ export async function cancelExecution(
 
   // Only cancel if currently enqueued or running
   const result =
-    await env.MESH_REQUEST_CONTEXT.state.DATABASE.DATABASES_RUN_SQL({
+    await env.MESH_REQUEST_CONTEXT?.state?.DATABASE.DATABASES_RUN_SQL({
       sql: `
       UPDATE workflow_execution
       SET 

--- a/mcp-studio/server/db/schemas/agents.ts
+++ b/mcp-studio/server/db/schemas/agents.ts
@@ -19,7 +19,7 @@ export async function runSQL<T = unknown>(
     return p;
   });
   const response =
-    await env.MESH_REQUEST_CONTEXT.state.DATABASE.DATABASES_RUN_SQL({
+    await env.MESH_REQUEST_CONTEXT?.state?.DATABASE.DATABASES_RUN_SQL({
       sql,
       params: sanitizedParams,
     });

--- a/mcp-studio/server/engine/events.ts
+++ b/mcp-studio/server/engine/events.ts
@@ -16,7 +16,7 @@ export async function getPendingEvents(
 ): Promise<WorkflowEvent[]> {
   const now = Date.now();
   const result =
-    await env.MESH_REQUEST_CONTEXT.state.DATABASE.DATABASES_RUN_SQL({
+    await env.MESH_REQUEST_CONTEXT?.state?.DATABASE.DATABASES_RUN_SQL({
       sql: `SELECT * FROM workflow_event WHERE execution_id = ? AND consumed_at IS NULL
           AND (visible_at IS NULL OR visible_at <= ?) ${type ? "AND type = ?" : ""}
           ORDER BY visible_at ASC NULLS FIRST, created_at ASC`,
@@ -48,7 +48,7 @@ export async function consumeSignal(
   signalId: string,
 ): Promise<boolean> {
   const result =
-    await env.MESH_REQUEST_CONTEXT.state.DATABASE.DATABASES_RUN_SQL({
+    await env.MESH_REQUEST_CONTEXT?.state?.DATABASE.DATABASES_RUN_SQL({
       sql: `UPDATE workflow_event SET consumed_at = ? WHERE id = ? AND consumed_at IS NULL RETURNING id`,
       params: [Date.now(), signalId],
     });

--- a/mcp-studio/server/prompts.ts
+++ b/mcp-studio/server/prompts.ts
@@ -44,7 +44,7 @@ interface StoredPrompt {
  * Load prompts from the database
  */
 async function loadPrompts(env: Env): Promise<StoredPrompt[]> {
-  if (!env.MESH_REQUEST_CONTEXT.state.DATABASE) {
+  if (!env.MESH_REQUEST_CONTEXT?.state?.DATABASE) {
     return [];
   }
 

--- a/mcp-studio/server/tools/assistant.ts
+++ b/mcp-studio/server/tools/assistant.ts
@@ -26,13 +26,13 @@ import {
 import { createPrivateTool } from "@decocms/runtime/tools";
 import type { z } from "zod";
 import { runSQL } from "../db/postgres.ts";
-import type { Env } from "../types/env.ts";
 import {
   buildOrderByClause,
   buildWhereClause,
   type OrderByExpression,
   type WhereExpression,
 } from "../db/schemas/query-builder.ts";
+import type { Env } from "../types/env.ts";
 
 // Extract binding schemas
 const LIST_BINDING = ASSISTANTS_BINDING.find(
@@ -151,7 +151,7 @@ export const createListTool = (env: Env) =>
     outputSchema: LIST_BINDING.outputSchema,
     execute: async ({ context }) => {
       // If DATABASE is not available, return empty list
-      if (!env.MESH_REQUEST_CONTEXT.state.DATABASE) {
+      if (!env.MESH_REQUEST_CONTEXT?.state?.DATABASE) {
         return {
           items: [],
           totalCount: 0,
@@ -210,7 +210,7 @@ export const createGetTool = (env: Env) =>
     inputSchema: CollectionGetInputSchema,
     outputSchema: createCollectionGetOutputSchema(AssistantSchema),
     execute: async ({ context }) => {
-      if (!env.MESH_REQUEST_CONTEXT.state.DATABASE) {
+      if (!env.MESH_REQUEST_CONTEXT?.state?.DATABASE) {
         return { item: null };
       }
 
@@ -246,7 +246,7 @@ export const createInsertTool = (env: Env) =>
     }: {
       context: z.infer<typeof CREATE_INPUT_SCHEMA>;
     }) => {
-      if (!env.MESH_REQUEST_CONTEXT.state.DATABASE) {
+      if (!env.MESH_REQUEST_CONTEXT?.state?.DATABASE) {
         throw new Error("DATABASE not configured for mcp-studio");
       }
 
@@ -318,7 +318,7 @@ export const createUpdateTool = (env: Env) =>
     }: {
       context: z.infer<typeof UPDATE_INPUT_SCHEMA>;
     }) => {
-      if (!env.MESH_REQUEST_CONTEXT.state.DATABASE) {
+      if (!env.MESH_REQUEST_CONTEXT?.state?.DATABASE) {
         throw new Error("DATABASE not configured for mcp-studio");
       }
 
@@ -397,7 +397,7 @@ export const createDeleteTool = (env: Env) =>
     }: {
       context: z.infer<typeof CollectionDeleteInputSchema>;
     }) => {
-      if (!env.MESH_REQUEST_CONTEXT.state.DATABASE) {
+      if (!env.MESH_REQUEST_CONTEXT?.state?.DATABASE) {
         throw new Error("DATABASE not configured for mcp-studio");
       }
 

--- a/mcp-studio/server/tools/workflow.ts
+++ b/mcp-studio/server/tools/workflow.ts
@@ -114,14 +114,14 @@ export const createListTool = (env: Env) =>
         `;
 
       const itemsResult: any =
-        await env.MESH_REQUEST_CONTEXT.state.DATABASE.DATABASES_RUN_SQL({
+        await env.MESH_REQUEST_CONTEXT?.state?.DATABASE.DATABASES_RUN_SQL({
           sql,
           params: [...params, limit, offset],
         });
 
       const countQuery = `SELECT COUNT(*) as count FROM workflow_collection ${whereClause}`;
       const countResult =
-        await env.MESH_REQUEST_CONTEXT.state.DATABASE.DATABASES_RUN_SQL({
+        await env.MESH_REQUEST_CONTEXT?.state?.DATABASE.DATABASES_RUN_SQL({
           sql: countQuery,
           params,
         });
@@ -147,7 +147,7 @@ export async function getWorkflowCollection(
   id: string,
 ): Promise<Workflow | null> {
   const result =
-    await env.MESH_REQUEST_CONTEXT.state.DATABASE.DATABASES_RUN_SQL({
+    await env.MESH_REQUEST_CONTEXT?.state?.DATABASE.DATABASES_RUN_SQL({
       sql: "SELECT * FROM workflow_collection WHERE id = ? LIMIT 1",
       params: [id],
     });
@@ -313,7 +313,7 @@ y        UPDATE workflow_collection
       `;
 
   const result =
-    await env.MESH_REQUEST_CONTEXT.state.DATABASE.DATABASES_RUN_SQL({
+    await env.MESH_REQUEST_CONTEXT?.state?.DATABASE.DATABASES_RUN_SQL({
       sql,
       params,
     });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add null-safe checks around env.MESH_REQUEST_CONTEXT.state.DATABASE to prevent crashes when the database binding is missing. Calls now fail gracefully or return empty results where appropriate.

- **Bug Fixes**
  - Switched database calls to use optional chaining (?.) and guards before DATABASES_RUN_SQL.
  - Added safe early returns or clear errors in assistants, workflows, prompts, executions, and events when DATABASE is not configured.

<sup>Written for commit a258e2d5a791c439eecc421e58659745e71035e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

