### PR TITLE
feat(slack): add SLACK_LIST_DMS tool and sender name in DMs

### DIFF
--- a/slack-mcp/server/lib/types.ts
+++ b/slack-mcp/server/lib/types.ts
@@ -141,6 +141,7 @@ export interface SlackChannel {
   is_member: boolean;
   created: number;
   creator: string;
+  user?: string;
   topic?: {
     value: string;
     creator: string;

--- a/slack-mcp/server/slack/handlers/eventHandler.ts
+++ b/slack-mcp/server/slack/handlers/eventHandler.ts
@@ -17,6 +17,7 @@ import {
   addReaction,
   removeReaction,
   deleteMessage,
+  getUserInfo,
 } from "../../lib/slack-client.ts";
 import type {
   SlackEvent,
@@ -845,8 +846,29 @@ async function handleDirectMessage(
     await removeReaction(channel, ts, "eyes");
   }
 
+  // Resolve sender name so the LLM knows who it's talking to
+  let senderText = text;
+  try {
+    const userInfo = await getUserInfo(user);
+    const senderName = userInfo
+      ? userInfo.profile?.display_name || userInfo.real_name || userInfo.name
+      : null;
+    if (senderName) {
+      senderText = `[Mensagem de ${senderName}]\n${text}`;
+      console.log(`[EventHandler] DM sender resolved: ${senderName}`);
+    }
+  } catch (err) {
+    console.warn(`[EventHandler] Failed to resolve DM sender name:`, err);
+  }
+
   console.log(`[EventHandler] Building LLM messages for DM...`);
-  const messages = await buildLLMMessages(channel, text, ts, undefined, media);
+  const messages = await buildLLMMessages(
+    channel,
+    senderText,
+    ts,
+    undefined,
+    media,
+  );
   console.log(`[EventHandler] LLM messages built: ${messages.length} messages`);
   messages.forEach((msg, i) => {
     console.log(

--- a/slack-mcp/server/tools/channels.ts
+++ b/slack-mcp/server/tools/channels.ts
@@ -14,6 +14,7 @@ import {
   getChannelMembers,
   openDM,
   inviteToChannel,
+  getUserInfo,
 } from "../lib/slack-client.ts";
 
 /**
@@ -92,6 +93,80 @@ export const createListChannelsTool = (_env: Env) =>
         return {
           success: false,
           channels: [],
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+  });
+
+/**
+ * List all direct message conversations
+ */
+export const createListDMsTool = (_env: Env) =>
+  createTool({
+    id: "SLACK_LIST_DMS",
+    description:
+      "List all direct message conversations the bot has. Returns channel IDs that can be used with SLACK_GET_CHANNEL_HISTORY to read DM messages.",
+    annotations: { readOnlyHint: true },
+    inputSchema: z
+      .object({
+        limit: z
+          .number()
+          .optional()
+          .default(100)
+          .describe("Maximum number of DMs to return"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        dms: z.array(
+          z.object({
+            channel_id: z.string(),
+            user_id: z.string(),
+            user_name: z.string(),
+          }),
+        ),
+        error: z.string().optional(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as { limit?: number };
+
+      try {
+        const channels = await listChannels({
+          types: "im",
+          limit: input.limit,
+          skipCache: true,
+        });
+
+        const imChannels = channels.filter((c) => c.is_im && c.user);
+
+        const dms = await Promise.all(
+          imChannels.map(async (c) => {
+            const userInfo = await getUserInfo(c.user!);
+            const userName = userInfo
+              ? userInfo.profile?.display_name ||
+                userInfo.real_name ||
+                userInfo.name
+              : "(unknown user)";
+
+            return {
+              channel_id: c.id,
+              user_id: c.user!,
+              user_name: userName,
+            };
+          }),
+        );
+
+        return {
+          success: true,
+          dms,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          dms: [],
           error: error instanceof Error ? error.message : String(error),
         };
       }
@@ -356,6 +431,7 @@ export const createInviteToChannelTool = (_env: Env) =>
  */
 export const channelTools = [
   createListChannelsTool,
+  createListDMsTool,
   createGetChannelInfoTool,
   createJoinChannelTool,
   createGetChannelMembersTool,

--- a/slack-mcp/tsconfig.json
+++ b/slack-mcp/tsconfig.json
@@ -21,13 +21,6 @@
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    /* Path Aliases */
-    "baseUrl": ".",
-    "paths": {
-      "server/*": [
-        "./server/*"
-      ]
-    },
     /* Types */
     "types": [
       "@types/node"


### PR DESCRIPTION
## Summary
- Adds `SLACK_LIST_DMS` tool that lists all bot DM conversations with resolved user names and channel IDs
- Injects the sender's display name into DM messages sent to the LLM (`[Mensagem de {name}]`) so the agent knows who it's talking to
- Adds `user?` field to `SlackChannel` type to support IM channel data from Slack API

## Test plan
- [ ] Deploy and call `SLACK_LIST_DMS` — should return DM conversations with user names
- [ ] Use a returned `channel_id` with `SLACK_GET_CHANNEL_HISTORY` to read DM messages
- [ ] Send a DM to the bot and verify the LLM receives the sender name in the message

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `SLACK_LIST_DMS` to list the bot’s DM conversations with resolved user names and channel IDs, and inject the sender’s display name into DM messages so the agent knows who is speaking. Also remove deprecated tsconfig path settings to keep CI green on TypeScript 7.0.

- **New Features**
  - `SLACK_LIST_DMS` returns DMs with `{ channel_id, user_id, user_name }` and optional `limit`.
  - DM messages include “[Mensagem de {name}]” when the sender is resolved via `getUserInfo`.
  - `SlackChannel` adds `user?` for IM channel data; tool registered in `channelTools`.

- **Bug Fixes**
  - Removed unused `baseUrl`/`paths` from `tsconfig.json` (deprecated in TS 7.0).

<sup>Written for commit 989175f118dd497d16d23fa1fe57e6c7a4ab66d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

