### PR TITLE
chore: bump @decocms/runtime to 1.4.0, migrate createPrivateTool

### DIFF
--- a/airtable/package.json
+++ b/airtable/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.8",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/airtable/server/tools/auth.ts
+++ b/airtable/server/tools/auth.ts
@@ -1,16 +1,17 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { getAccessToken } from "../lib/env.ts";
 import { AirtableClient } from "../lib/airtable-client.ts";
 
 export const createWhoamiTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "airtable_whoami",
     description:
       "Get the current authenticated user's ID, email, and OAuth scopes.",
     inputSchema: z.object({}),
-    execute: async () => {
+    execute: async (_input, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AirtableClient(getAccessToken(env));
       return await client.whoami();
     },

--- a/airtable/server/tools/bases.ts
+++ b/airtable/server/tools/bases.ts
@@ -1,11 +1,11 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { getAccessToken } from "../lib/env.ts";
 import { AirtableClient } from "../lib/airtable-client.ts";
 
 export const createListBasesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "airtable_list_bases",
     description:
       "List all Airtable bases accessible to the authenticated user. Supports pagination via offset.",
@@ -15,14 +15,15 @@ export const createListBasesTool = (env: Env) =>
         .optional()
         .describe("Pagination offset from a previous response."),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AirtableClient(getAccessToken(env));
       return await client.listBases(context.offset);
     },
   });
 
 export const createGetBaseSchemaTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "airtable_get_base_schema",
     description: "Get the schema (tables, fields, views) of an Airtable base.",
     inputSchema: z.object({
@@ -34,7 +35,8 @@ export const createGetBaseSchemaTool = (env: Env) =>
         .optional()
         .describe("Pagination offset from a previous response."),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AirtableClient(getAccessToken(env));
       return await client.getBaseSchema(context.baseId, context.offset);
     },

--- a/airtable/server/tools/fields.ts
+++ b/airtable/server/tools/fields.ts
@@ -1,11 +1,11 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { getAccessToken } from "../lib/env.ts";
 import { AirtableClient } from "../lib/airtable-client.ts";
 
 export const createCreateFieldTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "airtable_create_field",
     description: "Create a new field in an Airtable table.",
     inputSchema: z.object({
@@ -21,7 +21,8 @@ export const createCreateFieldTool = (env: Env) =>
         .optional()
         .describe("Field-type-specific options."),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AirtableClient(getAccessToken(env));
       return await client.createField(context.baseId, context.tableId, {
         name: context.name,
@@ -33,7 +34,7 @@ export const createCreateFieldTool = (env: Env) =>
   });
 
 export const createUpdateFieldTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "airtable_update_field",
     description:
       "Update the name or description of an existing field in an Airtable table.",
@@ -56,7 +57,8 @@ export const createUpdateFieldTool = (env: Env) =>
             "Provide at least one field to update (name or description).",
         },
       ),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AirtableClient(getAccessToken(env));
       return await client.updateField(
         context.baseId,

--- a/airtable/server/tools/records.ts
+++ b/airtable/server/tools/records.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { getAccessToken } from "../lib/env.ts";
@@ -14,7 +14,7 @@ const SortSchema = z.object({
 });
 
 export const createListRecordsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "airtable_list_records",
     description:
       "List records from an Airtable table with optional filtering, sorting, and field selection.",
@@ -50,7 +50,8 @@ export const createListRecordsTool = (env: Env) =>
         .optional()
         .describe("Pagination offset from a previous response."),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { baseId, tableIdOrName, ...options } = context;
       const client = new AirtableClient(getAccessToken(env));
       return await client.listRecords(baseId, tableIdOrName, options);
@@ -58,7 +59,7 @@ export const createListRecordsTool = (env: Env) =>
   });
 
 export const createGetRecordTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "airtable_get_record",
     description: "Retrieve a single record by its ID from an Airtable table.",
     inputSchema: z.object({
@@ -66,7 +67,8 @@ export const createGetRecordTool = (env: Env) =>
       tableIdOrName: z.string().describe("The ID or name of the table."),
       recordId: z.string().describe("The ID of the record to retrieve."),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AirtableClient(getAccessToken(env));
       return await client.getRecord(
         context.baseId,
@@ -77,7 +79,7 @@ export const createGetRecordTool = (env: Env) =>
   });
 
 export const createSearchRecordsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "airtable_search_records",
     description:
       "Search for records in an Airtable table by matching a term against specified fields.",
@@ -107,7 +109,8 @@ export const createSearchRecordsTool = (env: Env) =>
         .optional()
         .describe("Pagination offset from a previous response."),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { baseId, tableIdOrName, searchTerm, searchFields, ...options } =
         context;
 
@@ -126,7 +129,7 @@ export const createSearchRecordsTool = (env: Env) =>
   });
 
 export const createCreateRecordsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "airtable_create_records",
     description: `Create one or more records in an Airtable table. Maximum ${MAX_BATCH_RECORDS} records per request.`,
     inputSchema: z.object({
@@ -150,7 +153,8 @@ export const createCreateRecordsTool = (env: Env) =>
           "If true, Airtable will auto-convert field values to the correct type.",
         ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AirtableClient(getAccessToken(env));
       return await client.createRecords(
         context.baseId,
@@ -162,7 +166,7 @@ export const createCreateRecordsTool = (env: Env) =>
   });
 
 export const createUpdateRecordsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "airtable_update_records",
     description: `Update one or more records in an Airtable table. Maximum ${MAX_BATCH_RECORDS} records per request. Supports upsert via performUpsert.`,
     inputSchema: z.object({
@@ -198,7 +202,8 @@ export const createUpdateRecordsTool = (env: Env) =>
         .optional()
         .describe("If provided, performs an upsert instead of a plain update."),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AirtableClient(getAccessToken(env));
       return await client.updateRecords(
         context.baseId,
@@ -211,7 +216,7 @@ export const createUpdateRecordsTool = (env: Env) =>
   });
 
 export const createDeleteRecordsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "airtable_delete_records",
     description: `Delete one or more records from an Airtable table. Maximum ${MAX_BATCH_RECORDS} records per request.`,
     inputSchema: z.object({
@@ -223,7 +228,8 @@ export const createDeleteRecordsTool = (env: Env) =>
         .max(MAX_BATCH_RECORDS)
         .describe(`Array of record IDs to delete (1-${MAX_BATCH_RECORDS}).`),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AirtableClient(getAccessToken(env));
       return await client.deleteRecords(
         context.baseId,

--- a/airtable/server/tools/tables.ts
+++ b/airtable/server/tools/tables.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { getAccessToken } from "../lib/env.ts";
@@ -9,7 +9,7 @@ const FieldOptionSchema = z
   .describe("Field-type-specific options (e.g., choices for select fields).");
 
 export const createCreateTableTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "airtable_create_table",
     description:
       "Create a new table in an Airtable base with specified fields.",
@@ -37,7 +37,8 @@ export const createCreateTableTool = (env: Env) =>
           "Array of fields for the table. At least one field is required.",
         ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AirtableClient(getAccessToken(env));
       return await client.createTable(context.baseId, {
         name: context.name,
@@ -48,7 +49,7 @@ export const createCreateTableTool = (env: Env) =>
   });
 
 export const createUpdateTableTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "airtable_update_table",
     description:
       "Update the name or description of an existing Airtable table.",
@@ -70,7 +71,8 @@ export const createUpdateTableTool = (env: Env) =>
             "Provide at least one field to update (name or description).",
         },
       ),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AirtableClient(getAccessToken(env));
       return await client.updateTable(context.baseId, context.tableId, {
         name: context.name,

--- a/airtable/tsconfig.json
+++ b/airtable/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "ES2024", "DOM", "DOM.Iterable"],

--- a/blog-post-generator/package.json
+++ b/blog-post-generator/package.json
@@ -14,7 +14,7 @@
     "build": "bun run build:server"
   },
   "dependencies": {
-    "@decocms/runtime": "1.1.3",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/blog-post-generator/server/tools/generate-blog-post.ts
+++ b/blog-post-generator/server/tools/generate-blog-post.ts
@@ -5,7 +5,7 @@
  */
 
 import { z } from "zod";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import type { Env } from "../types/env.ts";
 
 /**
@@ -63,7 +63,7 @@ const BlogPostRecommendationSchema = z.object({
  * Generate blog post tool - generates blog posts from context and tone of voice
  */
 export const generateBlogPostTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "generate_blog_post",
     description:
       "Generate blog post suggestions from context and tone of voice. " +
@@ -127,7 +127,8 @@ export const generateBlogPostTool = (env: Env) =>
         .describe("Raw response from webhook for additional details"),
       error: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const {
         contextText,
         contextJson,

--- a/blog-post-generator/tsconfig.json
+++ b/blog-post-generator/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023"],

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@decocms/mcps",
       "dependencies": {
-        "@decocms/runtime": "1.3.1",
+        "@decocms/runtime": "1.4.0",
         "@types/node": "^24.10.0",
         "zod": "^3.24.3",
       },
@@ -20,7 +20,7 @@
       "name": "@decocms/airtable",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.8",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -33,7 +33,7 @@
       "name": "blog-post-generator",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.1.3",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -46,7 +46,7 @@
       "name": "content-scraper",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.6",
+        "@decocms/runtime": "1.4.0",
         "@supabase/supabase-js": "^2.49.0",
         "zod": "^4.0.0",
       },
@@ -67,7 +67,7 @@
       "name": "data-for-seo",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "^1.2.6",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -81,7 +81,7 @@
       "name": "datajud",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "0.25.1",
+        "@decocms/runtime": "1.4.0",
         "zod": "^3.24.3",
       },
       "devDependencies": {
@@ -104,7 +104,7 @@
         "@ai-sdk/provider": "^3.0.2",
         "@ai-sdk/provider-utils": "^4.0.4",
         "@decocms/bindings": "^1.1.1",
-        "@decocms/runtime": "1.1.3",
+        "@decocms/runtime": "1.4.0",
         "@openrouter/ai-sdk-provider": "^1.5.4",
         "@openrouter/sdk": "^0.3.11",
         "ai": "^6.0.3",
@@ -128,7 +128,7 @@
       "name": "deco-news-weekly-digest",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.1.3",
+        "@decocms/runtime": "1.4.0",
         "@supabase/supabase-js": "^2.49.0",
         "zod": "^4.0.0",
       },
@@ -150,7 +150,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@decocms/bindings": "^1.0.8",
-        "@decocms/runtime": "^1.3.0",
+        "@decocms/runtime": "1.4.0",
         "@discordjs/voice": "^0.19.0",
         "@supabase/supabase-js": "^2.47.10",
         "discord.js": "14.25.1",
@@ -173,7 +173,7 @@
       "name": "farmrio-reorder-collection-db",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "kysely": "^0.28.11",
         "pg": "^8.19.0",
         "zod": "^4.0.0",
@@ -190,7 +190,7 @@
       "name": "flux",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -204,7 +204,7 @@
       "name": "gemini-pro-vision",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "0.24.0",
+        "@decocms/runtime": "1.4.0",
         "zod": "^3.24.3",
       },
       "devDependencies": {
@@ -240,7 +240,7 @@
       "name": "github-repo-reports",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "@octokit/rest": "^22.0.1",
         "yaml": "^2.8.2",
         "zod": "^4.0.0",
@@ -256,7 +256,7 @@
       "name": "google-apps-script",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -271,7 +271,7 @@
       "name": "google-big-query",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -285,7 +285,7 @@
       "name": "google-calendar",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "^1.2.6",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -299,7 +299,7 @@
       "name": "google-calendar-sa",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "^1.2.6",
+        "@decocms/runtime": "1.4.0",
         "google-calendar": "workspace:*",
         "zod": "^4.0.0",
       },
@@ -314,7 +314,7 @@
       "name": "google-docs",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -329,7 +329,7 @@
       "name": "google-drive",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -344,7 +344,7 @@
       "name": "google-forms",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -362,7 +362,7 @@
         "@ai-sdk/google": "^2.0.40",
         "@ai-sdk/provider": "^3.0.2",
         "@decocms/bindings": "^1.1.1",
-        "@decocms/runtime": "1.1.3",
+        "@decocms/runtime": "1.4.0",
         "ai": "^6.0.3",
         "zod": "^4.0.0",
       },
@@ -378,7 +378,7 @@
       "name": "google-gmail",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -393,7 +393,7 @@
       "name": "google-meet",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -408,7 +408,7 @@
       "name": "google-search-console",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -423,7 +423,7 @@
       "name": "google-sheets",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -438,7 +438,7 @@
       "name": "google-slides",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -453,7 +453,7 @@
       "name": "google-tag-manager",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -468,7 +468,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@decocms/bindings": "1.0.1-alpha.23",
-        "@decocms/runtime": "1.0.0-alpha.41",
+        "@decocms/runtime": "1.4.0",
         "@supabase/supabase-js": "^2.57.4",
         "zod": "^3.24.3",
       },
@@ -485,7 +485,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@decocms/bindings": "^1.0.8",
-        "@decocms/runtime": "1.1.3",
+        "@decocms/runtime": "1.4.0",
         "@modelcontextprotocol/sdk": "^1.20.0",
         "zod": "^3.24.3",
       },
@@ -501,7 +501,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@decocms/bindings": "^1.1.3",
-        "@decocms/runtime": "1.2.8",
+        "@decocms/runtime": "1.4.0",
         "@jitl/quickjs-singlefile-cjs-release-sync": "^0.31.0",
         "@modelcontextprotocol/sdk": "^1.25.1",
         "@types/prettier": "^3.0.0",
@@ -523,7 +523,7 @@
       "name": "meta-ads",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.1.3",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -539,7 +539,7 @@
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@decocms/mcps-shared": "workspace:*",
-        "@decocms/runtime": "^1.2.10",
+        "@decocms/runtime": "1.4.0",
         "@hookform/resolvers": "^5.2.2",
         "@modelcontextprotocol/ext-apps": "^1.1.2",
         "@modelcontextprotocol/sdk": "^1.26.0",
@@ -587,7 +587,7 @@
       "name": "nanobanana",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -603,7 +603,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.716.0",
         "@aws-sdk/s3-request-presigner": "^3.716.0",
-        "@decocms/runtime": "1.1.3",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -621,7 +621,7 @@
         "@ai-sdk/provider": "^3.0.2",
         "@ai-sdk/provider-utils": "^4.0.4",
         "@decocms/bindings": "^1.3.1",
-        "@decocms/runtime": "1.2.8",
+        "@decocms/runtime": "1.4.0",
         "@openrouter/ai-sdk-provider": "^1.5.4",
         "@openrouter/sdk": "^0.3.11",
         "ai": "^6.0.3",
@@ -644,7 +644,7 @@
       "name": "perplexity",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "undici": "^7.0.0",
         "zod": "^4.0.0",
       },
@@ -659,7 +659,7 @@
       "name": "pinecone",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "0.25.1",
+        "@decocms/runtime": "1.4.0",
         "zod": "^3.24.3",
       },
       "devDependencies": {
@@ -679,7 +679,7 @@
       "name": "readonly-sql",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "0.25.1",
+        "@decocms/runtime": "1.4.0",
         "postgres": "^3.4.5",
         "zod": "^3.24.3",
       },
@@ -701,7 +701,7 @@
       "name": "reddit",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "0.25.1",
+        "@decocms/runtime": "1.4.0",
         "zod": "^3.24.3",
       },
       "devDependencies": {
@@ -722,7 +722,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@decocms/bindings": "^1.0.4",
-        "@decocms/runtime": "1.1.3",
+        "@decocms/runtime": "1.4.0",
         "@supabase/supabase-js": "^2.89.0",
         "zod": "^4.0.0",
       },
@@ -741,7 +741,7 @@
       "name": "replicate",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "0.25.1",
+        "@decocms/runtime": "1.4.0",
         "replicate": "^1.4.0",
         "zod": "^3.24.3",
       },
@@ -763,7 +763,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@decocms/bindings": "1.0.7",
-        "@decocms/runtime": "1.1.3",
+        "@decocms/runtime": "1.4.0",
         "@types/bun": "^1.2.14",
         "vite": "7.2.0",
         "zod": "^4.0.0",
@@ -774,7 +774,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@decocms/bindings": "^1.0.8",
-        "@decocms/runtime": "1.3.0",
+        "@decocms/runtime": "1.4.0",
         "@slack/web-api": "^7.8.0",
         "@supabase/supabase-js": "^2.47.10",
         "hono": "^4.7.4",
@@ -798,7 +798,7 @@
       "name": "sora",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "0.25.1",
+        "@decocms/runtime": "1.4.0",
         "zod": "^3.24.3",
       },
       "devDependencies": {
@@ -818,7 +818,7 @@
       "name": "strapi",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "^1.2.7",
+        "@decocms/runtime": "1.4.0",
         "qs": "^6.14.0",
         "zod": "^4.0.0",
       },
@@ -834,7 +834,7 @@
       "name": "mcp-template-minimal",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -848,7 +848,7 @@
       "name": "tiktok-ads",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.1.3",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -863,7 +863,7 @@
       "name": "veo",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -877,7 +877,7 @@
       "name": "virtual-try-on",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -892,7 +892,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@decocms/bindings": "^1.3.1",
-        "@decocms/runtime": "1.3.1",
+        "@decocms/runtime": "1.4.0",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -912,7 +912,7 @@
       "dependencies": {
         "@ai-sdk/openai": "^1.3.22",
         "@ai-sdk/openai-compatible": "^0.2.14",
-        "@decocms/runtime": "1.1.3",
+        "@decocms/runtime": "1.4.0",
         "@supabase/supabase-js": "^2.49.1",
         "ai": "^4.3.16",
         "zod": "^4.0.0",
@@ -933,7 +933,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@decocms/bindings": "^1.1.3",
-        "@decocms/runtime": "1.1.3",
+        "@decocms/runtime": "1.4.0",
         "@upstash/redis": "^1.36.1",
         "ai": "^6.0.50",
         "hono": "^4.11.3",
@@ -950,7 +950,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@decocms/bindings": "^1.1.3",
-        "@decocms/runtime": "1.1.3",
+        "@decocms/runtime": "1.4.0",
         "hono": "^4.11.3",
         "zod": "^4.0.0",
       },
@@ -964,7 +964,7 @@
       "name": "whisper",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "0.24.0",
+        "@decocms/runtime": "1.4.0",
         "zod": "^3.24.3",
       },
       "devDependencies": {
@@ -1192,8 +1192,6 @@
 
     "@deco-cx/warp-node": ["@deco-cx/warp-node@0.3.16", "", { "dependencies": { "undici": "^6.21.0", "ws": "^8.18.0" } }, "sha512-8cak+6YDrfJiYAkRqLCcywXrDaCkfKjbq/zU0zYUc5DSTt5bOzrA7RifqCLAfAgtEBw0mDdcr4IRPqGz65RdbA=="],
 
-    "@deco/mcp": ["@jsr/deco__mcp@0.5.5", "https://npm.jsr.io/~/11/@jsr/deco__mcp/0.5.5.tgz", { "dependencies": { "@jsr/deco__deco": "^1.112.1", "@jsr/hono__hono": "^4.5.4", "@modelcontextprotocol/sdk": "^1.11.4", "fetch-to-node": "^2.1.0", "zod": "^3.24.2" } }, "sha512-46TaWGu7lbsPleHjCVrG6afhQjv3muBTNRFBkIhLrSzlQ+9d21UeukpYs19z0AGpOlmjSSK9qIRFTf8SlH2B6Q=="],
-
     "@decocms/airtable": ["@decocms/airtable@workspace:airtable"],
 
     "@decocms/bindings": ["@decocms/bindings@1.0.7", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.1", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-NPYv4+VpI6XQbfMewy307Q1jp9QZc8a6lsC2g9Z/DCewKqFOCqAKsRrhBSGaujKEzHqxNLSqXhFx8/Vn3ODVJA=="],
@@ -1202,7 +1200,7 @@
 
     "@decocms/openrouter": ["@decocms/openrouter@workspace:openrouter"],
 
-    "@decocms/runtime": ["@decocms/runtime@1.3.1", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-7GzBsrPimBJcoCxB/3DyHqHvNYUe+kEshxKd/DD+Uvf/jbxi/i+vrvazzpcoXSuhOE/XSxNemosg9rKMHwdvVA=="],
+    "@decocms/runtime": ["@decocms/runtime@1.4.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-tWRsfJ8YxGPyVkrTWwQ9BNakThE7WCd1eWnPBAxzAeJn1ldMDzIrJMyi9bOkGqUB2mvswrDoVXNqFLPxbNEIPg=="],
 
     "@decocms/vite-plugin": ["@decocms/vite-plugin@1.0.0-alpha.1", "", { "dependencies": { "@cloudflare/vite-plugin": "^1.13.4", "vite": "7.2.0" } }, "sha512-DI9zNH49pVk8aQ+7rNYwqTZhjQ4RZDA+kA1t3ifwc4RLJsOtYv8LOXERRZnou7CcKVTdXPB06M8gbMWPpSaq8w=="],
 
@@ -1394,75 +1392,9 @@
 
     "@jsdevtools/ono": ["@jsdevtools/ono@7.1.3", "", {}, "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="],
 
-    "@jsr/core__asyncutil": ["@jsr/core__asyncutil@1.2.0", "https://npm.jsr.io/~/11/@jsr/core__asyncutil/1.2.0.tgz", {}, "sha512-ic0VDrZ6b/Qr42M4yYraNV6yjClCzAUw/ADD9PiCw0h3+Le94EHzpT2WcdKkDehIHDiwQ8cgM6thvRHEj71PEw=="],
-
-    "@jsr/deco__codemod-toolkit": ["@jsr/deco__codemod-toolkit@0.3.4", "https://npm.jsr.io/~/11/@jsr/deco__codemod-toolkit/0.3.4.tgz", { "dependencies": { "@jsr/std__flags": "^0.224.0", "@jsr/std__fmt": "^1.0.0", "@jsr/std__fs": "^1.0.1", "@jsr/std__path": "^1.0.2", "@jsr/std__semver": "^1.0.1", "diff": "5.1.0", "ts-morph": "^21.0" } }, "sha512-ykI472we3cPyP1bDJ9TCfAqFu2CYMghLNx+UVVuByEvkRikMGfffQpRl18yqQnQ0elVYJtyr7InJVzlzuw1sRA=="],
-
-    "@jsr/deco__deco": ["@jsr/deco__deco@1.137.1", "https://npm.jsr.io/~/11/@jsr/deco__deco/1.137.1.tgz", { "dependencies": { "@jsr/core__asyncutil": "^1.0.2", "@jsr/deco__codemod-toolkit": "^0.3.4", "@jsr/deco__deno-ast-wasm": "^0.5.5", "@jsr/deco__durable": "^0.5.3", "@jsr/deco__inspect-vscode": "0.2.1", "@jsr/deco__warp": "^0.3.8", "@jsr/deno__cache-dir": "0.10.1", "@jsr/hono__hono": "^4.5.4", "@jsr/std__assert": "^1.0.2", "@jsr/std__async": "^0.224.1", "@jsr/std__cli": "^1.0.3", "@jsr/std__crypto": "1.0.0-rc.1", "@jsr/std__encoding": "^1.0.0-rc.1", "@jsr/std__flags": "^0.224.0", "@jsr/std__fmt": "^0.225.3", "@jsr/std__fs": "^0.229.1", "@jsr/std__http": "^1.0.0", "@jsr/std__io": "^0.224.4", "@jsr/std__log": "^0.224.5", "@jsr/std__media-types": "^1.0.0-rc.1", "@jsr/std__path": "^0.225.2", "@jsr/std__semver": "^0.224.3", "@jsr/zaubrik__djwt": "^3.0.2", "@opentelemetry/api": "1.9.0", "@opentelemetry/api-logs": "0.52.1", "@opentelemetry/exporter-logs-otlp-http": "0.52.1", "@opentelemetry/exporter-metrics-otlp-http": "0.52.1", "@opentelemetry/exporter-trace-otlp-proto": "0.52.1", "@opentelemetry/instrumentation": "0.52.1", "@opentelemetry/instrumentation-fetch": "0.52.1", "@opentelemetry/otlp-exporter-base": "0.52.1", "@opentelemetry/resources": "1.25.1", "@opentelemetry/sdk-logs": "0.52.1", "@opentelemetry/sdk-metrics": "1.25.1", "@opentelemetry/sdk-trace-base": "1.25.1", "@opentelemetry/sdk-trace-node": "1.25.1", "@opentelemetry/semantic-conventions": "1.25.1", "@redis/client": "^1.6.0", "@types/json-schema": "7.0.11", "brotli": "1.3.3", "fast-json-patch": "^3.1.1", "lru-cache": "10.2.0", "preact": "10.23.1", "preact-render-to-string": "6.4.0", "simple-git": "^3.25.0", "terser": "5.34.0", "ua-parser-js": "2.0.0-beta.2", "unique-names-generator": "4.7.1", "utility-types": "3.10.0", "weak-lru-cache": "1.0.0" } }, "sha512-/euR/jwlSbycVpHP7W1Zp8urWmTxz2GU1/Mput+rzTYpK62Z7EBINkg4GDzOBcZk2y+KzCNweNLvawHWZ2Am+w=="],
-
-    "@jsr/deco__deno-ast-wasm": ["@jsr/deco__deno-ast-wasm@0.5.5", "https://npm.jsr.io/~/11/@jsr/deco__deno-ast-wasm/0.5.5.tgz", {}, "sha512-weeOVf6cddt6hGDUNlMYbCAxV2nCnj3fm7Pb7pdqvKus9Wqo9NmcWKyZqu5P5Q0ai9xOFURFa+GGEZP0pRfIwg=="],
-
-    "@jsr/deco__durable": ["@jsr/deco__durable@0.5.3", "https://npm.jsr.io/~/11/@jsr/deco__durable/0.5.3.tgz", {}, "sha512-dNG401EIIN4BDwzRi3MUOoyaz9C2N4K3vCsm19aN2RABdAhjWIgAMWd5R1lTIrwHktCTYIGuQvnlrw1V3p9xyQ=="],
-
-    "@jsr/deco__inspect-vscode": ["@jsr/deco__inspect-vscode@0.2.1", "https://npm.jsr.io/~/11/@jsr/deco__inspect-vscode/0.2.1.tgz", { "dependencies": { "@jsr/std__path": "^1.0.2", "fuse.js": "7.0.0" } }, "sha512-cl5GguNRHVkHAlvBHP2LKWU3kX+WtSG5vKymLDU7w72whdTi+0LyDPecshneLmYG6nvQSeYxL+OeYg4Ln1LE+A=="],
-
-    "@jsr/deco__warp": ["@jsr/deco__warp@0.3.10", "https://npm.jsr.io/~/11/@jsr/deco__warp/0.3.10.tgz", {}, "sha512-nNgKFI+Wyflsuc4cBOxMgz2vEhJifRgKUojpkK3B375Jrkc9j00omWeUoUI10YwEzZKh5ZJBlKU8sa4q4xVTEQ=="],
-
-    "@jsr/deno__cache-dir": ["@jsr/deno__cache-dir@0.10.1", "https://npm.jsr.io/~/11/@jsr/deno__cache-dir/0.10.1.tgz", { "dependencies": { "@jsr/deno__graph": "^0.73.1", "@jsr/std__fmt": "^0.223", "@jsr/std__fs": "^0.223", "@jsr/std__io": "^0.223", "@jsr/std__path": "^0.223" } }, "sha512-RBWPI0b+Mc/pYiqIdojn9O4VvGu6qecelYslNerlJSm4heQORATX+EAE/41jaMwg3s1tWLp+gNiWvQgoy/4TRQ=="],
-
-    "@jsr/deno__graph": ["@jsr/deno__graph@0.73.1", "https://npm.jsr.io/~/11/@jsr/deno__graph/0.73.1.tgz", {}, "sha512-8MrXym1aHkOttvGSKZGAjayW3hV5b2PADfE5Q7MGAMMA7lClBXC73ZiQNlbmhzyebZAb0UDd6sUXoKEJLDCYtg=="],
-
-    "@jsr/hono__hono": ["@jsr/hono__hono@4.11.9", "https://npm.jsr.io/~/11/@jsr/hono__hono/4.11.9.tgz", {}, "sha512-lWgFLeFAQxbN5CHJWQpgBeh6i/j+MCx2w8CWwM7g0NjW+C8dUorJeuLou4ARUi+AYZw/lKfOpsqdJKYDdb6ckA=="],
-
-    "@jsr/std__assert": ["@jsr/std__assert@1.0.18", "https://npm.jsr.io/~/11/@jsr/std__assert/1.0.18.tgz", { "dependencies": { "@jsr/std__internal": "^1.0.12" } }, "sha512-oxE6Go+SQJcAc8UVtocaAkKOO39QyyYrb2cwLy7PojoHOrWnCyMe5E3ItmVWjiqOjCceHofwTSmnXxcU8GTSFw=="],
-
-    "@jsr/std__async": ["@jsr/std__async@0.224.2", "https://npm.jsr.io/~/11/@jsr/std__async/0.224.2.tgz", {}, "sha512-Yjj6RXpw4xqnxR94IwYaJgP8cVGRT2nokAts07eG98PbfXXDCc8TqE3twVwOD9xYJ0u/ND09SvsGvVxe/O2cwQ=="],
-
-    "@jsr/std__bytes": ["@jsr/std__bytes@1.0.6", "https://npm.jsr.io/~/11/@jsr/std__bytes/1.0.6.tgz", {}, "sha512-St6yKggjFGhxS52IFLJWvkchRFbAKg2Xh8UxA4S1EGz7GJ2Ui+ssDDldj/w2c8vCxvl6qgR0HaYbKeFJNqujmA=="],
-
-    "@jsr/std__cli": ["@jsr/std__cli@1.0.27", "https://npm.jsr.io/~/11/@jsr/std__cli/1.0.27.tgz", { "dependencies": { "@jsr/std__fmt": "^1.0.9", "@jsr/std__internal": "^1.0.12" } }, "sha512-aaY6VYkdv0qmAIiaYNfBH9Pd3Te5bJsEUQmNg/ak43AorET5+pBcI9RgqCgBXfkb2tBnLUlTBklQvirMz/CnAQ=="],
-
-    "@jsr/std__crypto": ["@jsr/std__crypto@1.0.0-rc.1", "https://npm.jsr.io/~/11/@jsr/std__crypto/1.0.0-rc.1.tgz", {}, "sha512-HdqxgBx468H2ePsUUEYh4dyABELe1qxt4r2qK4UAR4gBrLxPRMBmAkZD0E7n/kUYA7+LTtLZ7OOhjZoQ9PPgrQ=="],
-
-    "@jsr/std__encoding": ["@jsr/std__encoding@1.0.10", "https://npm.jsr.io/~/11/@jsr/std__encoding/1.0.10.tgz", {}, "sha512-WK2njnDTyKefroRNk2Ooq7GStp6Y0ccAvr4To+Z/zecRAGe7+OSvH9DbiaHpAKwEi2KQbmpWMOYsdNt+TsdmSw=="],
-
-    "@jsr/std__flags": ["@jsr/std__flags@0.224.0", "https://npm.jsr.io/~/11/@jsr/std__flags/0.224.0.tgz", { "dependencies": { "@jsr/std__assert": "^0.224.0" } }, "sha512-Rp77j2Fru/W2WO4Ks8R4kkoRurnb0xU1m9+jkas1De2eKJM4lSxQ3/vY0lqljm/51tkjULS5VnistmzbMTE0sg=="],
-
-    "@jsr/std__fmt": ["@jsr/std__fmt@0.225.6", "https://npm.jsr.io/~/11/@jsr/std__fmt/0.225.6.tgz", {}, "sha512-5wll7CImyrJfen4fecziNSxZ5S6Fo3H1rQqKMQDewRGHAnFVqcHLe8wwCuDLK+HTbSPy6AkR3b136WpjVdOjTQ=="],
-
-    "@jsr/std__fs": ["@jsr/std__fs@0.229.3", "https://npm.jsr.io/~/11/@jsr/std__fs/0.229.3.tgz", { "dependencies": { "@jsr/std__path": "1.0.0-rc.1" } }, "sha512-hXsLcP1dumz3VbRKVhPtzs7Wigxhqp2rtBzwzrF9Cz9IMqZkp7EoKHxeqcUiduf7yYxVV/vbnfhjqbOLvlljjA=="],
-
-    "@jsr/std__html": ["@jsr/std__html@1.0.5", "https://npm.jsr.io/~/11/@jsr/std__html/1.0.5.tgz", {}, "sha512-8ypLaw6ORY7jisEvsXOS/D631/pMCX78mV7fyromfzJXxqb35OUNCBC2E4Ca0goKQJW8I2XhEgoFu0ZXaIiGvA=="],
-
-    "@jsr/std__http": ["@jsr/std__http@1.0.24", "https://npm.jsr.io/~/11/@jsr/std__http/1.0.24.tgz", { "dependencies": { "@jsr/std__cli": "^1.0.27", "@jsr/std__encoding": "^1.0.10", "@jsr/std__fmt": "^1.0.9", "@jsr/std__fs": "^1.0.22", "@jsr/std__html": "^1.0.5", "@jsr/std__media-types": "^1.1.0", "@jsr/std__net": "^1.0.6", "@jsr/std__path": "^1.1.4", "@jsr/std__streams": "^1.0.17" } }, "sha512-mfUI8vAkMVvf0wYxkZd9ZKfwFryLanHe+nbvxfFPkNO24B2IY6knkBJNN28cTZ8SITh8t8rv56Cx5uOAc0uGFg=="],
-
-    "@jsr/std__internal": ["@jsr/std__internal@1.0.12", "https://npm.jsr.io/~/11/@jsr/std__internal/1.0.12.tgz", {}, "sha512-6xReMW9p+paJgqoFRpOE2nogJFvzPfaLHLIlyADYjKMUcwDyjKZxryIbgcU+gxiTygn8yCjld1HoI0ET4/iZeA=="],
-
-    "@jsr/std__io": ["@jsr/std__io@0.224.9", "https://npm.jsr.io/~/11/@jsr/std__io/0.224.9.tgz", { "dependencies": { "@jsr/std__bytes": "^1.0.2" } }, "sha512-MwBAa4WDb2yOuzbd21cweZfIFnH5I0ICOtCTi2ckHLQ+Dx99gvavXPX+e7nqrahaDuaaBlZcA5TC6XHh99IOpw=="],
-
-    "@jsr/std__log": ["@jsr/std__log@0.224.14", "https://npm.jsr.io/~/11/@jsr/std__log/0.224.14.tgz", { "dependencies": { "@jsr/std__fmt": "^1.0.5", "@jsr/std__fs": "^1.0.11", "@jsr/std__io": "^0.225.2" } }, "sha512-EHT7E0plakyzk/gxMrwqUf3YGCCxN3Is25QrEh7toYA7qwj46R4qY7cIaDEKy8QqI5JHOFHwWXOClcPK6goIoQ=="],
-
-    "@jsr/std__media-types": ["@jsr/std__media-types@1.1.0", "https://npm.jsr.io/~/11/@jsr/std__media-types/1.1.0.tgz", {}, "sha512-dHvaxHL7ENWnltgL653uo3KnKFse3ZbopZop2gqsT7yrscx7irZEClu5Cba7gMPPRk4Lg1FbriNcaBViM2RSBw=="],
-
-    "@jsr/std__net": ["@jsr/std__net@1.0.6", "https://npm.jsr.io/~/11/@jsr/std__net/1.0.6.tgz", {}, "sha512-mh27Fw4UMCjGSIMoOhjia5cS5fNP9M9DZYhGB7EYSZNnzf/eguFiarii/W4oDwYMmnxCMouUzhc6Y7jFuwTzcg=="],
-
-    "@jsr/std__path": ["@jsr/std__path@0.225.2", "https://npm.jsr.io/~/11/@jsr/std__path/0.225.2.tgz", { "dependencies": { "@jsr/std__assert": "^0.226.0" } }, "sha512-7JIWv7OKgLAYVEL0IYbYREcsCYZ8kONle1CzgHsJEY5zqYcZdAgEKdku/vBAVgBfKVnWWOEPr9kFNXTy2IhQ8w=="],
-
-    "@jsr/std__semver": ["@jsr/std__semver@0.224.3", "https://npm.jsr.io/~/11/@jsr/std__semver/0.224.3.tgz", {}, "sha512-ABzkpv3qqScjDH141pacyv4nx8A0KKHHkkT1rMVBxYrIQiAqxfZW/hFhCNf3dUh5ouKh2Nbg5auoaoKKhUFuiw=="],
-
-    "@jsr/std__streams": ["@jsr/std__streams@1.0.17", "https://npm.jsr.io/~/11/@jsr/std__streams/1.0.17.tgz", { "dependencies": { "@jsr/std__bytes": "^1.0.6" } }, "sha512-LnPlWk20mDIV5/nqoUomAB8umOimfGEyWRApxLgekXFuqKGDsGpUAi58amieVU2XAGNclmUOtQOcQ/qOl3PNFg=="],
-
-    "@jsr/zaubrik__djwt": ["@jsr/zaubrik__djwt@3.0.2", "https://npm.jsr.io/~/11/@jsr/zaubrik__djwt/3.0.2.tgz", { "dependencies": { "@jsr/std__encoding": "0.224.0" } }, "sha512-gHd0mMXnQMKFuJhzsjynQY6JxMY2gcdQKLRfSv/6cPsbTf9QofNFAI1kDFJ1XjFLIH+F9Q+uLHfgYBI3ffzEDQ=="],
-
-    "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
-
-    "@kwsites/promise-deferred": ["@kwsites/promise-deferred@1.1.1", "", {}, "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="],
-
     "@langchain/core": ["@langchain/core@0.3.80", "", { "dependencies": { "@cfworker/json-schema": "^4.0.2", "ansi-styles": "^5.0.0", "camelcase": "6", "decamelize": "1.2.0", "js-tiktoken": "^1.0.12", "langsmith": "^0.3.67", "mustache": "^4.2.0", "p-queue": "^6.6.2", "p-retry": "4", "uuid": "^10.0.0", "zod": "^3.25.32", "zod-to-json-schema": "^3.22.3" } }, "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA=="],
 
     "@langchain/textsplitters": ["@langchain/textsplitters@0.1.0", "", { "dependencies": { "js-tiktoken": "^1.0.12" }, "peerDependencies": { "@langchain/core": ">=0.2.21 <0.4.0" } }, "sha512-djI4uw9rlkAb5iMhtLED+xJebDdAG935AdP4eRTB02R7OB/act55Bj9wsskhZsvuyQRpO4O1wQOp85s6T6GWmw=="],
-
-    "@mastra/cloudflare-d1": ["@mastra/cloudflare-d1@0.13.10", "", { "dependencies": { "cloudflare": "^4.5.0" }, "peerDependencies": { "@mastra/core": ">=0.18.1-0 <0.25.0-0" } }, "sha512-Y+cFg9tNUACm/C3O8xavMrY9ydHgXXWxXJriaBQLVWNvuHD87YfjZjdFHK9AyRlVSsq0qbvM//v3ZH/fDNXaMQ=="],
 
     "@mastra/core": ["@mastra/core@0.24.9", "", { "dependencies": { "@a2a-js/sdk": "~0.2.4", "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.33", "@ai-sdk/google-v5": "npm:@ai-sdk/google@2.0.40", "@ai-sdk/mistral-v5": "npm:@ai-sdk/mistral@2.0.23", "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.22", "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.53", "@ai-sdk/provider": "^1.1.3", "@ai-sdk/provider-utils": "^2.2.8", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.12", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.0", "@ai-sdk/ui-utils": "^1.2.11", "@ai-sdk/xai-v5": "npm:@ai-sdk/xai@2.0.26", "@isaacs/ttlcache": "^1.4.1", "@mastra/schema-compat": "0.11.9", "@openrouter/ai-sdk-provider-v5": "npm:@openrouter/ai-sdk-provider@1.2.3", "@opentelemetry/api": "^1.9.0", "@opentelemetry/auto-instrumentations-node": "^0.62.1", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0", "@opentelemetry/exporter-trace-otlp-http": "^0.203.0", "@opentelemetry/otlp-exporter-base": "^0.203.0", "@opentelemetry/otlp-transformer": "^0.203.0", "@opentelemetry/resources": "^2.0.1", "@opentelemetry/sdk-metrics": "^2.0.1", "@opentelemetry/sdk-node": "^0.203.0", "@opentelemetry/sdk-trace-base": "^2.0.1", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/semantic-conventions": "^1.36.0", "@sindresorhus/slugify": "^2.2.1", "ai": "^4.3.19", "ai-v5": "npm:ai@5.0.97", "date-fns": "^3.6.0", "dotenv": "^16.6.1", "hono": "^4.9.7", "hono-openapi": "^0.4.8", "js-tiktoken": "^1.0.20", "json-schema": "^0.4.0", "lru-cache": "^11.2.2", "p-map": "^7.0.3", "p-retry": "^7.1.0", "pino": "^9.7.0", "pino-pretty": "^13.0.0", "radash": "^12.1.1", "sift": "^17.1.3", "xstate": "^5.20.1", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-EjAPnX6pq7Y+7YN/kO92HIHqfk9Z/jtggE4Ww6wiL2Gvr01eFoNZSmsrIT4vTQAdD4oM41R2x1ndgtKFAJRH0w=="],
 
@@ -1493,12 +1425,6 @@
     "@napi-rs/canvas-linux-x64-musl": ["@napi-rs/canvas-linux-x64-musl@0.1.80", "", { "os": "linux", "cpu": "x64" }, "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg=="],
 
     "@napi-rs/canvas-win32-x64-msvc": ["@napi-rs/canvas-win32-x64-msvc@0.1.80", "", { "os": "win32", "cpu": "x64" }, "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg=="],
-
-    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
-
-    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
-
-    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
 
@@ -1585,8 +1511,6 @@
     "@opentelemetry/instrumentation-express": ["@opentelemetry/instrumentation-express@0.52.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.203.0", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-W7pizN0Wh1/cbNhhTf7C62NpyYw7VfCFTYg0DYieSTrtPBT1vmoSZei19wfKLnrMsz3sHayCg0HxCVL2c+cz5w=="],
 
     "@opentelemetry/instrumentation-fastify": ["@opentelemetry/instrumentation-fastify@0.48.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.203.0", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-3zQlE/DoVfVH6/ycuTv7vtR/xib6WOa0aLFfslYcvE62z0htRu/ot8PV/zmMZfnzpTQj8S/4ULv36R6UIbpJIg=="],
-
-    "@opentelemetry/instrumentation-fetch": ["@opentelemetry/instrumentation-fetch@0.52.1", "", { "dependencies": { "@opentelemetry/core": "1.25.1", "@opentelemetry/instrumentation": "0.52.1", "@opentelemetry/sdk-trace-web": "1.25.1", "@opentelemetry/semantic-conventions": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-EJDQXdv1ZGyBifox+8BK+hP0tg29abNPdScE+lW77bUVrThD5vn2dOo+blAS3Z8Od+eqTUTDzXVDIFjGgTK01w=="],
 
     "@opentelemetry/instrumentation-fs": ["@opentelemetry/instrumentation-fs@0.23.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.203.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Puan+QopWHA/KNYvDfOZN6M/JtF6buXEyD934vrb8WhsX1/FuM7OtoMlQyIqAadnE8FqqDL4KDPiEfCQH6pQcQ=="],
 
@@ -1679,8 +1603,6 @@
     "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.5.0", "", { "dependencies": { "@opentelemetry/core": "2.5.0", "@opentelemetry/resources": "2.5.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-VzRf8LzotASEyNDUxTdaJ9IRJ1/h692WyArDBInf5puLCjxbICD6XkHgpuudis56EndyS7LYFmtTMny6UABNdQ=="],
 
     "@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@2.5.0", "", { "dependencies": { "@opentelemetry/context-async-hooks": "2.5.0", "@opentelemetry/core": "2.5.0", "@opentelemetry/sdk-trace-base": "2.5.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-O6N/ejzburFm2C84aKNrwJVPpt6HSTSq8T0ZUMq3xT2XmqT4cwxUItcL5UWGThYuq8RTcbH8u1sfj6dmRci0Ow=="],
-
-    "@opentelemetry/sdk-trace-web": ["@opentelemetry/sdk-trace-web@1.25.1", "", { "dependencies": { "@opentelemetry/core": "1.25.1", "@opentelemetry/sdk-trace-base": "1.25.1", "@opentelemetry/semantic-conventions": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SS6JaSkHngcBCNdWGthzcvaKGRnDw2AeP57HyTEileLToJ7WLMeV+064iRlVyoT4+e77MRp2T2dDSrmaUyxoNg=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.39.0", "", {}, "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg=="],
 
@@ -1867,8 +1789,6 @@
     "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
-
-    "@redis/client": ["@redis/client@1.6.1", "", { "dependencies": { "cluster-key-slot": "1.1.2", "generic-pool": "3.9.0", "yallist": "4.0.0" } }, "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
@@ -2176,8 +2096,6 @@
 
     "@types/node": ["@types/node@24.10.12", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-68e+T28EbdmLSTkPgs3+UacC6rzmqrcWFPQs1C8mwJhI/r5Uxr0yEuQotczNRROd1gq30NGxee+fo0rSIxpyAw=="],
 
-    "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
-
     "@types/oracledb": ["@types/oracledb@6.5.2", "", { "dependencies": { "@types/node": "*" } }, "sha512-kK1eBS/Adeyis+3OlBDMeQQuasIDLUYXsi2T15ccNJ0iyUpQ4xDF7svFu3+bGVrI0CMBUclPciz+lsQR3JX3TQ=="],
 
     "@types/pdf-parse": ["@types/pdf-parse@1.1.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA=="],
@@ -2204,8 +2122,6 @@
 
     "@types/serve-static": ["@types/serve-static@1.15.10", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "<1" } }, "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw=="],
 
-    "@types/shimmer": ["@types/shimmer@1.2.0", "", {}, "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="],
-
     "@types/tedious": ["@types/tedious@4.0.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
 
     "@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
@@ -2231,8 +2147,6 @@
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
-
-    "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
     "ai": ["ai@6.0.78", "", { "dependencies": { "@ai-sdk/gateway": "3.0.39", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.14", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-eriIX/NLWfWNDeE/OJy8wmIp9fyaH7gnxTOCPT5bp0MNkvORstp1TwRUql9au8XjXzH7o2WApqbwgxJDDV0Rbw=="],
 
@@ -2274,8 +2188,6 @@
 
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
-    "bidc": ["bidc@0.0.3", "", {}, "sha512-stoXSIDBnqJhquTf0fNNoEfz2JfFCVXADoIim9c5QjWB7CoK3353ZtnJSydPNfzTLoeYuV5/0QNuSz34nSRSag=="],
-
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
@@ -2293,8 +2205,6 @@
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
-
-    "brotli": ["brotli@1.3.3", "", { "dependencies": { "base64-js": "^1.1.2" } }, "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
@@ -2339,8 +2249,6 @@
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "clone": ["clone@2.1.2", "", {}, "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="],
-
-    "cloudflare": ["cloudflare@4.5.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-fPcbPKx4zF45jBvQ0z7PCdgejVAPBBCZxwqk1k7krQNfpM07Cfj97/Q6wBzvYqlWXx/zt1S9+m8vnfCe06umbQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
@@ -2462,8 +2370,6 @@
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
-    "diff": ["diff@5.1.0", "", {}, "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw=="],
-
     "diff-match-patch": ["diff-match-patch@1.0.5", "", {}, "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="],
 
     "dingbat-to-unicode": ["dingbat-to-unicode@1.0.1", "", {}, "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w=="],
@@ -2477,8 +2383,6 @@
     "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
-
-    "drizzle-orm": ["drizzle-orm@0.44.7", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ=="],
 
     "duck": ["duck@0.1.12", "", { "dependencies": { "underscore": "^1.13.1" } }, "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg=="],
 
@@ -2554,10 +2458,6 @@
 
     "fast-equals": ["fast-equals@5.4.0", "", {}, "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw=="],
 
-    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
-
-    "fast-json-patch": ["fast-json-patch@3.1.1", "", {}, "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="],
-
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
@@ -2566,11 +2466,7 @@
 
     "fast-xml-parser": ["fast-xml-parser@5.3.4", "", { "dependencies": { "strnum": "^2.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA=="],
 
-    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
-
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
-
-    "fetch-to-node": ["fetch-to-node@2.1.0", "", {}, "sha512-Wq05j6LE1GrWpT2t1YbCkyFY6xKRJq3hx/oRJdWEJpZlik3g25MmdJS6RFm49iiMJw6zpZuBOrgihOgy2jGyAA=="],
 
     "figures": ["figures@2.0.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA=="],
 
@@ -2586,10 +2482,6 @@
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
-    "form-data-encoder": ["form-data-encoder@1.7.2", "", {}, "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="],
-
-    "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
-
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "forwarded-parse": ["forwarded-parse@2.1.2", "", {}, "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="],
@@ -2600,8 +2492,6 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
-    "fuse.js": ["fuse.js@7.0.0", "", {}, "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q=="],
-
     "fuzzy": ["fuzzy@0.1.3", "", {}, "sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w=="],
 
     "gaxios": ["gaxios@6.7.1", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "is-stream": "^2.0.0", "node-fetch": "^2.6.9", "uuid": "^9.0.1" } }, "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ=="],
@@ -2609,8 +2499,6 @@
     "gcp-metadata": ["gcp-metadata@6.1.1", "", { "dependencies": { "gaxios": "^6.1.1", "google-logging-utils": "^0.0.2", "json-bigint": "^1.0.0" } }, "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A=="],
 
     "gemini-pro-vision": ["gemini-pro-vision@workspace:gemini-pro-vision"],
-
-    "generic-pool": ["generic-pool@3.9.0", "", {}, "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
@@ -2629,8 +2517,6 @@
     "github-repo-reports": ["github-repo-reports@workspace:github-repo-reports"],
 
     "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
-
-    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "google-apps-script": ["google-apps-script@workspace:google-apps-script"],
 
@@ -2687,8 +2573,6 @@
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
-
-    "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
     "hyperdx": ["hyperdx@workspace:hyperdx"],
 
@@ -2838,8 +2722,6 @@
 
     "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="],
 
-    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
-
     "lodash.snakecase": ["lodash.snakecase@4.1.1", "", {}, "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="],
 
     "log-symbols": ["log-symbols@4.1.0", "", { "dependencies": { "chalk": "^4.1.0", "is-unicode-supported": "^0.1.0" } }, "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg=="],
@@ -2870,8 +2752,6 @@
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
-    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
-
     "meta-ads": ["meta-ads@workspace:meta-ads"],
 
     "methods": ["methods@1.1.2", "", {}, "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="],
@@ -2880,7 +2760,7 @@
 
     "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
 
-    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
@@ -2893,8 +2773,6 @@
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
-
-    "mkdirp": ["mkdirp@3.0.1", "", { "bin": { "mkdirp": "dist/cjs/src/bin.js" } }, "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="],
 
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
@@ -2915,8 +2793,6 @@
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
-
-    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
@@ -3046,13 +2922,7 @@
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
-    "preact": ["preact@10.23.1", "", {}, "sha512-O5UdRsNh4vdZaTieWe3XOgSpdMAmkIYBCT3VhQDlKrzyCm8lUYsk0fmVEvoQQifoOjFRTaHZO69ylrzTW2BH+A=="],
-
-    "preact-render-to-string": ["preact-render-to-string@6.4.0", "", { "dependencies": { "pretty-format": "^3.8.0" }, "peerDependencies": { "preact": ">=10" } }, "sha512-pzDwezZaLbK371OiJjXDsZJwVOALzFX5M1wEh2Kr0pEApq5AV6bRH/DFbA/zNA7Lck/duyREPQLLvzu2G6hEQQ=="],
-
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
-
-    "pretty-format": ["pretty-format@3.8.0", "", {}, "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="],
 
     "prism-media": ["prism-media@1.3.5", "", { "peerDependencies": { "@discordjs/opus": ">=0.8.0 <1.0.0", "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0", "node-opus": "^0.3.3", "opusscript": "^0.0.8" }, "optionalPeers": ["@discordjs/opus", "ffmpeg-static", "node-opus", "opusscript"] }, "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA=="],
 
@@ -3075,8 +2945,6 @@
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
-
-    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
@@ -3154,8 +3022,6 @@
 
     "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
-    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
-
     "rollup": ["rollup@4.57.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.1", "@rollup/rollup-android-arm64": "4.57.1", "@rollup/rollup-darwin-arm64": "4.57.1", "@rollup/rollup-darwin-x64": "4.57.1", "@rollup/rollup-freebsd-arm64": "4.57.1", "@rollup/rollup-freebsd-x64": "4.57.1", "@rollup/rollup-linux-arm-gnueabihf": "4.57.1", "@rollup/rollup-linux-arm-musleabihf": "4.57.1", "@rollup/rollup-linux-arm64-gnu": "4.57.1", "@rollup/rollup-linux-arm64-musl": "4.57.1", "@rollup/rollup-linux-loong64-gnu": "4.57.1", "@rollup/rollup-linux-loong64-musl": "4.57.1", "@rollup/rollup-linux-ppc64-gnu": "4.57.1", "@rollup/rollup-linux-ppc64-musl": "4.57.1", "@rollup/rollup-linux-riscv64-gnu": "4.57.1", "@rollup/rollup-linux-riscv64-musl": "4.57.1", "@rollup/rollup-linux-s390x-gnu": "4.57.1", "@rollup/rollup-linux-x64-gnu": "4.57.1", "@rollup/rollup-linux-x64-musl": "4.57.1", "@rollup/rollup-openbsd-x64": "4.57.1", "@rollup/rollup-openharmony-arm64": "4.57.1", "@rollup/rollup-win32-arm64-msvc": "4.57.1", "@rollup/rollup-win32-ia32-msvc": "4.57.1", "@rollup/rollup-win32-x64-gnu": "4.57.1", "@rollup/rollup-win32-x64-msvc": "4.57.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
@@ -3163,8 +3029,6 @@
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "run-async": ["run-async@3.0.0", "", {}, "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q=="],
-
-    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "rx-lite": ["rx-lite@4.0.8", "", {}, "sha512-Cun9QucwK6MIrp3mry/Y7hqD1oFqTYLQ4pGxaHTjIdaFDWRGGLikqp6u8LcWJnzpoALg9hap+JGk8sFIUuEGNA=="],
 
@@ -3204,8 +3068,6 @@
 
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
-    "shimmer": ["shimmer@1.2.1", "", {}, "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="],
-
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
     "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
@@ -3217,8 +3079,6 @@
     "sift": ["sift@17.1.3", "", {}, "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
-
-    "simple-git": ["simple-git@3.30.0", "", { "dependencies": { "@kwsites/file-exists": "^1.1.1", "@kwsites/promise-deferred": "^1.1.1", "debug": "^4.4.0" } }, "sha512-q6lxyDsCmEal/MEGhP1aVyQ3oxnagGlBDOVSIB4XUVLl1iZh0Pah6ebC9V4xBap/RfgP2WlI8EKs0WS0rMEJHg=="],
 
     "simple-wcswidth": ["simple-wcswidth@1.1.2", "", {}, "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw=="],
 
@@ -3328,8 +3188,6 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "ua-parser-js": ["ua-parser-js@2.0.0-beta.2", "", {}, "sha512-v1tudz3YJqB2lFtmhs/Wh2aPNsOatJBeCQp5s67rgx7UprG1pkOgzm8H1jXabaMZBXH9cWU3gePSgBTe3lFeRA=="],
-
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
     "underscore": ["underscore@1.13.7", "", {}, "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="],
@@ -3339,8 +3197,6 @@
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
-
-    "unique-names-generator": ["unique-names-generator@4.7.1", "", {}, "sha512-lMx9dX+KRmG8sq6gulYYpKWZc9RlGsgBR6aoO8Qsm3qvkSJ+3rAymr+TnV8EDMrIrwuFJ4kruzMWM/OpYzPoow=="],
 
     "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
@@ -3357,8 +3213,6 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
-
-    "utility-types": ["utility-types@3.10.0", "", {}, "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg=="],
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
 
@@ -3383,10 +3237,6 @@
     "vtex-docs": ["vtex-docs@workspace:vtex-docs"],
 
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
-
-    "weak-lru-cache": ["weak-lru-cache@1.0.0", "", {}, "sha512-135bPugHHIJLNx20guHgk4etZAbd7nou34NQfdKkJPgMuC3Oqn4cT6f7ORVvnud9oEyXJVJXPcTFsUvttGm5xg=="],
-
-    "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
@@ -3424,7 +3274,7 @@
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
-    "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
@@ -3518,21 +3368,13 @@
 
     "@deco-cx/warp-node/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
-    "@deco/mcp/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "@decocms/airtable/@decocms/runtime": ["@decocms/runtime@1.2.8", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.3", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-AG0nqc7ofe7oGeqQpqoqsmSo2t9bZ+xEVnhHDXKQqwmGgXHwRhfVTzROqUq0rasTGnrnTKKSRVLgsHWUgfCaxA=="],
-
     "@decocms/airtable/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@decocms/bindings/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "@decocms/mcps-shared/@decocms/runtime": ["@decocms/runtime@1.1.3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-pj6OccmpWulMjyOt9FHTNX41xHk800uzhmoYK/xq9h1f+DfDBMqyOZnt70Zmwrab7dMDO2w3VQD+NlgFKtrw1w=="],
-
     "@decocms/mcps-shared/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "@decocms/openrouter/@decocms/bindings": ["@decocms/bindings@1.3.4", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-TVNvJVsgHVv+1M28HfgfY+8/vAsxt6nD6wzGR8LsDPtWuvAbqtsAHNvQyiiaP0vEpSILlJsI2saxnrDZ9yBpBA=="],
-
-    "@decocms/openrouter/@decocms/runtime": ["@decocms/runtime@1.2.8", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.3", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-AG0nqc7ofe7oGeqQpqoqsmSo2t9bZ+xEVnhHDXKQqwmGgXHwRhfVTzROqUq0rasTGnrnTKKSRVLgsHWUgfCaxA=="],
+    "@decocms/openrouter/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
     "@decocms/openrouter/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -3561,76 +3403,6 @@
     "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
-
-    "@jsr/deco__codemod-toolkit/@jsr/std__fmt": ["@jsr/std__fmt@1.0.9", "https://npm.jsr.io/~/11/@jsr/std__fmt/1.0.9.tgz", {}, "sha512-YFJJMozmORj2K91c5J9opWeh0VUwrd+Mwb7Pr0FkVCAKVLu2UhT4LyvJqWiyUT+eF+MdfqQ9F7RtQj4bXn9Smw=="],
-
-    "@jsr/deco__codemod-toolkit/@jsr/std__fs": ["@jsr/std__fs@1.0.22", "https://npm.jsr.io/~/11/@jsr/std__fs/1.0.22.tgz", { "dependencies": { "@jsr/std__internal": "^1.0.12", "@jsr/std__path": "^1.1.4" } }, "sha512-PvDtgT25IqhFEX2LjQI0aTz/Wg61jCtJ8l19fE9MUSvSmtw57Kzr6sM7GcCsSrsZEdQ7wjLfXvvhy8irta4Zww=="],
-
-    "@jsr/deco__codemod-toolkit/@jsr/std__path": ["@jsr/std__path@1.1.4", "https://npm.jsr.io/~/11/@jsr/std__path/1.1.4.tgz", { "dependencies": { "@jsr/std__internal": "^1.0.12" } }, "sha512-SK4u9H6NVTfolhPdlvdYXfNFefy1W04AEHWJydryYbk+xqzNiVmr5o7TLJLJFqwHXuwMRhwrn+mcYeUfS0YFaA=="],
-
-    "@jsr/deco__codemod-toolkit/@jsr/std__semver": ["@jsr/std__semver@1.0.8", "https://npm.jsr.io/~/11/@jsr/std__semver/1.0.8.tgz", {}, "sha512-YhkykPU2Majz66e+rQbP0okYc7kKv+U32aguLPCXZZAL+vEVmBA+khHjPHhLBpWR073gzU3WHqGRgB7a/aXCjg=="],
-
-    "@jsr/deco__codemod-toolkit/ts-morph": ["ts-morph@21.0.1", "", { "dependencies": { "@ts-morph/common": "~0.22.0", "code-block-writer": "^12.0.0" } }, "sha512-dbDtVdEAncKctzrVZ+Nr7kHpHkv+0JDJb2MjjpBaj8bFeCkePU9rHfMklmhuLFnpeq/EJZk2IhStY6NzqgjOkg=="],
-
-    "@jsr/deco__deco/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.52.1", "", { "dependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A=="],
-
-    "@jsr/deco__deco/@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.52.1", "", { "dependencies": { "@opentelemetry/api-logs": "0.52.1", "@opentelemetry/core": "1.25.1", "@opentelemetry/otlp-exporter-base": "0.52.1", "@opentelemetry/otlp-transformer": "0.52.1", "@opentelemetry/sdk-logs": "0.52.1" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-qKgywId2DbdowPZpOBXQKp0B8DfhfIArmSic15z13Nk/JAOccBUQdPwDjDnjsM5f0ckZFMVR2t/tijTUAqDZoA=="],
-
-    "@jsr/deco__deco/@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.52.1", "", { "dependencies": { "@opentelemetry/core": "1.25.1", "@opentelemetry/otlp-exporter-base": "0.52.1", "@opentelemetry/otlp-transformer": "0.52.1", "@opentelemetry/resources": "1.25.1", "@opentelemetry/sdk-metrics": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-oAHPOy1sZi58bwqXaucd19F/v7+qE2EuVslQOEeLQT94CDuZJJ4tbWzx8DpYBTrOSzKqqrMtx9+PMxkrcbxOyQ=="],
-
-    "@jsr/deco__deco/@opentelemetry/exporter-trace-otlp-proto": ["@opentelemetry/exporter-trace-otlp-proto@0.52.1", "", { "dependencies": { "@opentelemetry/core": "1.25.1", "@opentelemetry/otlp-exporter-base": "0.52.1", "@opentelemetry/otlp-transformer": "0.52.1", "@opentelemetry/resources": "1.25.1", "@opentelemetry/sdk-trace-base": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-pt6uX0noTQReHXNeEslQv7x311/F1gJzMnp1HD2qgypLRPbXDeMzzeTngRTUaUbP6hqWNtPxuLr4DEoZG+TcEQ=="],
-
-    "@jsr/deco__deco/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.52.1", "", { "dependencies": { "@opentelemetry/api-logs": "0.52.1", "@types/shimmer": "^1.0.2", "import-in-the-middle": "^1.8.1", "require-in-the-middle": "^7.1.1", "semver": "^7.5.2", "shimmer": "^1.2.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-uXJbYU/5/MBHjMp1FqrILLRuiJCs3Ofk0MeRDk8g1S1gD47U8X3JnSwcMO1rtRo1x1a7zKaQHaoYu49p/4eSKw=="],
-
-    "@jsr/deco__deco/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.52.1", "", { "dependencies": { "@opentelemetry/core": "1.25.1", "@opentelemetry/otlp-transformer": "0.52.1" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-z175NXOtX5ihdlshtYBe5RpGeBoTXVCKPPLiQlD6FHvpM4Ch+p2B0yWKYSrBfLH24H9zjJiBdTrtD+hLlfnXEQ=="],
-
-    "@jsr/deco__deco/@opentelemetry/resources": ["@opentelemetry/resources@1.25.1", "", { "dependencies": { "@opentelemetry/core": "1.25.1", "@opentelemetry/semantic-conventions": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ=="],
-
-    "@jsr/deco__deco/@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.52.1", "", { "dependencies": { "@opentelemetry/api-logs": "0.52.1", "@opentelemetry/core": "1.25.1", "@opentelemetry/resources": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-MBYh+WcPPsN8YpRHRmK1Hsca9pVlyyKd4BxOC4SsgHACnl/bPp4Cri9hWhVm5+2tiQ9Zf4qSc1Jshw9tOLGWQA=="],
-
-    "@jsr/deco__deco/@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@1.25.1", "", { "dependencies": { "@opentelemetry/core": "1.25.1", "@opentelemetry/resources": "1.25.1", "lodash.merge": "^4.6.2" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q=="],
-
-    "@jsr/deco__deco/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@1.25.1", "", { "dependencies": { "@opentelemetry/core": "1.25.1", "@opentelemetry/resources": "1.25.1", "@opentelemetry/semantic-conventions": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw=="],
-
-    "@jsr/deco__deco/@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@1.25.1", "", { "dependencies": { "@opentelemetry/context-async-hooks": "1.25.1", "@opentelemetry/core": "1.25.1", "@opentelemetry/propagator-b3": "1.25.1", "@opentelemetry/propagator-jaeger": "1.25.1", "@opentelemetry/sdk-trace-base": "1.25.1", "semver": "^7.5.2" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-nMcjFIKxnFqoez4gUmihdBrbpsEnAX/Xj16sGvZm+guceYE0NE00vLhpDVK6f3q8Q4VFI5xG8JjlXKMB/SkTTQ=="],
-
-    "@jsr/deco__deco/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.25.1", "", {}, "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="],
-
-    "@jsr/deco__deco/@types/json-schema": ["@types/json-schema@7.0.11", "", {}, "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="],
-
-    "@jsr/deco__deco/lru-cache": ["lru-cache@10.2.0", "", {}, "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q=="],
-
-    "@jsr/deco__inspect-vscode/@jsr/std__path": ["@jsr/std__path@1.1.4", "https://npm.jsr.io/~/11/@jsr/std__path/1.1.4.tgz", { "dependencies": { "@jsr/std__internal": "^1.0.12" } }, "sha512-SK4u9H6NVTfolhPdlvdYXfNFefy1W04AEHWJydryYbk+xqzNiVmr5o7TLJLJFqwHXuwMRhwrn+mcYeUfS0YFaA=="],
-
-    "@jsr/deno__cache-dir/@jsr/std__fmt": ["@jsr/std__fmt@0.223.0", "https://npm.jsr.io/~/11/@jsr/std__fmt/0.223.0.tgz", {}, "sha512-iuviJIMnAxlrQaDhe6vuYVyENvN8I1YUfjv8if7SeCc1sE+K820Jaqe6J2K+UivIkXnh0Qh3Wh/PBIvdK9sI5g=="],
-
-    "@jsr/deno__cache-dir/@jsr/std__fs": ["@jsr/std__fs@0.223.0", "https://npm.jsr.io/~/11/@jsr/std__fs/0.223.0.tgz", { "dependencies": { "@jsr/std__assert": "^0.223.0", "@jsr/std__path": "^0.223.0" } }, "sha512-YBguetZEKTJZidCmxqwE6R/24XvGBg0Yj3hXelgd4AomSVxW4x8WKA3G4sBLfjd2I+N2QzitssGfbIOnw713MA=="],
-
-    "@jsr/deno__cache-dir/@jsr/std__io": ["@jsr/std__io@0.223.0", "https://npm.jsr.io/~/11/@jsr/std__io/0.223.0.tgz", { "dependencies": { "@jsr/std__assert": "^0.223.0", "@jsr/std__bytes": "^0.223.0" } }, "sha512-VUPpfHeLvhooQFyujLSj6/KDCqgF+joBpb6eO9dg+JJWvy5wHj1Nl2EMRQe6Pl8nNVUwjt+ZraydkGTdlDS1jw=="],
-
-    "@jsr/deno__cache-dir/@jsr/std__path": ["@jsr/std__path@0.223.0", "https://npm.jsr.io/~/11/@jsr/std__path/0.223.0.tgz", { "dependencies": { "@jsr/std__assert": "^0.223.0" } }, "sha512-zeAxeBWFMmvlJdvBOzgIGmuqV6vLsZHt+2SWkIF00mMr2k96emGaq0Nw4KRnqkB4syawgc3OAo4EAbWJBu7Yvw=="],
-
-    "@jsr/std__cli/@jsr/std__fmt": ["@jsr/std__fmt@1.0.9", "https://npm.jsr.io/~/11/@jsr/std__fmt/1.0.9.tgz", {}, "sha512-YFJJMozmORj2K91c5J9opWeh0VUwrd+Mwb7Pr0FkVCAKVLu2UhT4LyvJqWiyUT+eF+MdfqQ9F7RtQj4bXn9Smw=="],
-
-    "@jsr/std__flags/@jsr/std__assert": ["@jsr/std__assert@0.224.0", "https://npm.jsr.io/~/11/@jsr/std__assert/0.224.0.tgz", { "dependencies": { "@jsr/std__fmt": "^0.224.0", "@jsr/std__internal": "^0.224.0" } }, "sha512-RB0p0ydybgKSfTba6kHWytfpEJ0CBPi+byxZikLYa51L9uLINW52/j6n4KuiLFoh2cdFfpNZSNMY/dzQPW90DQ=="],
-
-    "@jsr/std__fs/@jsr/std__path": ["@jsr/std__path@1.0.0-rc.1", "https://npm.jsr.io/~/11/@jsr/std__path/1.0.0-rc.1.tgz", {}, "sha512-bGolWCcaF8HGT0QVZr/heEaHm6MEgpOI7LyrV4JLuBYrLb81FAX7m3Li77JnF06RNhJViY8K7zvPpuVIiakyvA=="],
-
-    "@jsr/std__http/@jsr/std__fmt": ["@jsr/std__fmt@1.0.9", "https://npm.jsr.io/~/11/@jsr/std__fmt/1.0.9.tgz", {}, "sha512-YFJJMozmORj2K91c5J9opWeh0VUwrd+Mwb7Pr0FkVCAKVLu2UhT4LyvJqWiyUT+eF+MdfqQ9F7RtQj4bXn9Smw=="],
-
-    "@jsr/std__http/@jsr/std__fs": ["@jsr/std__fs@1.0.22", "https://npm.jsr.io/~/11/@jsr/std__fs/1.0.22.tgz", { "dependencies": { "@jsr/std__internal": "^1.0.12", "@jsr/std__path": "^1.1.4" } }, "sha512-PvDtgT25IqhFEX2LjQI0aTz/Wg61jCtJ8l19fE9MUSvSmtw57Kzr6sM7GcCsSrsZEdQ7wjLfXvvhy8irta4Zww=="],
-
-    "@jsr/std__http/@jsr/std__path": ["@jsr/std__path@1.1.4", "https://npm.jsr.io/~/11/@jsr/std__path/1.1.4.tgz", { "dependencies": { "@jsr/std__internal": "^1.0.12" } }, "sha512-SK4u9H6NVTfolhPdlvdYXfNFefy1W04AEHWJydryYbk+xqzNiVmr5o7TLJLJFqwHXuwMRhwrn+mcYeUfS0YFaA=="],
-
-    "@jsr/std__log/@jsr/std__fmt": ["@jsr/std__fmt@1.0.9", "https://npm.jsr.io/~/11/@jsr/std__fmt/1.0.9.tgz", {}, "sha512-YFJJMozmORj2K91c5J9opWeh0VUwrd+Mwb7Pr0FkVCAKVLu2UhT4LyvJqWiyUT+eF+MdfqQ9F7RtQj4bXn9Smw=="],
-
-    "@jsr/std__log/@jsr/std__fs": ["@jsr/std__fs@1.0.22", "https://npm.jsr.io/~/11/@jsr/std__fs/1.0.22.tgz", { "dependencies": { "@jsr/std__internal": "^1.0.12", "@jsr/std__path": "^1.1.4" } }, "sha512-PvDtgT25IqhFEX2LjQI0aTz/Wg61jCtJ8l19fE9MUSvSmtw57Kzr6sM7GcCsSrsZEdQ7wjLfXvvhy8irta4Zww=="],
-
-    "@jsr/std__log/@jsr/std__io": ["@jsr/std__io@0.225.3", "https://npm.jsr.io/~/11/@jsr/std__io/0.225.3.tgz", { "dependencies": { "@jsr/std__bytes": "^1.0.6" } }, "sha512-IDXY253ipW6FV34CJVxO+3ubfvSEEzw9N2W303KnLe9K/Y9+v/ID1dQYf9VsCCOFMpFtCmOLqzIZsRqv6yQnWw=="],
-
-    "@jsr/std__path/@jsr/std__assert": ["@jsr/std__assert@0.226.0", "https://npm.jsr.io/~/11/@jsr/std__assert/0.226.0.tgz", { "dependencies": { "@jsr/std__internal": "^1.0.0" } }, "sha512-xCuUFDfHkIZd96glKgjZbnYFqu6blu8Y53SyvDMlFDJm1Y/j+/FcW6xq7TzGFIaF5B9QecIlDfamfhzA8ZdVbg=="],
-
-    "@jsr/zaubrik__djwt/@jsr/std__encoding": ["@jsr/std__encoding@0.224.0", "https://npm.jsr.io/~/11/@jsr/std__encoding/0.224.0.tgz", {}, "sha512-V13A1JV6kvtlCyxeznQM8qYSPep5fiMfe59dnYD9gx//3TCHnGoqP2588qPDBGeD8IDrSUId3Czg/nGbcPt9Dw=="],
 
     "@langchain/core/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
@@ -3718,12 +3490,6 @@
 
     "@opentelemetry/exporter-zipkin/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.0.1", "", { "dependencies": { "@opentelemetry/core": "2.0.1", "@opentelemetry/resources": "2.0.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ=="],
 
-    "@opentelemetry/instrumentation-fetch/@opentelemetry/core": ["@opentelemetry/core@1.25.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ=="],
-
-    "@opentelemetry/instrumentation-fetch/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.52.1", "", { "dependencies": { "@opentelemetry/api-logs": "0.52.1", "@types/shimmer": "^1.0.2", "import-in-the-middle": "^1.8.1", "require-in-the-middle": "^7.1.1", "semver": "^7.5.2", "shimmer": "^1.2.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-uXJbYU/5/MBHjMp1FqrILLRuiJCs3Ofk0MeRDk8g1S1gD47U8X3JnSwcMO1rtRo1x1a7zKaQHaoYu49p/4eSKw=="],
-
-    "@opentelemetry/instrumentation-fetch/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.25.1", "", {}, "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="],
-
     "@opentelemetry/instrumentation-http/@opentelemetry/core": ["@opentelemetry/core@2.0.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw=="],
 
     "@opentelemetry/instrumentation-pg/@types/pg": ["@types/pg@8.15.5", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ=="],
@@ -3757,12 +3523,6 @@
     "@opentelemetry/sdk-node/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.0.1", "", { "dependencies": { "@opentelemetry/core": "2.0.1", "@opentelemetry/resources": "2.0.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ=="],
 
     "@opentelemetry/sdk-node/@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@2.0.1", "", { "dependencies": { "@opentelemetry/context-async-hooks": "2.0.1", "@opentelemetry/core": "2.0.1", "@opentelemetry/sdk-trace-base": "2.0.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-UhdbPF19pMpBtCWYP5lHbTogLWx9N0EBxtdagvkn5YtsAnCBZzL7SjktG+ZmupRgifsHMjwUaCCaVmqGfSADmA=="],
-
-    "@opentelemetry/sdk-trace-web/@opentelemetry/core": ["@opentelemetry/core@1.25.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ=="],
-
-    "@opentelemetry/sdk-trace-web/@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@1.25.1", "", { "dependencies": { "@opentelemetry/core": "1.25.1", "@opentelemetry/resources": "1.25.1", "@opentelemetry/semantic-conventions": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw=="],
-
-    "@opentelemetry/sdk-trace-web/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.25.1", "", {}, "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="],
 
     "@poppinss/dumper/supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
@@ -3884,19 +3644,13 @@
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
-    "blog-post-generator/@decocms/runtime": ["@decocms/runtime@1.1.3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-pj6OccmpWulMjyOt9FHTNX41xHk800uzhmoYK/xq9h1f+DfDBMqyOZnt70Zmwrab7dMDO2w3VQD+NlgFKtrw1w=="],
-
     "blog-post-generator/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "c12/dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "cloudflare/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
-
     "concurrently/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "content-scraper/@decocms/runtime": ["@decocms/runtime@1.2.6", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.3", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-Eyp9pWkhlFLU3iQl/dQEULcUnirwcggKo3TEH0l5fLpkYoIDY48lW360T9iNm2Cd2ic1jRO13+rpo5eUTYU39w=="],
 
     "content-scraper/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
@@ -3904,25 +3658,17 @@
 
     "content-scraper/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "data-for-seo/@decocms/runtime": ["@decocms/runtime@1.2.13", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-3l7i+j8e6NAy8ue8hSY/9YKEUNcRZxV6tPIGoI0RqScDhFTpARlv1KkURulGyboehhkg9AEpCoXcACwZbKU9Kw=="],
-
     "data-for-seo/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
     "data-for-seo/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "datajud/@decocms/runtime": ["@decocms/runtime@0.25.1", "", { "dependencies": { "@cloudflare/workers-types": "^4.20250617.0", "@deco/mcp": "npm:@jsr/deco__mcp@0.5.5", "@mastra/cloudflare-d1": "^0.13.4", "@mastra/core": "^0.20.2", "@modelcontextprotocol/sdk": "^1.19.1", "bidc": "0.0.3", "drizzle-orm": "^0.44.5", "jose": "^6.0.11", "mime-db": "1.52.0", "zod": "^3.25.76", "zod-from-json-schema": "^0.0.5", "zod-to-json-schema": "^3.24.4" } }, "sha512-G1J09NpHkuOcBQMPDi7zJDwtNweH33/39sOsR/mpA+sRWn2W3CX51FXeB5dp06oAmCe9BoBpYnyvb896hSQ+Jg=="],
 
     "datajud/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.20.2", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-6rqTdFt67AAAzln3NOKsXRmv5ZzPkgbfaebKBqUbts7vK1GZudqnrun5a8d3M/h955cam9RHZ6Jb4Y1XhnmFPg=="],
 
     "deco-cli/@supabase/supabase-js": ["@supabase/supabase-js@2.50.0", "", { "dependencies": { "@supabase/auth-js": "2.70.0", "@supabase/functions-js": "2.4.4", "@supabase/node-fetch": "2.6.15", "@supabase/postgrest-js": "1.19.4", "@supabase/realtime-js": "2.11.10", "@supabase/storage-js": "2.7.1" } }, "sha512-M1Gd5tPaaghYZ9OjeO1iORRqbTWFEz/cF3pPubRnMPzA+A8SiUsXXWDP+DWsASZcjEcVEcVQIAF38i5wrijYOg=="],
 
-    "deco-llm/@decocms/bindings": ["@decocms/bindings@1.3.4", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-TVNvJVsgHVv+1M28HfgfY+8/vAsxt6nD6wzGR8LsDPtWuvAbqtsAHNvQyiiaP0vEpSILlJsI2saxnrDZ9yBpBA=="],
-
-    "deco-llm/@decocms/runtime": ["@decocms/runtime@1.1.3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-pj6OccmpWulMjyOt9FHTNX41xHk800uzhmoYK/xq9h1f+DfDBMqyOZnt70Zmwrab7dMDO2w3VQD+NlgFKtrw1w=="],
+    "deco-llm/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
     "deco-llm/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "deco-news-weekly-digest/@decocms/runtime": ["@decocms/runtime@1.1.3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-pj6OccmpWulMjyOt9FHTNX41xHk800uzhmoYK/xq9h1f+DfDBMqyOZnt70Zmwrab7dMDO2w3VQD+NlgFKtrw1w=="],
 
     "deco-news-weekly-digest/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
@@ -3932,9 +3678,7 @@
 
     "defaults/clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
 
-    "discord-read/@decocms/bindings": ["@decocms/bindings@1.3.4", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-TVNvJVsgHVv+1M28HfgfY+8/vAsxt6nD6wzGR8LsDPtWuvAbqtsAHNvQyiiaP0vEpSILlJsI2saxnrDZ9yBpBA=="],
-
-    "discord-read/@decocms/runtime": ["@decocms/runtime@1.3.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-xRFTV9gqrdsUCAkJ3xoBOeDGXps6moZeZB/NNL+XZ7LNa4qzfmL3BGWG42n8xbFyEpprfEfOtOD+tVgWhkPDxQ=="],
+    "discord-read/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
     "discord-read/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -3946,15 +3690,11 @@
 
     "external-editor/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
-    "farmrio-reorder-collection-db/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
-
     "farmrio-reorder-collection-db/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
     "farmrio-reorder-collection-db/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
-
-    "flux/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
 
     "flux/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -3962,13 +3702,9 @@
 
     "gaxios/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
-    "gemini-pro-vision/@decocms/runtime": ["@decocms/runtime@0.24.0", "", { "dependencies": { "@cloudflare/workers-types": "^4.20250617.0", "@deco/mcp": "npm:@jsr/deco__mcp@0.5.5", "@mastra/cloudflare-d1": "^0.13.4", "@mastra/core": "^0.20.2", "@modelcontextprotocol/sdk": "^1.19.1", "bidc": "0.0.3", "drizzle-orm": "^0.44.5", "jose": "^6.0.11", "mime-db": "1.52.0", "zod": "^3.25.76", "zod-from-json-schema": "^0.0.5", "zod-to-json-schema": "^3.24.4" } }, "sha512-ZWa9z6I0dl4LtVnv3NUDvxuVYU0Aka1gpUEkpJP0tW2ETCGQkmDx50MdFqEksXiL1RHoNZuv45Fz8u9FkdTKJg=="],
-
     "gemini-pro-vision/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.20.2", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-6rqTdFt67AAAzln3NOKsXRmv5ZzPkgbfaebKBqUbts7vK1GZudqnrun5a8d3M/h955cam9RHZ6Jb4Y1XhnmFPg=="],
 
     "github/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
-
-    "github/@decocms/runtime": ["@decocms/runtime@1.4.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-tWRsfJ8YxGPyVkrTWwQ9BNakThE7WCd1eWnPBAxzAeJn1ldMDzIrJMyi9bOkGqUB2mvswrDoVXNqFLPxbNEIPg=="],
 
     "github/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
@@ -3978,81 +3714,47 @@
 
     "github/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "github-repo-reports/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
-
     "github-repo-reports/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
     "github-repo-reports/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "google-apps-script/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
-
     "google-apps-script/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "google-big-query/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
 
     "google-big-query/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "google-calendar/@decocms/runtime": ["@decocms/runtime@1.3.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-xRFTV9gqrdsUCAkJ3xoBOeDGXps6moZeZB/NNL+XZ7LNa4qzfmL3BGWG42n8xbFyEpprfEfOtOD+tVgWhkPDxQ=="],
-
     "google-calendar/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "google-calendar-sa/@decocms/runtime": ["@decocms/runtime@1.3.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-xRFTV9gqrdsUCAkJ3xoBOeDGXps6moZeZB/NNL+XZ7LNa4qzfmL3BGWG42n8xbFyEpprfEfOtOD+tVgWhkPDxQ=="],
 
     "google-calendar-sa/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "google-docs/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
-
     "google-docs/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "google-drive/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
-
     "google-drive/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "google-forms/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
 
     "google-forms/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "google-gemini/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
-    "google-gemini/@decocms/runtime": ["@decocms/runtime@1.1.3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-pj6OccmpWulMjyOt9FHTNX41xHk800uzhmoYK/xq9h1f+DfDBMqyOZnt70Zmwrab7dMDO2w3VQD+NlgFKtrw1w=="],
-
     "google-gemini/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
     "google-gemini/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "google-gmail/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
-
     "google-gmail/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "google-meet/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
 
     "google-meet/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "google-search-console/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
-
     "google-search-console/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "google-sheets/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
 
     "google-sheets/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "google-slides/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
-
     "google-slides/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "google-tag-manager/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
 
     "google-tag-manager/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "grain/@decocms/bindings": ["@decocms/bindings@1.0.1-alpha.23", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.20.2", "zod": "^3.25.76", "zod-from-json-schema": "^0.0.5" } }, "sha512-CVvfLeQPzD0RwkIznl4CPg8yLcdz5O2bgMmaL+lyHe+azO2qkGpQkTp1pX5fDhdr7jvWtjTcThUNoiCno58cSw=="],
 
-    "grain/@decocms/runtime": ["@decocms/runtime@1.0.0-alpha.41", "", { "dependencies": { "@ai-sdk/provider": "^2.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@deco/mcp": "npm:@jsr/deco__mcp@0.7.8", "@decocms/bindings": "1.0.1-alpha.23", "@modelcontextprotocol/sdk": "1.20.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^3.25.76", "zod-to-json-schema": "3.25.0" } }, "sha512-zpGy4bMoly/uQV8jNOeaAsIbXs5rS+ksXGqvIU9EqS3cH/aP2Dab158sy12OH+ixvlAZab5bd7yBij0viy+T6g=="],
-
     "grain/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.20.2", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-6rqTdFt67AAAzln3NOKsXRmv5ZzPkgbfaebKBqUbts7vK1GZudqnrun5a8d3M/h955cam9RHZ6Jb4Y1XhnmFPg=="],
 
     "hyperdx/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
-
-    "hyperdx/@decocms/runtime": ["@decocms/runtime@1.1.3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-pj6OccmpWulMjyOt9FHTNX41xHk800uzhmoYK/xq9h1f+DfDBMqyOZnt70Zmwrab7dMDO2w3VQD+NlgFKtrw1w=="],
 
     "hyperdx/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
@@ -4076,27 +3778,17 @@
 
     "mcp-studio/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
-    "mcp-studio/@decocms/runtime": ["@decocms/runtime@1.2.8", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.3", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-AG0nqc7ofe7oGeqQpqoqsmSo2t9bZ+xEVnhHDXKQqwmGgXHwRhfVTzROqUq0rasTGnrnTKKSRVLgsHWUgfCaxA=="],
-
     "mcp-studio/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
     "mcp-studio/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "mcp-template-minimal/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
 
     "mcp-template-minimal/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
     "mcp-template-minimal/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "meta-ads/@decocms/runtime": ["@decocms/runtime@1.1.3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-pj6OccmpWulMjyOt9FHTNX41xHk800uzhmoYK/xq9h1f+DfDBMqyOZnt70Zmwrab7dMDO2w3VQD+NlgFKtrw1w=="],
-
     "meta-ads/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
-    "mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "multi-channel-inbox/@decocms/runtime": ["@decocms/runtime@1.3.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-xRFTV9gqrdsUCAkJ3xoBOeDGXps6moZeZB/NNL+XZ7LNa4qzfmL3BGWG42n8xbFyEpprfEfOtOD+tVgWhkPDxQ=="],
 
     "multi-channel-inbox/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
@@ -4104,15 +3796,11 @@
 
     "multi-channel-inbox/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "nanobanana/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
-
     "nanobanana/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
     "nanobanana/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "nypm/citty": ["citty@0.2.1", "", {}, "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg=="],
-
-    "object-storage/@decocms/runtime": ["@decocms/runtime@1.1.3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-pj6OccmpWulMjyOt9FHTNX41xHk800uzhmoYK/xq9h1f+DfDBMqyOZnt70Zmwrab7dMDO2w3VQD+NlgFKtrw1w=="],
 
     "object-storage/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
@@ -4122,11 +3810,7 @@
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
-    "perplexity/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
-
     "perplexity/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "pinecone/@decocms/runtime": ["@decocms/runtime@0.25.1", "", { "dependencies": { "@cloudflare/workers-types": "^4.20250617.0", "@deco/mcp": "npm:@jsr/deco__mcp@0.5.5", "@mastra/cloudflare-d1": "^0.13.4", "@mastra/core": "^0.20.2", "@modelcontextprotocol/sdk": "^1.19.1", "bidc": "0.0.3", "drizzle-orm": "^0.44.5", "jose": "^6.0.11", "mime-db": "1.52.0", "zod": "^3.25.76", "zod-from-json-schema": "^0.0.5", "zod-to-json-schema": "^3.24.4" } }, "sha512-G1J09NpHkuOcBQMPDi7zJDwtNweH33/39sOsR/mpA+sRWn2W3CX51FXeB5dp06oAmCe9BoBpYnyvb896hSQ+Jg=="],
 
     "pinecone/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.20.2", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-6rqTdFt67AAAzln3NOKsXRmv5ZzPkgbfaebKBqUbts7vK1GZudqnrun5a8d3M/h955cam9RHZ6Jb4Y1XhnmFPg=="],
 
@@ -4138,11 +3822,7 @@
 
     "radix-ui/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
-    "readonly-sql/@decocms/runtime": ["@decocms/runtime@0.25.1", "", { "dependencies": { "@cloudflare/workers-types": "^4.20250617.0", "@deco/mcp": "npm:@jsr/deco__mcp@0.5.5", "@mastra/cloudflare-d1": "^0.13.4", "@mastra/core": "^0.20.2", "@modelcontextprotocol/sdk": "^1.19.1", "bidc": "0.0.3", "drizzle-orm": "^0.44.5", "jose": "^6.0.11", "mime-db": "1.52.0", "zod": "^3.25.76", "zod-from-json-schema": "^0.0.5", "zod-to-json-schema": "^3.24.4" } }, "sha512-G1J09NpHkuOcBQMPDi7zJDwtNweH33/39sOsR/mpA+sRWn2W3CX51FXeB5dp06oAmCe9BoBpYnyvb896hSQ+Jg=="],
-
     "readonly-sql/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.20.2", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-6rqTdFt67AAAzln3NOKsXRmv5ZzPkgbfaebKBqUbts7vK1GZudqnrun5a8d3M/h955cam9RHZ6Jb4Y1XhnmFPg=="],
-
-    "reddit/@decocms/runtime": ["@decocms/runtime@0.25.1", "", { "dependencies": { "@cloudflare/workers-types": "^4.20250617.0", "@deco/mcp": "npm:@jsr/deco__mcp@0.5.5", "@mastra/cloudflare-d1": "^0.13.4", "@mastra/core": "^0.20.2", "@modelcontextprotocol/sdk": "^1.19.1", "bidc": "0.0.3", "drizzle-orm": "^0.44.5", "jose": "^6.0.11", "mime-db": "1.52.0", "zod": "^3.25.76", "zod-from-json-schema": "^0.0.5", "zod-to-json-schema": "^3.24.4" } }, "sha512-G1J09NpHkuOcBQMPDi7zJDwtNweH33/39sOsR/mpA+sRWn2W3CX51FXeB5dp06oAmCe9BoBpYnyvb896hSQ+Jg=="],
 
     "reddit/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
@@ -4150,13 +3830,9 @@
 
     "registry/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
-    "registry/@decocms/runtime": ["@decocms/runtime@1.1.3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-pj6OccmpWulMjyOt9FHTNX41xHk800uzhmoYK/xq9h1f+DfDBMqyOZnt70Zmwrab7dMDO2w3VQD+NlgFKtrw1w=="],
-
     "registry/@types/node": ["@types/node@22.19.10", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-tF5VOugLS/EuDlTBijk0MqABfP8UxgYazTLo3uIn3b4yJgg26QRbVYJYsDtHrjdDUIRfP70+VfhTTc+CE1yskw=="],
 
     "registry/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "replicate/@decocms/runtime": ["@decocms/runtime@0.25.1", "", { "dependencies": { "@cloudflare/workers-types": "^4.20250617.0", "@deco/mcp": "npm:@jsr/deco__mcp@0.5.5", "@mastra/cloudflare-d1": "^0.13.4", "@mastra/core": "^0.20.2", "@modelcontextprotocol/sdk": "^1.19.1", "bidc": "0.0.3", "drizzle-orm": "^0.44.5", "jose": "^6.0.11", "mime-db": "1.52.0", "zod": "^3.25.76", "zod-from-json-schema": "^0.0.5", "zod-to-json-schema": "^3.24.4" } }, "sha512-G1J09NpHkuOcBQMPDi7zJDwtNweH33/39sOsR/mpA+sRWn2W3CX51FXeB5dp06oAmCe9BoBpYnyvb896hSQ+Jg=="],
 
     "replicate/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.20.2", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-6rqTdFt67AAAzln3NOKsXRmv5ZzPkgbfaebKBqUbts7vK1GZudqnrun5a8d3M/h955cam9RHZ6Jb4Y1XhnmFPg=="],
 
@@ -4168,17 +3844,11 @@
 
     "slack-mcp/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
-    "slack-mcp/@decocms/runtime": ["@decocms/runtime@1.3.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-xRFTV9gqrdsUCAkJ3xoBOeDGXps6moZeZB/NNL+XZ7LNa4qzfmL3BGWG42n8xbFyEpprfEfOtOD+tVgWhkPDxQ=="],
-
     "slack-mcp/kysely": ["kysely@0.27.6", "", {}, "sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ=="],
 
     "slack-mcp/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "sora/@decocms/runtime": ["@decocms/runtime@0.25.1", "", { "dependencies": { "@cloudflare/workers-types": "^4.20250617.0", "@deco/mcp": "npm:@jsr/deco__mcp@0.5.5", "@mastra/cloudflare-d1": "^0.13.4", "@mastra/core": "^0.20.2", "@modelcontextprotocol/sdk": "^1.19.1", "bidc": "0.0.3", "drizzle-orm": "^0.44.5", "jose": "^6.0.11", "mime-db": "1.52.0", "zod": "^3.25.76", "zod-from-json-schema": "^0.0.5", "zod-to-json-schema": "^3.24.4" } }, "sha512-G1J09NpHkuOcBQMPDi7zJDwtNweH33/39sOsR/mpA+sRWn2W3CX51FXeB5dp06oAmCe9BoBpYnyvb896hSQ+Jg=="],
-
     "sora/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.20.2", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-6rqTdFt67AAAzln3NOKsXRmv5ZzPkgbfaebKBqUbts7vK1GZudqnrun5a8d3M/h955cam9RHZ6Jb4Y1XhnmFPg=="],
-
-    "strapi/@decocms/runtime": ["@decocms/runtime@1.3.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-xRFTV9gqrdsUCAkJ3xoBOeDGXps6moZeZB/NNL+XZ7LNa4qzfmL3BGWG42n8xbFyEpprfEfOtOD+tVgWhkPDxQ=="],
 
     "strapi/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -4186,17 +3856,11 @@
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
-    "tiktok-ads/@decocms/runtime": ["@decocms/runtime@1.1.3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-pj6OccmpWulMjyOt9FHTNX41xHk800uzhmoYK/xq9h1f+DfDBMqyOZnt70Zmwrab7dMDO2w3VQD+NlgFKtrw1w=="],
-
     "tiktok-ads/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "veo/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
 
     "veo/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
     "veo/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "virtual-try-on/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
 
     "virtual-try-on/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
@@ -4208,8 +3872,6 @@
 
     "vtex/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "vtex-docs/@decocms/runtime": ["@decocms/runtime@1.1.3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-pj6OccmpWulMjyOt9FHTNX41xHk800uzhmoYK/xq9h1f+DfDBMqyOZnt70Zmwrab7dMDO2w3VQD+NlgFKtrw1w=="],
-
     "vtex-docs/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.20.2", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-6rqTdFt67AAAzln3NOKsXRmv5ZzPkgbfaebKBqUbts7vK1GZudqnrun5a8d3M/h955cam9RHZ6Jb4Y1XhnmFPg=="],
 
     "vtex-docs/ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
@@ -4218,21 +3880,15 @@
 
     "whatsapp-management/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
-    "whatsapp-management/@decocms/runtime": ["@decocms/runtime@1.1.3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-pj6OccmpWulMjyOt9FHTNX41xHk800uzhmoYK/xq9h1f+DfDBMqyOZnt70Zmwrab7dMDO2w3VQD+NlgFKtrw1w=="],
-
     "whatsapp-management/deco-cli": ["deco-cli@0.28.5", "", { "dependencies": { "@deco-cx/warp-node": "0.3.16", "@modelcontextprotocol/sdk": "1.20.2", "@supabase/ssr": "0.6.1", "@supabase/supabase-js": "2.50.0", "chalk": "^5.3.0", "commander": "^12.0.0", "glob": "^10.3.10", "ignore": "^7.0.5", "inquirer": "^9.2.15", "inquirer-search-checkbox": "^1.0.0", "inquirer-search-list": "^1.2.6", "jose": "^6.0.11", "json-schema-to-typescript": "^15.0.4", "object-hash": "^3.0.0", "prettier": "^3.6.2", "semver": "^7.6.0", "smol-toml": "^1.3.4", "zod": "^3.25.76" }, "bin": { "deco": "dist/cli.js", "deconfig": "dist/deconfig.js" } }, "sha512-DDzOPKrvMhoS6lu9u5nM8bP7LABClh8RKsVa6wHY+I6PUOtjKuk/mAgxJOt1uO9q2Ku9sgPle9FOyE/crM0Iqg=="],
 
     "whatsapp-management/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "whatsappagent/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
-    "whatsappagent/@decocms/runtime": ["@decocms/runtime@1.1.3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-pj6OccmpWulMjyOt9FHTNX41xHk800uzhmoYK/xq9h1f+DfDBMqyOZnt70Zmwrab7dMDO2w3VQD+NlgFKtrw1w=="],
-
     "whatsappagent/deco-cli": ["deco-cli@0.28.5", "", { "dependencies": { "@deco-cx/warp-node": "0.3.16", "@modelcontextprotocol/sdk": "1.20.2", "@supabase/ssr": "0.6.1", "@supabase/supabase-js": "2.50.0", "chalk": "^5.3.0", "commander": "^12.0.0", "glob": "^10.3.10", "ignore": "^7.0.5", "inquirer": "^9.2.15", "inquirer-search-checkbox": "^1.0.0", "inquirer-search-list": "^1.2.6", "jose": "^6.0.11", "json-schema-to-typescript": "^15.0.4", "object-hash": "^3.0.0", "prettier": "^3.6.2", "semver": "^7.6.0", "smol-toml": "^1.3.4", "zod": "^3.25.76" }, "bin": { "deco": "dist/cli.js", "deconfig": "dist/deconfig.js" } }, "sha512-DDzOPKrvMhoS6lu9u5nM8bP7LABClh8RKsVa6wHY+I6PUOtjKuk/mAgxJOt1uO9q2Ku9sgPle9FOyE/crM0Iqg=="],
 
     "whatsappagent/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "whisper/@decocms/runtime": ["@decocms/runtime@0.24.0", "", { "dependencies": { "@cloudflare/workers-types": "^4.20250617.0", "@deco/mcp": "npm:@jsr/deco__mcp@0.5.5", "@mastra/cloudflare-d1": "^0.13.4", "@mastra/core": "^0.20.2", "@modelcontextprotocol/sdk": "^1.19.1", "bidc": "0.0.3", "drizzle-orm": "^0.44.5", "jose": "^6.0.11", "mime-db": "1.52.0", "zod": "^3.25.76", "zod-from-json-schema": "^0.0.5", "zod-to-json-schema": "^3.24.4" } }, "sha512-ZWa9z6I0dl4LtVnv3NUDvxuVYU0Aka1gpUEkpJP0tW2ETCGQkmDx50MdFqEksXiL1RHoNZuv45Fz8u9FkdTKJg=="],
 
     "whisper/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.20.2", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-6rqTdFt67AAAzln3NOKsXRmv5ZzPkgbfaebKBqUbts7vK1GZudqnrun5a8d3M/h955cam9RHZ6Jb4Y1XhnmFPg=="],
 
@@ -4274,21 +3930,7 @@
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
-    "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
-
-    "@deco/mcp/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "@decocms/airtable/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "@decocms/airtable/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "@decocms/mcps-shared/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
     "@decocms/openrouter/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
-
-    "@decocms/openrouter/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "@decocms/openrouter/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "@decocms/runtime/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
@@ -4297,56 +3939,6 @@
     "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
-    "@jsr/deco__codemod-toolkit/ts-morph/@ts-morph/common": ["@ts-morph/common@0.22.0", "", { "dependencies": { "fast-glob": "^3.3.2", "minimatch": "^9.0.3", "mkdirp": "^3.0.1", "path-browserify": "^1.0.1" } }, "sha512-HqNBuV/oIlMKdkLshXd1zKBqNQCsuPEsgQOkfFQ/eUKjRlwndXW1AjN9LVkBEIukm00gGXSRmfkl0Wv5VXLnlw=="],
-
-    "@jsr/deco__codemod-toolkit/ts-morph/code-block-writer": ["code-block-writer@12.0.0", "", {}, "sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w=="],
-
-    "@jsr/deco__deco/@opentelemetry/exporter-logs-otlp-http/@opentelemetry/core": ["@opentelemetry/core@1.25.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ=="],
-
-    "@jsr/deco__deco/@opentelemetry/exporter-logs-otlp-http/@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.52.1", "", { "dependencies": { "@opentelemetry/api-logs": "0.52.1", "@opentelemetry/core": "1.25.1", "@opentelemetry/resources": "1.25.1", "@opentelemetry/sdk-logs": "0.52.1", "@opentelemetry/sdk-metrics": "1.25.1", "@opentelemetry/sdk-trace-base": "1.25.1", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-I88uCZSZZtVa0XniRqQWKbjAUm73I8tpEy/uJYPPYw5d7BRdVk0RfTBQw8kSUl01oVWEuqxLDa802222MYyWHg=="],
-
-    "@jsr/deco__deco/@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/core": ["@opentelemetry/core@1.25.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ=="],
-
-    "@jsr/deco__deco/@opentelemetry/exporter-metrics-otlp-http/@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.52.1", "", { "dependencies": { "@opentelemetry/api-logs": "0.52.1", "@opentelemetry/core": "1.25.1", "@opentelemetry/resources": "1.25.1", "@opentelemetry/sdk-logs": "0.52.1", "@opentelemetry/sdk-metrics": "1.25.1", "@opentelemetry/sdk-trace-base": "1.25.1", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-I88uCZSZZtVa0XniRqQWKbjAUm73I8tpEy/uJYPPYw5d7BRdVk0RfTBQw8kSUl01oVWEuqxLDa802222MYyWHg=="],
-
-    "@jsr/deco__deco/@opentelemetry/exporter-trace-otlp-proto/@opentelemetry/core": ["@opentelemetry/core@1.25.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ=="],
-
-    "@jsr/deco__deco/@opentelemetry/exporter-trace-otlp-proto/@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.52.1", "", { "dependencies": { "@opentelemetry/api-logs": "0.52.1", "@opentelemetry/core": "1.25.1", "@opentelemetry/resources": "1.25.1", "@opentelemetry/sdk-logs": "0.52.1", "@opentelemetry/sdk-metrics": "1.25.1", "@opentelemetry/sdk-trace-base": "1.25.1", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-I88uCZSZZtVa0XniRqQWKbjAUm73I8tpEy/uJYPPYw5d7BRdVk0RfTBQw8kSUl01oVWEuqxLDa802222MYyWHg=="],
-
-    "@jsr/deco__deco/@opentelemetry/otlp-exporter-base/@opentelemetry/core": ["@opentelemetry/core@1.25.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ=="],
-
-    "@jsr/deco__deco/@opentelemetry/otlp-exporter-base/@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.52.1", "", { "dependencies": { "@opentelemetry/api-logs": "0.52.1", "@opentelemetry/core": "1.25.1", "@opentelemetry/resources": "1.25.1", "@opentelemetry/sdk-logs": "0.52.1", "@opentelemetry/sdk-metrics": "1.25.1", "@opentelemetry/sdk-trace-base": "1.25.1", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-I88uCZSZZtVa0XniRqQWKbjAUm73I8tpEy/uJYPPYw5d7BRdVk0RfTBQw8kSUl01oVWEuqxLDa802222MYyWHg=="],
-
-    "@jsr/deco__deco/@opentelemetry/resources/@opentelemetry/core": ["@opentelemetry/core@1.25.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ=="],
-
-    "@jsr/deco__deco/@opentelemetry/sdk-logs/@opentelemetry/core": ["@opentelemetry/core@1.25.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ=="],
-
-    "@jsr/deco__deco/@opentelemetry/sdk-metrics/@opentelemetry/core": ["@opentelemetry/core@1.25.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ=="],
-
-    "@jsr/deco__deco/@opentelemetry/sdk-trace-base/@opentelemetry/core": ["@opentelemetry/core@1.25.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ=="],
-
-    "@jsr/deco__deco/@opentelemetry/sdk-trace-node/@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@1.25.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-UW/ge9zjvAEmRWVapOP0qyCvPulWU6cQxGxDbWEFfGOj1VBBZAuOqTo3X6yWmDTD3Xe15ysCZChHncr2xFMIfQ=="],
-
-    "@jsr/deco__deco/@opentelemetry/sdk-trace-node/@opentelemetry/core": ["@opentelemetry/core@1.25.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ=="],
-
-    "@jsr/deco__deco/@opentelemetry/sdk-trace-node/@opentelemetry/propagator-b3": ["@opentelemetry/propagator-b3@1.25.1", "", { "dependencies": { "@opentelemetry/core": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-p6HFscpjrv7//kE+7L+3Vn00VEDUJB0n6ZrjkTYHrJ58QZ8B3ajSJhRbCcY6guQ3PDjTbxWklyvIN2ojVbIb1A=="],
-
-    "@jsr/deco__deco/@opentelemetry/sdk-trace-node/@opentelemetry/propagator-jaeger": ["@opentelemetry/propagator-jaeger@1.25.1", "", { "dependencies": { "@opentelemetry/core": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-nBprRf0+jlgxks78G/xq72PipVK+4or9Ypntw0gVZYNTCSK8rg5SeaGV19tV920CMqBD/9UIOiFr23Li/Q8tiA=="],
-
-    "@jsr/deno__cache-dir/@jsr/std__fs/@jsr/std__assert": ["@jsr/std__assert@0.223.0", "https://npm.jsr.io/~/11/@jsr/std__assert/0.223.0.tgz", { "dependencies": { "@jsr/std__fmt": "^0.223.0" } }, "sha512-qcx+Oe/fdwQu3+XXTFXN6j7bLlEbgHDXvqokSCdJknqOz8bOdzMT5TW1bJbKhInUx2M8Kiz80HLm8VuMaOx6Xw=="],
-
-    "@jsr/deno__cache-dir/@jsr/std__io/@jsr/std__assert": ["@jsr/std__assert@0.223.0", "https://npm.jsr.io/~/11/@jsr/std__assert/0.223.0.tgz", { "dependencies": { "@jsr/std__fmt": "^0.223.0" } }, "sha512-qcx+Oe/fdwQu3+XXTFXN6j7bLlEbgHDXvqokSCdJknqOz8bOdzMT5TW1bJbKhInUx2M8Kiz80HLm8VuMaOx6Xw=="],
-
-    "@jsr/deno__cache-dir/@jsr/std__io/@jsr/std__bytes": ["@jsr/std__bytes@0.223.0", "https://npm.jsr.io/~/11/@jsr/std__bytes/0.223.0.tgz", {}, "sha512-6bhkazZZPE8iYa3unUKEd0Nk4o0k9pWe4VAjyQVqgx+hbMjLCWQHhdNCW9ySbWUbqBVuI/V+FdWGzxdfAk/HjQ=="],
-
-    "@jsr/deno__cache-dir/@jsr/std__path/@jsr/std__assert": ["@jsr/std__assert@0.223.0", "https://npm.jsr.io/~/11/@jsr/std__assert/0.223.0.tgz", { "dependencies": { "@jsr/std__fmt": "^0.223.0" } }, "sha512-qcx+Oe/fdwQu3+XXTFXN6j7bLlEbgHDXvqokSCdJknqOz8bOdzMT5TW1bJbKhInUx2M8Kiz80HLm8VuMaOx6Xw=="],
-
-    "@jsr/std__flags/@jsr/std__assert/@jsr/std__fmt": ["@jsr/std__fmt@0.224.0", "https://npm.jsr.io/~/11/@jsr/std__fmt/0.224.0.tgz", {}, "sha512-lyrH5LesMB897QW0NIbZlGp72Ucopj2hMZW2wqB0NyZhuXfLH2sPBIUpCSf87kRKTGnx90JV905w4iTp0TD+Sg=="],
-
-    "@jsr/std__flags/@jsr/std__assert/@jsr/std__internal": ["@jsr/std__internal@0.224.0", "https://npm.jsr.io/~/11/@jsr/std__internal/0.224.0.tgz", { "dependencies": { "@jsr/std__fmt": "^0.224.0" } }, "sha512-inYzKOGAFK2tyy1D4NfwlbPiqEcSaXfOms3Tm4Y+1LmKSYOeB9wjqWHF4y/BJuYj8XUv61F7eaHaIw6NIlhBWg=="],
-
-    "@jsr/std__log/@jsr/std__fs/@jsr/std__path": ["@jsr/std__path@1.1.4", "https://npm.jsr.io/~/11/@jsr/std__path/1.1.4.tgz", { "dependencies": { "@jsr/std__internal": "^1.0.12" } }, "sha512-SK4u9H6NVTfolhPdlvdYXfNFefy1W04AEHWJydryYbk+xqzNiVmr5o7TLJLJFqwHXuwMRhwrn+mcYeUfS0YFaA=="],
 
     "@mastra/schema-compat/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W+cB1sOWvPcz9qiIsNtD+HxUrBUva2vWv2K1EFukuImX+HA0uZx3EyyOjhYQ9gtf/teqEG80M6OvJ7xx/VLV2A=="],
 
@@ -4370,27 +3962,15 @@
 
     "@openrouter/ai-sdk-provider/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
 
-    "@opentelemetry/instrumentation-fetch/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.52.1", "", { "dependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A=="],
-
     "@opentelemetry/instrumentation-pg/@types/pg/pg-protocol": ["pg-protocol@1.11.0", "", {}, "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g=="],
 
     "@opentelemetry/sdk-node/@opentelemetry/sdk-trace-node/@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.0.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-XuY23lSI3d4PEqKA+7SLtAgwqIfc6E/E9eAQWLN1vlpC53ybO3o6jW4BsXo1xvz9lYyyWItfQDDLzezER01mCw=="],
-
-    "@opentelemetry/sdk-trace-web/@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@1.25.1", "", { "dependencies": { "@opentelemetry/core": "1.25.1", "@opentelemetry/semantic-conventions": "1.25.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ=="],
 
     "@types/pg-pool/@types/pg/pg-protocol": ["pg-protocol@1.11.0", "", {}, "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g=="],
 
     "ai-v5/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.0.5", "", {}, "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw=="],
 
-    "blog-post-generator/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "cloudflare/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
-
     "concurrently/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
-
-    "content-scraper/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "content-scraper/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "content-scraper/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
@@ -4402,15 +3982,7 @@
 
     "content-scraper/deco-cli/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "data-for-seo/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.3.3", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.26.0", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-rCfoYu6uZnKezmCJ0u0bu+67k4B6a9dxU3K0R5TGNuSgHnHQuArXANZR8tn/0raQYZPTste1Yqi865tgQ2cZyg=="],
-
     "data-for-seo/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
-
-    "datajud/@decocms/runtime/@mastra/core": ["@mastra/core@0.20.2", "", { "dependencies": { "@a2a-js/sdk": "~0.2.4", "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.23", "@ai-sdk/google-v5": "npm:@ai-sdk/google@2.0.17", "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.19", "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.42", "@ai-sdk/provider": "^1.1.3", "@ai-sdk/provider-utils": "^2.2.8", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.10", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.0", "@ai-sdk/ui-utils": "^1.2.11", "@ai-sdk/xai-v5": "npm:@ai-sdk/xai@2.0.23", "@isaacs/ttlcache": "^1.4.1", "@mastra/schema-compat": "0.11.4", "@openrouter/ai-sdk-provider-v5": "npm:@openrouter/ai-sdk-provider@1.2.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/auto-instrumentations-node": "^0.62.1", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0", "@opentelemetry/exporter-trace-otlp-http": "^0.203.0", "@opentelemetry/otlp-exporter-base": "^0.203.0", "@opentelemetry/otlp-transformer": "^0.203.0", "@opentelemetry/resources": "^2.0.1", "@opentelemetry/sdk-metrics": "^2.0.1", "@opentelemetry/sdk-node": "^0.203.0", "@opentelemetry/sdk-trace-base": "^2.0.1", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/semantic-conventions": "^1.36.0", "@sindresorhus/slugify": "^2.2.1", "ai": "^4.3.19", "ai-v5": "npm:ai@5.0.60", "date-fns": "^3.6.0", "dotenv": "^16.6.1", "hono": "^4.9.7", "hono-openapi": "^0.4.8", "js-tiktoken": "^1.0.20", "json-schema": "^0.4.0", "json-schema-to-zod": "^2.6.1", "p-map": "^7.0.3", "pino": "^9.7.0", "pino-pretty": "^13.0.0", "radash": "^12.1.1", "sift": "^17.1.3", "xstate": "^5.20.1", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-RbwuLwOVrcLbbjLFEBSlGTBA3mzGAy4bXp4JeXg2miJWDR/7WbXtxKIU+sTZGw5LpzlvvEFtj7JtHI1l+gKMVg=="],
-
-    "datajud/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "datajud/@decocms/runtime/zod-from-json-schema": ["zod-from-json-schema@0.0.5", "", { "dependencies": { "zod": "^3.24.2" } }, "sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ=="],
 
     "datajud/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
@@ -4426,12 +3998,6 @@
 
     "deco-llm/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
-    "deco-llm/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "deco-news-weekly-digest/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "deco-news-weekly-digest/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
-
     "deco-news-weekly-digest/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
     "deco-news-weekly-digest/deco-cli/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
@@ -4444,31 +4010,11 @@
 
     "discord-read/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
-    "discord-read/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
-
-    "discord-read/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
-
-    "farmrio-reorder-collection-db/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "farmrio-reorder-collection-db/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
-
     "farmrio-reorder-collection-db/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
-    "flux/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "flux/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core": ["@mastra/core@0.20.2", "", { "dependencies": { "@a2a-js/sdk": "~0.2.4", "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.23", "@ai-sdk/google-v5": "npm:@ai-sdk/google@2.0.17", "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.19", "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.42", "@ai-sdk/provider": "^1.1.3", "@ai-sdk/provider-utils": "^2.2.8", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.10", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.0", "@ai-sdk/ui-utils": "^1.2.11", "@ai-sdk/xai-v5": "npm:@ai-sdk/xai@2.0.23", "@isaacs/ttlcache": "^1.4.1", "@mastra/schema-compat": "0.11.4", "@openrouter/ai-sdk-provider-v5": "npm:@openrouter/ai-sdk-provider@1.2.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/auto-instrumentations-node": "^0.62.1", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0", "@opentelemetry/exporter-trace-otlp-http": "^0.203.0", "@opentelemetry/otlp-exporter-base": "^0.203.0", "@opentelemetry/otlp-transformer": "^0.203.0", "@opentelemetry/resources": "^2.0.1", "@opentelemetry/sdk-metrics": "^2.0.1", "@opentelemetry/sdk-node": "^0.203.0", "@opentelemetry/sdk-trace-base": "^2.0.1", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/semantic-conventions": "^1.36.0", "@sindresorhus/slugify": "^2.2.1", "ai": "^4.3.19", "ai-v5": "npm:ai@5.0.60", "date-fns": "^3.6.0", "dotenv": "^16.6.1", "hono": "^4.9.7", "hono-openapi": "^0.4.8", "js-tiktoken": "^1.0.20", "json-schema": "^0.4.0", "json-schema-to-zod": "^2.6.1", "p-map": "^7.0.3", "pino": "^9.7.0", "pino-pretty": "^13.0.0", "radash": "^12.1.1", "sift": "^17.1.3", "xstate": "^5.20.1", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-RbwuLwOVrcLbbjLFEBSlGTBA3mzGAy4bXp4JeXg2miJWDR/7WbXtxKIU+sTZGw5LpzlvvEFtj7JtHI1l+gKMVg=="],
-
-    "gemini-pro-vision/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "gemini-pro-vision/@decocms/runtime/zod-from-json-schema": ["zod-from-json-schema@0.0.5", "", { "dependencies": { "zod": "^3.24.2" } }, "sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ=="],
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "gemini-pro-vision/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
-
-    "github-repo-reports/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "github-repo-reports/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
 
     "github-repo-reports/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
@@ -4480,81 +4026,13 @@
 
     "github/deco-cli/@supabase/supabase-js": ["@supabase/supabase-js@2.50.0", "", { "dependencies": { "@supabase/auth-js": "2.70.0", "@supabase/functions-js": "2.4.4", "@supabase/node-fetch": "2.6.15", "@supabase/postgrest-js": "1.19.4", "@supabase/realtime-js": "2.11.10", "@supabase/storage-js": "2.7.1" } }, "sha512-M1Gd5tPaaghYZ9OjeO1iORRqbTWFEz/cF3pPubRnMPzA+A8SiUsXXWDP+DWsASZcjEcVEcVQIAF38i5wrijYOg=="],
 
-    "google-apps-script/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "google-apps-script/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
-
-    "google-big-query/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "google-big-query/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
-
-    "google-calendar-sa/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
-
-    "google-calendar-sa/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
-
-    "google-calendar/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
-
-    "google-calendar/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
-
-    "google-docs/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "google-docs/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
-
-    "google-drive/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "google-drive/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
-
-    "google-forms/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "google-forms/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
-
-    "google-gemini/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "google-gemini/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
-
     "google-gemini/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
-    "google-gmail/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "google-gmail/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
-
-    "google-meet/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "google-meet/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
-
-    "google-search-console/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "google-search-console/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
-
-    "google-sheets/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "google-sheets/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
-
-    "google-slides/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "google-slides/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
-
-    "google-tag-manager/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "google-tag-manager/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
-
     "grain/@decocms/bindings/zod-from-json-schema": ["zod-from-json-schema@0.0.5", "", { "dependencies": { "zod": "^3.24.2" } }, "sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ=="],
-
-    "grain/@decocms/runtime/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
-
-    "grain/@decocms/runtime/@deco/mcp": ["@jsr/deco__mcp@0.7.8", "https://npm.jsr.io/~/11/@jsr/deco__mcp/0.7.8.tgz", { "dependencies": { "@jsr/deco__deco": "^1.112.1", "@jsr/hono__hono": "^4.5.4", "@modelcontextprotocol/sdk": "^1.11.4", "fetch-to-node": "^2.1.0", "zod": "^3.24.2" } }, "sha512-NcDGuKv2ZxId8ZHCD3zGZhHNLzrExn+DL11yDo60mZ44zbbRwuLRRmAYTwrdtZ6A45fVWYmEIloPY93tKrtimw=="],
-
-    "grain/@decocms/runtime/zod-to-json-schema": ["zod-to-json-schema@3.25.0", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ=="],
 
     "grain/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "hyperdx/@decocms/bindings/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "hyperdx/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "hyperdx/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
-
-    "hyperdx/@decocms/runtime/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "hyperdx/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
@@ -4608,65 +4086,23 @@
 
     "log-symbols/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "mcp-studio/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "mcp-studio/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
     "mcp-studio/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
-    "mcp-template-minimal/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "mcp-template-minimal/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
-
     "mcp-template-minimal/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
-
-    "meta-ads/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "multi-channel-inbox/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
     "multi-channel-inbox/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
     "multi-channel-inbox/vite/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
 
-    "nanobanana/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "nanobanana/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
-
     "nanobanana/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
-
-    "object-storage/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "object-storage/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
 
     "object-storage/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
     "ora/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "perplexity/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "perplexity/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
-
-    "pinecone/@decocms/runtime/@mastra/core": ["@mastra/core@0.20.2", "", { "dependencies": { "@a2a-js/sdk": "~0.2.4", "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.23", "@ai-sdk/google-v5": "npm:@ai-sdk/google@2.0.17", "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.19", "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.42", "@ai-sdk/provider": "^1.1.3", "@ai-sdk/provider-utils": "^2.2.8", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.10", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.0", "@ai-sdk/ui-utils": "^1.2.11", "@ai-sdk/xai-v5": "npm:@ai-sdk/xai@2.0.23", "@isaacs/ttlcache": "^1.4.1", "@mastra/schema-compat": "0.11.4", "@openrouter/ai-sdk-provider-v5": "npm:@openrouter/ai-sdk-provider@1.2.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/auto-instrumentations-node": "^0.62.1", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0", "@opentelemetry/exporter-trace-otlp-http": "^0.203.0", "@opentelemetry/otlp-exporter-base": "^0.203.0", "@opentelemetry/otlp-transformer": "^0.203.0", "@opentelemetry/resources": "^2.0.1", "@opentelemetry/sdk-metrics": "^2.0.1", "@opentelemetry/sdk-node": "^0.203.0", "@opentelemetry/sdk-trace-base": "^2.0.1", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/semantic-conventions": "^1.36.0", "@sindresorhus/slugify": "^2.2.1", "ai": "^4.3.19", "ai-v5": "npm:ai@5.0.60", "date-fns": "^3.6.0", "dotenv": "^16.6.1", "hono": "^4.9.7", "hono-openapi": "^0.4.8", "js-tiktoken": "^1.0.20", "json-schema": "^0.4.0", "json-schema-to-zod": "^2.6.1", "p-map": "^7.0.3", "pino": "^9.7.0", "pino-pretty": "^13.0.0", "radash": "^12.1.1", "sift": "^17.1.3", "xstate": "^5.20.1", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-RbwuLwOVrcLbbjLFEBSlGTBA3mzGAy4bXp4JeXg2miJWDR/7WbXtxKIU+sTZGw5LpzlvvEFtj7JtHI1l+gKMVg=="],
-
-    "pinecone/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "pinecone/@decocms/runtime/zod-from-json-schema": ["zod-from-json-schema@0.0.5", "", { "dependencies": { "zod": "^3.24.2" } }, "sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ=="],
-
     "pinecone/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
-    "readonly-sql/@decocms/runtime/@mastra/core": ["@mastra/core@0.20.2", "", { "dependencies": { "@a2a-js/sdk": "~0.2.4", "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.23", "@ai-sdk/google-v5": "npm:@ai-sdk/google@2.0.17", "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.19", "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.42", "@ai-sdk/provider": "^1.1.3", "@ai-sdk/provider-utils": "^2.2.8", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.10", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.0", "@ai-sdk/ui-utils": "^1.2.11", "@ai-sdk/xai-v5": "npm:@ai-sdk/xai@2.0.23", "@isaacs/ttlcache": "^1.4.1", "@mastra/schema-compat": "0.11.4", "@openrouter/ai-sdk-provider-v5": "npm:@openrouter/ai-sdk-provider@1.2.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/auto-instrumentations-node": "^0.62.1", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0", "@opentelemetry/exporter-trace-otlp-http": "^0.203.0", "@opentelemetry/otlp-exporter-base": "^0.203.0", "@opentelemetry/otlp-transformer": "^0.203.0", "@opentelemetry/resources": "^2.0.1", "@opentelemetry/sdk-metrics": "^2.0.1", "@opentelemetry/sdk-node": "^0.203.0", "@opentelemetry/sdk-trace-base": "^2.0.1", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/semantic-conventions": "^1.36.0", "@sindresorhus/slugify": "^2.2.1", "ai": "^4.3.19", "ai-v5": "npm:ai@5.0.60", "date-fns": "^3.6.0", "dotenv": "^16.6.1", "hono": "^4.9.7", "hono-openapi": "^0.4.8", "js-tiktoken": "^1.0.20", "json-schema": "^0.4.0", "json-schema-to-zod": "^2.6.1", "p-map": "^7.0.3", "pino": "^9.7.0", "pino-pretty": "^13.0.0", "radash": "^12.1.1", "sift": "^17.1.3", "xstate": "^5.20.1", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-RbwuLwOVrcLbbjLFEBSlGTBA3mzGAy4bXp4JeXg2miJWDR/7WbXtxKIU+sTZGw5LpzlvvEFtj7JtHI1l+gKMVg=="],
-
-    "readonly-sql/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "readonly-sql/@decocms/runtime/zod-from-json-schema": ["zod-from-json-schema@0.0.5", "", { "dependencies": { "zod": "^3.24.2" } }, "sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ=="],
-
     "readonly-sql/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
-
-    "reddit/@decocms/runtime/@mastra/core": ["@mastra/core@0.20.2", "", { "dependencies": { "@a2a-js/sdk": "~0.2.4", "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.23", "@ai-sdk/google-v5": "npm:@ai-sdk/google@2.0.17", "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.19", "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.42", "@ai-sdk/provider": "^1.1.3", "@ai-sdk/provider-utils": "^2.2.8", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.10", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.0", "@ai-sdk/ui-utils": "^1.2.11", "@ai-sdk/xai-v5": "npm:@ai-sdk/xai@2.0.23", "@isaacs/ttlcache": "^1.4.1", "@mastra/schema-compat": "0.11.4", "@openrouter/ai-sdk-provider-v5": "npm:@openrouter/ai-sdk-provider@1.2.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/auto-instrumentations-node": "^0.62.1", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0", "@opentelemetry/exporter-trace-otlp-http": "^0.203.0", "@opentelemetry/otlp-exporter-base": "^0.203.0", "@opentelemetry/otlp-transformer": "^0.203.0", "@opentelemetry/resources": "^2.0.1", "@opentelemetry/sdk-metrics": "^2.0.1", "@opentelemetry/sdk-node": "^0.203.0", "@opentelemetry/sdk-trace-base": "^2.0.1", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/semantic-conventions": "^1.36.0", "@sindresorhus/slugify": "^2.2.1", "ai": "^4.3.19", "ai-v5": "npm:ai@5.0.60", "date-fns": "^3.6.0", "dotenv": "^16.6.1", "hono": "^4.9.7", "hono-openapi": "^0.4.8", "js-tiktoken": "^1.0.20", "json-schema": "^0.4.0", "json-schema-to-zod": "^2.6.1", "p-map": "^7.0.3", "pino": "^9.7.0", "pino-pretty": "^13.0.0", "radash": "^12.1.1", "sift": "^17.1.3", "xstate": "^5.20.1", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-RbwuLwOVrcLbbjLFEBSlGTBA3mzGAy4bXp4JeXg2miJWDR/7WbXtxKIU+sTZGw5LpzlvvEFtj7JtHI1l+gKMVg=="],
-
-    "reddit/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "reddit/@decocms/runtime/zod-from-json-schema": ["zod-from-json-schema@0.0.5", "", { "dependencies": { "zod": "^3.24.2" } }, "sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ=="],
 
     "reddit/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
@@ -4680,51 +4116,17 @@
 
     "registry/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
-    "registry/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
     "registry/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
-
-    "replicate/@decocms/runtime/@mastra/core": ["@mastra/core@0.20.2", "", { "dependencies": { "@a2a-js/sdk": "~0.2.4", "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.23", "@ai-sdk/google-v5": "npm:@ai-sdk/google@2.0.17", "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.19", "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.42", "@ai-sdk/provider": "^1.1.3", "@ai-sdk/provider-utils": "^2.2.8", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.10", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.0", "@ai-sdk/ui-utils": "^1.2.11", "@ai-sdk/xai-v5": "npm:@ai-sdk/xai@2.0.23", "@isaacs/ttlcache": "^1.4.1", "@mastra/schema-compat": "0.11.4", "@openrouter/ai-sdk-provider-v5": "npm:@openrouter/ai-sdk-provider@1.2.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/auto-instrumentations-node": "^0.62.1", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0", "@opentelemetry/exporter-trace-otlp-http": "^0.203.0", "@opentelemetry/otlp-exporter-base": "^0.203.0", "@opentelemetry/otlp-transformer": "^0.203.0", "@opentelemetry/resources": "^2.0.1", "@opentelemetry/sdk-metrics": "^2.0.1", "@opentelemetry/sdk-node": "^0.203.0", "@opentelemetry/sdk-trace-base": "^2.0.1", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/semantic-conventions": "^1.36.0", "@sindresorhus/slugify": "^2.2.1", "ai": "^4.3.19", "ai-v5": "npm:ai@5.0.60", "date-fns": "^3.6.0", "dotenv": "^16.6.1", "hono": "^4.9.7", "hono-openapi": "^0.4.8", "js-tiktoken": "^1.0.20", "json-schema": "^0.4.0", "json-schema-to-zod": "^2.6.1", "p-map": "^7.0.3", "pino": "^9.7.0", "pino-pretty": "^13.0.0", "radash": "^12.1.1", "sift": "^17.1.3", "xstate": "^5.20.1", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-RbwuLwOVrcLbbjLFEBSlGTBA3mzGAy4bXp4JeXg2miJWDR/7WbXtxKIU+sTZGw5LpzlvvEFtj7JtHI1l+gKMVg=="],
-
-    "replicate/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "replicate/@decocms/runtime/zod-from-json-schema": ["zod-from-json-schema@0.0.5", "", { "dependencies": { "zod": "^3.24.2" } }, "sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ=="],
 
     "replicate/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "slack-mcp/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
-    "slack-mcp/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
-
-    "sora/@decocms/runtime/@mastra/core": ["@mastra/core@0.20.2", "", { "dependencies": { "@a2a-js/sdk": "~0.2.4", "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.23", "@ai-sdk/google-v5": "npm:@ai-sdk/google@2.0.17", "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.19", "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.42", "@ai-sdk/provider": "^1.1.3", "@ai-sdk/provider-utils": "^2.2.8", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.10", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.0", "@ai-sdk/ui-utils": "^1.2.11", "@ai-sdk/xai-v5": "npm:@ai-sdk/xai@2.0.23", "@isaacs/ttlcache": "^1.4.1", "@mastra/schema-compat": "0.11.4", "@openrouter/ai-sdk-provider-v5": "npm:@openrouter/ai-sdk-provider@1.2.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/auto-instrumentations-node": "^0.62.1", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0", "@opentelemetry/exporter-trace-otlp-http": "^0.203.0", "@opentelemetry/otlp-exporter-base": "^0.203.0", "@opentelemetry/otlp-transformer": "^0.203.0", "@opentelemetry/resources": "^2.0.1", "@opentelemetry/sdk-metrics": "^2.0.1", "@opentelemetry/sdk-node": "^0.203.0", "@opentelemetry/sdk-trace-base": "^2.0.1", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/semantic-conventions": "^1.36.0", "@sindresorhus/slugify": "^2.2.1", "ai": "^4.3.19", "ai-v5": "npm:ai@5.0.60", "date-fns": "^3.6.0", "dotenv": "^16.6.1", "hono": "^4.9.7", "hono-openapi": "^0.4.8", "js-tiktoken": "^1.0.20", "json-schema": "^0.4.0", "json-schema-to-zod": "^2.6.1", "p-map": "^7.0.3", "pino": "^9.7.0", "pino-pretty": "^13.0.0", "radash": "^12.1.1", "sift": "^17.1.3", "xstate": "^5.20.1", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-RbwuLwOVrcLbbjLFEBSlGTBA3mzGAy4bXp4JeXg2miJWDR/7WbXtxKIU+sTZGw5LpzlvvEFtj7JtHI1l+gKMVg=="],
-
-    "sora/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "sora/@decocms/runtime/zod-from-json-schema": ["zod-from-json-schema@0.0.5", "", { "dependencies": { "zod": "^3.24.2" } }, "sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ=="],
-
     "sora/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
-
-    "strapi/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
-
-    "strapi/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
-
-    "tiktok-ads/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "veo/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "veo/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
 
     "veo/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
-    "virtual-try-on/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "virtual-try-on/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
-
     "virtual-try-on/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
-
-    "vtex-docs/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "vtex-docs/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.1", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ=="],
 
     "vtex-docs/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
@@ -4744,8 +4146,6 @@
 
     "whatsapp-management/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
-    "whatsapp-management/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
     "whatsapp-management/deco-cli/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.20.2", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-6rqTdFt67AAAzln3NOKsXRmv5ZzPkgbfaebKBqUbts7vK1GZudqnrun5a8d3M/h955cam9RHZ6Jb4Y1XhnmFPg=="],
 
     "whatsapp-management/deco-cli/@supabase/supabase-js": ["@supabase/supabase-js@2.50.0", "", { "dependencies": { "@supabase/auth-js": "2.70.0", "@supabase/functions-js": "2.4.4", "@supabase/node-fetch": "2.6.15", "@supabase/postgrest-js": "1.19.4", "@supabase/realtime-js": "2.11.10", "@supabase/storage-js": "2.7.1" } }, "sha512-M1Gd5tPaaghYZ9OjeO1iORRqbTWFEz/cF3pPubRnMPzA+A8SiUsXXWDP+DWsASZcjEcVEcVQIAF38i5wrijYOg=="],
@@ -4754,19 +4154,11 @@
 
     "whatsappagent/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
-    "whatsappagent/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
     "whatsappagent/deco-cli/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.20.2", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-6rqTdFt67AAAzln3NOKsXRmv5ZzPkgbfaebKBqUbts7vK1GZudqnrun5a8d3M/h955cam9RHZ6Jb4Y1XhnmFPg=="],
 
     "whatsappagent/deco-cli/@supabase/supabase-js": ["@supabase/supabase-js@2.50.0", "", { "dependencies": { "@supabase/auth-js": "2.70.0", "@supabase/functions-js": "2.4.4", "@supabase/node-fetch": "2.6.15", "@supabase/postgrest-js": "1.19.4", "@supabase/realtime-js": "2.11.10", "@supabase/storage-js": "2.7.1" } }, "sha512-M1Gd5tPaaghYZ9OjeO1iORRqbTWFEz/cF3pPubRnMPzA+A8SiUsXXWDP+DWsASZcjEcVEcVQIAF38i5wrijYOg=="],
 
     "whatsappagent/deco-cli/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "whisper/@decocms/runtime/@mastra/core": ["@mastra/core@0.20.2", "", { "dependencies": { "@a2a-js/sdk": "~0.2.4", "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.23", "@ai-sdk/google-v5": "npm:@ai-sdk/google@2.0.17", "@ai-sdk/openai-compatible-v5": "npm:@ai-sdk/openai-compatible@1.0.19", "@ai-sdk/openai-v5": "npm:@ai-sdk/openai@2.0.42", "@ai-sdk/provider": "^1.1.3", "@ai-sdk/provider-utils": "^2.2.8", "@ai-sdk/provider-utils-v5": "npm:@ai-sdk/provider-utils@3.0.10", "@ai-sdk/provider-v5": "npm:@ai-sdk/provider@2.0.0", "@ai-sdk/ui-utils": "^1.2.11", "@ai-sdk/xai-v5": "npm:@ai-sdk/xai@2.0.23", "@isaacs/ttlcache": "^1.4.1", "@mastra/schema-compat": "0.11.4", "@openrouter/ai-sdk-provider-v5": "npm:@openrouter/ai-sdk-provider@1.2.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/auto-instrumentations-node": "^0.62.1", "@opentelemetry/core": "^2.0.1", "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0", "@opentelemetry/exporter-trace-otlp-http": "^0.203.0", "@opentelemetry/otlp-exporter-base": "^0.203.0", "@opentelemetry/otlp-transformer": "^0.203.0", "@opentelemetry/resources": "^2.0.1", "@opentelemetry/sdk-metrics": "^2.0.1", "@opentelemetry/sdk-node": "^0.203.0", "@opentelemetry/sdk-trace-base": "^2.0.1", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/semantic-conventions": "^1.36.0", "@sindresorhus/slugify": "^2.2.1", "ai": "^4.3.19", "ai-v5": "npm:ai@5.0.60", "date-fns": "^3.6.0", "dotenv": "^16.6.1", "hono": "^4.9.7", "hono-openapi": "^0.4.8", "js-tiktoken": "^1.0.20", "json-schema": "^0.4.0", "json-schema-to-zod": "^2.6.1", "p-map": "^7.0.3", "pino": "^9.7.0", "pino-pretty": "^13.0.0", "radash": "^12.1.1", "sift": "^17.1.3", "xstate": "^5.20.1", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-RbwuLwOVrcLbbjLFEBSlGTBA3mzGAy4bXp4JeXg2miJWDR/7WbXtxKIU+sTZGw5LpzlvvEFtj7JtHI1l+gKMVg=="],
-
-    "whisper/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "whisper/@decocms/runtime/zod-from-json-schema": ["zod-from-json-schema@0.0.5", "", { "dependencies": { "zod": "^3.24.2" } }, "sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ=="],
 
     "whisper/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
@@ -4842,8 +4234,6 @@
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
-    "@decocms/mcps-shared/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
     "@decocms/openrouter/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
     "@mastra/schema-compat/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.0.5", "", {}, "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw=="],
@@ -4851,8 +4241,6 @@
     "@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.0.5", "", {}, "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw=="],
 
     "@openrouter/ai-sdk-provider/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.0.5", "", {}, "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw=="],
-
-    "blog-post-generator/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "content-scraper/deco-cli/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -4866,45 +4254,11 @@
 
     "content-scraper/deco-cli/@supabase/supabase-js/@supabase/storage-js": ["@supabase/storage-js@2.7.1", "", { "dependencies": { "@supabase/node-fetch": "^2.6.14" } }, "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA=="],
 
-    "data-for-seo/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.26.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5": ["@ai-sdk/anthropic@2.0.23", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZEBiiv1UhjGjBwUU63pFhLK5LCSlNDb1idY9K1oZHm5/Fda1cuTojf32tOp0opH0RPbPAN/F8fyyNjbU33n9Kw=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/google-v5": ["@ai-sdk/google@2.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-6LyuUrCZuiULg0rUV+kT4T2jG19oUntudorI4ttv1ARkSbwl8A39ue3rA487aDDy6fUScdbGFiV5Yv/o4gidVA=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5": ["@ai-sdk/openai-compatible@1.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5": ["@ai-sdk/openai@2.0.42", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-9mM6QS8k0ooH9qMC27nlrYLQmNDnO6Rk0JTmFo/yUxpABEWOcvQhMWNHbp9lFL6Ty5vkdINrujhsAQfWuEleOg=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils-v5": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5": ["@ai-sdk/xai@2.0.23", "", { "dependencies": { "@ai-sdk/openai-compatible": "1.0.19", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Xo4r5W/Wvi4mkCD98DoafNxj9V3xysUlWOeqAYpqKeKkNQ2xtOTly2MHq+gP6wKud0Y/mI7hemkCMQgH6HOwzQ=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@mastra/schema-compat": ["@mastra/schema-compat@0.11.4", "", { "dependencies": { "json-schema": "^0.4.0", "zod-from-json-schema": "^0.5.0", "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "ai": "^4.0.0 || ^5.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-oh3+enP3oYftZlmJAKQQj5VXR86KgTMwfMnwALZyLk04dPSWfVD2wGytoDg5Qbi3rX9qHj6g0rMNa0CUjR6aTg=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5": ["@openrouter/ai-sdk-provider@1.2.0", "", { "peerDependencies": { "ai": "^5.0.0", "zod": "^3.24.1 || ^v4" } }, "sha512-stuIwq7Yb7DNmk3GuCtz+oS3nZOY4TXEV3V5KsknDGQN7Fpu3KRMQVWRc1J073xKdf0FC9EHOctSyzsACmp5Ag=="],
-
-    "datajud/@decocms/runtime/@mastra/core/ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
-
-    "datajud/@decocms/runtime/@mastra/core/ai-v5": ["ai@5.0.60", "", { "dependencies": { "@ai-sdk/gateway": "1.0.33", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-80U/3kmdBW6g+JkLXpz/P2EwkyEaWlPlYtuLUpx/JYK9F7WZh9NnkYoh1KvUi1Sbpo0NyurBTvX0a2AG9mmbDA=="],
-
-    "datajud/@decocms/runtime/@mastra/core/date-fns": ["date-fns@3.6.0", "", {}, "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="],
-
-    "datajud/@decocms/runtime/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
     "datajud/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "deco-cli/@supabase/supabase-js/@supabase/realtime-js/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "deco-llm/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
-
-    "deco-llm/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "deco-news-weekly-digest/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "deco-news-weekly-digest/deco-cli/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -4920,43 +4274,7 @@
 
     "discord-read/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
-    "discord-read/@decocms/runtime/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
-
-    "farmrio-reorder-collection-db/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "flux/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5": ["@ai-sdk/anthropic@2.0.23", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZEBiiv1UhjGjBwUU63pFhLK5LCSlNDb1idY9K1oZHm5/Fda1cuTojf32tOp0opH0RPbPAN/F8fyyNjbU33n9Kw=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/google-v5": ["@ai-sdk/google@2.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-6LyuUrCZuiULg0rUV+kT4T2jG19oUntudorI4ttv1ARkSbwl8A39ue3rA487aDDy6fUScdbGFiV5Yv/o4gidVA=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5": ["@ai-sdk/openai-compatible@1.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5": ["@ai-sdk/openai@2.0.42", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-9mM6QS8k0ooH9qMC27nlrYLQmNDnO6Rk0JTmFo/yUxpABEWOcvQhMWNHbp9lFL6Ty5vkdINrujhsAQfWuEleOg=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils-v5": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5": ["@ai-sdk/xai@2.0.23", "", { "dependencies": { "@ai-sdk/openai-compatible": "1.0.19", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Xo4r5W/Wvi4mkCD98DoafNxj9V3xysUlWOeqAYpqKeKkNQ2xtOTly2MHq+gP6wKud0Y/mI7hemkCMQgH6HOwzQ=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@mastra/schema-compat": ["@mastra/schema-compat@0.11.4", "", { "dependencies": { "json-schema": "^0.4.0", "zod-from-json-schema": "^0.5.0", "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "ai": "^4.0.0 || ^5.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-oh3+enP3oYftZlmJAKQQj5VXR86KgTMwfMnwALZyLk04dPSWfVD2wGytoDg5Qbi3rX9qHj6g0rMNa0CUjR6aTg=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5": ["@openrouter/ai-sdk-provider@1.2.0", "", { "peerDependencies": { "ai": "^5.0.0", "zod": "^3.24.1 || ^v4" } }, "sha512-stuIwq7Yb7DNmk3GuCtz+oS3nZOY4TXEV3V5KsknDGQN7Fpu3KRMQVWRc1J073xKdf0FC9EHOctSyzsACmp5Ag=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/ai-v5": ["ai@5.0.60", "", { "dependencies": { "@ai-sdk/gateway": "1.0.33", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-80U/3kmdBW6g+JkLXpz/P2EwkyEaWlPlYtuLUpx/JYK9F7WZh9NnkYoh1KvUi1Sbpo0NyurBTvX0a2AG9mmbDA=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/date-fns": ["date-fns@3.6.0", "", {}, "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="],
-
-    "gemini-pro-vision/@decocms/runtime/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
     "gemini-pro-vision/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "github-repo-reports/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "github/deco-cli/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
@@ -4970,39 +4288,7 @@
 
     "github/deco-cli/@supabase/supabase-js/@supabase/storage-js": ["@supabase/storage-js@2.7.1", "", { "dependencies": { "@supabase/node-fetch": "^2.6.14" } }, "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA=="],
 
-    "google-apps-script/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "google-big-query/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "google-calendar-sa/@decocms/runtime/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
-
-    "google-calendar/@decocms/runtime/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
-
-    "google-docs/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "google-drive/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "google-forms/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "google-gemini/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "google-gmail/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "google-meet/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "google-search-console/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "google-sheets/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "google-slides/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "google-tag-manager/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "grain/@decocms/runtime/@deco/mcp/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
     "grain/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "hyperdx/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "inquirer-search-checkbox/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
 
@@ -5023,10 +4309,6 @@
     "inquirer-search-list/inquirer/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@2.0.0", "", {}, "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w=="],
 
     "inquirer-search-list/inquirer/strip-ansi/ansi-regex": ["ansi-regex@3.0.1", "", {}, "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="],
-
-    "mcp-template-minimal/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "meta-ads/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "multi-channel-inbox/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
 
@@ -5080,99 +4362,9 @@
 
     "multi-channel-inbox/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
 
-    "nanobanana/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "object-storage/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "perplexity/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5": ["@ai-sdk/anthropic@2.0.23", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZEBiiv1UhjGjBwUU63pFhLK5LCSlNDb1idY9K1oZHm5/Fda1cuTojf32tOp0opH0RPbPAN/F8fyyNjbU33n9Kw=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/google-v5": ["@ai-sdk/google@2.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-6LyuUrCZuiULg0rUV+kT4T2jG19oUntudorI4ttv1ARkSbwl8A39ue3rA487aDDy6fUScdbGFiV5Yv/o4gidVA=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5": ["@ai-sdk/openai-compatible@1.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5": ["@ai-sdk/openai@2.0.42", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-9mM6QS8k0ooH9qMC27nlrYLQmNDnO6Rk0JTmFo/yUxpABEWOcvQhMWNHbp9lFL6Ty5vkdINrujhsAQfWuEleOg=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils-v5": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5": ["@ai-sdk/xai@2.0.23", "", { "dependencies": { "@ai-sdk/openai-compatible": "1.0.19", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Xo4r5W/Wvi4mkCD98DoafNxj9V3xysUlWOeqAYpqKeKkNQ2xtOTly2MHq+gP6wKud0Y/mI7hemkCMQgH6HOwzQ=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@mastra/schema-compat": ["@mastra/schema-compat@0.11.4", "", { "dependencies": { "json-schema": "^0.4.0", "zod-from-json-schema": "^0.5.0", "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "ai": "^4.0.0 || ^5.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-oh3+enP3oYftZlmJAKQQj5VXR86KgTMwfMnwALZyLk04dPSWfVD2wGytoDg5Qbi3rX9qHj6g0rMNa0CUjR6aTg=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5": ["@openrouter/ai-sdk-provider@1.2.0", "", { "peerDependencies": { "ai": "^5.0.0", "zod": "^3.24.1 || ^v4" } }, "sha512-stuIwq7Yb7DNmk3GuCtz+oS3nZOY4TXEV3V5KsknDGQN7Fpu3KRMQVWRc1J073xKdf0FC9EHOctSyzsACmp5Ag=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/ai-v5": ["ai@5.0.60", "", { "dependencies": { "@ai-sdk/gateway": "1.0.33", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-80U/3kmdBW6g+JkLXpz/P2EwkyEaWlPlYtuLUpx/JYK9F7WZh9NnkYoh1KvUi1Sbpo0NyurBTvX0a2AG9mmbDA=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/date-fns": ["date-fns@3.6.0", "", {}, "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="],
-
-    "pinecone/@decocms/runtime/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
     "pinecone/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5": ["@ai-sdk/anthropic@2.0.23", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZEBiiv1UhjGjBwUU63pFhLK5LCSlNDb1idY9K1oZHm5/Fda1cuTojf32tOp0opH0RPbPAN/F8fyyNjbU33n9Kw=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/google-v5": ["@ai-sdk/google@2.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-6LyuUrCZuiULg0rUV+kT4T2jG19oUntudorI4ttv1ARkSbwl8A39ue3rA487aDDy6fUScdbGFiV5Yv/o4gidVA=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5": ["@ai-sdk/openai-compatible@1.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5": ["@ai-sdk/openai@2.0.42", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-9mM6QS8k0ooH9qMC27nlrYLQmNDnO6Rk0JTmFo/yUxpABEWOcvQhMWNHbp9lFL6Ty5vkdINrujhsAQfWuEleOg=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils-v5": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5": ["@ai-sdk/xai@2.0.23", "", { "dependencies": { "@ai-sdk/openai-compatible": "1.0.19", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Xo4r5W/Wvi4mkCD98DoafNxj9V3xysUlWOeqAYpqKeKkNQ2xtOTly2MHq+gP6wKud0Y/mI7hemkCMQgH6HOwzQ=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@mastra/schema-compat": ["@mastra/schema-compat@0.11.4", "", { "dependencies": { "json-schema": "^0.4.0", "zod-from-json-schema": "^0.5.0", "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "ai": "^4.0.0 || ^5.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-oh3+enP3oYftZlmJAKQQj5VXR86KgTMwfMnwALZyLk04dPSWfVD2wGytoDg5Qbi3rX9qHj6g0rMNa0CUjR6aTg=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5": ["@openrouter/ai-sdk-provider@1.2.0", "", { "peerDependencies": { "ai": "^5.0.0", "zod": "^3.24.1 || ^v4" } }, "sha512-stuIwq7Yb7DNmk3GuCtz+oS3nZOY4TXEV3V5KsknDGQN7Fpu3KRMQVWRc1J073xKdf0FC9EHOctSyzsACmp5Ag=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/ai-v5": ["ai@5.0.60", "", { "dependencies": { "@ai-sdk/gateway": "1.0.33", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-80U/3kmdBW6g+JkLXpz/P2EwkyEaWlPlYtuLUpx/JYK9F7WZh9NnkYoh1KvUi1Sbpo0NyurBTvX0a2AG9mmbDA=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/date-fns": ["date-fns@3.6.0", "", {}, "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="],
-
-    "readonly-sql/@decocms/runtime/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
     "readonly-sql/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5": ["@ai-sdk/anthropic@2.0.23", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZEBiiv1UhjGjBwUU63pFhLK5LCSlNDb1idY9K1oZHm5/Fda1cuTojf32tOp0opH0RPbPAN/F8fyyNjbU33n9Kw=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/google-v5": ["@ai-sdk/google@2.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-6LyuUrCZuiULg0rUV+kT4T2jG19oUntudorI4ttv1ARkSbwl8A39ue3rA487aDDy6fUScdbGFiV5Yv/o4gidVA=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5": ["@ai-sdk/openai-compatible@1.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5": ["@ai-sdk/openai@2.0.42", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-9mM6QS8k0ooH9qMC27nlrYLQmNDnO6Rk0JTmFo/yUxpABEWOcvQhMWNHbp9lFL6Ty5vkdINrujhsAQfWuEleOg=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils-v5": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5": ["@ai-sdk/xai@2.0.23", "", { "dependencies": { "@ai-sdk/openai-compatible": "1.0.19", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Xo4r5W/Wvi4mkCD98DoafNxj9V3xysUlWOeqAYpqKeKkNQ2xtOTly2MHq+gP6wKud0Y/mI7hemkCMQgH6HOwzQ=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@mastra/schema-compat": ["@mastra/schema-compat@0.11.4", "", { "dependencies": { "json-schema": "^0.4.0", "zod-from-json-schema": "^0.5.0", "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "ai": "^4.0.0 || ^5.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-oh3+enP3oYftZlmJAKQQj5VXR86KgTMwfMnwALZyLk04dPSWfVD2wGytoDg5Qbi3rX9qHj6g0rMNa0CUjR6aTg=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5": ["@openrouter/ai-sdk-provider@1.2.0", "", { "peerDependencies": { "ai": "^5.0.0", "zod": "^3.24.1 || ^v4" } }, "sha512-stuIwq7Yb7DNmk3GuCtz+oS3nZOY4TXEV3V5KsknDGQN7Fpu3KRMQVWRc1J073xKdf0FC9EHOctSyzsACmp5Ag=="],
-
-    "reddit/@decocms/runtime/@mastra/core/ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
-
-    "reddit/@decocms/runtime/@mastra/core/ai-v5": ["ai@5.0.60", "", { "dependencies": { "@ai-sdk/gateway": "1.0.33", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-80U/3kmdBW6g+JkLXpz/P2EwkyEaWlPlYtuLUpx/JYK9F7WZh9NnkYoh1KvUi1Sbpo0NyurBTvX0a2AG9mmbDA=="],
-
-    "reddit/@decocms/runtime/@mastra/core/date-fns": ["date-fns@3.6.0", "", {}, "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="],
-
-    "reddit/@decocms/runtime/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "reddit/deco-cli/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -5188,81 +4380,11 @@
 
     "registry/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
-    "registry/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5": ["@ai-sdk/anthropic@2.0.23", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZEBiiv1UhjGjBwUU63pFhLK5LCSlNDb1idY9K1oZHm5/Fda1cuTojf32tOp0opH0RPbPAN/F8fyyNjbU33n9Kw=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/google-v5": ["@ai-sdk/google@2.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-6LyuUrCZuiULg0rUV+kT4T2jG19oUntudorI4ttv1ARkSbwl8A39ue3rA487aDDy6fUScdbGFiV5Yv/o4gidVA=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5": ["@ai-sdk/openai-compatible@1.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5": ["@ai-sdk/openai@2.0.42", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-9mM6QS8k0ooH9qMC27nlrYLQmNDnO6Rk0JTmFo/yUxpABEWOcvQhMWNHbp9lFL6Ty5vkdINrujhsAQfWuEleOg=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils-v5": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5": ["@ai-sdk/xai@2.0.23", "", { "dependencies": { "@ai-sdk/openai-compatible": "1.0.19", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Xo4r5W/Wvi4mkCD98DoafNxj9V3xysUlWOeqAYpqKeKkNQ2xtOTly2MHq+gP6wKud0Y/mI7hemkCMQgH6HOwzQ=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@mastra/schema-compat": ["@mastra/schema-compat@0.11.4", "", { "dependencies": { "json-schema": "^0.4.0", "zod-from-json-schema": "^0.5.0", "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "ai": "^4.0.0 || ^5.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-oh3+enP3oYftZlmJAKQQj5VXR86KgTMwfMnwALZyLk04dPSWfVD2wGytoDg5Qbi3rX9qHj6g0rMNa0CUjR6aTg=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5": ["@openrouter/ai-sdk-provider@1.2.0", "", { "peerDependencies": { "ai": "^5.0.0", "zod": "^3.24.1 || ^v4" } }, "sha512-stuIwq7Yb7DNmk3GuCtz+oS3nZOY4TXEV3V5KsknDGQN7Fpu3KRMQVWRc1J073xKdf0FC9EHOctSyzsACmp5Ag=="],
-
-    "replicate/@decocms/runtime/@mastra/core/ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
-
-    "replicate/@decocms/runtime/@mastra/core/ai-v5": ["ai@5.0.60", "", { "dependencies": { "@ai-sdk/gateway": "1.0.33", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-80U/3kmdBW6g+JkLXpz/P2EwkyEaWlPlYtuLUpx/JYK9F7WZh9NnkYoh1KvUi1Sbpo0NyurBTvX0a2AG9mmbDA=="],
-
-    "replicate/@decocms/runtime/@mastra/core/date-fns": ["date-fns@3.6.0", "", {}, "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="],
-
-    "replicate/@decocms/runtime/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
     "replicate/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "slack-mcp/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
-    "slack-mcp/@decocms/runtime/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5": ["@ai-sdk/anthropic@2.0.23", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZEBiiv1UhjGjBwUU63pFhLK5LCSlNDb1idY9K1oZHm5/Fda1cuTojf32tOp0opH0RPbPAN/F8fyyNjbU33n9Kw=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/google-v5": ["@ai-sdk/google@2.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-6LyuUrCZuiULg0rUV+kT4T2jG19oUntudorI4ttv1ARkSbwl8A39ue3rA487aDDy6fUScdbGFiV5Yv/o4gidVA=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5": ["@ai-sdk/openai-compatible@1.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5": ["@ai-sdk/openai@2.0.42", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-9mM6QS8k0ooH9qMC27nlrYLQmNDnO6Rk0JTmFo/yUxpABEWOcvQhMWNHbp9lFL6Ty5vkdINrujhsAQfWuEleOg=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils-v5": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5": ["@ai-sdk/xai@2.0.23", "", { "dependencies": { "@ai-sdk/openai-compatible": "1.0.19", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Xo4r5W/Wvi4mkCD98DoafNxj9V3xysUlWOeqAYpqKeKkNQ2xtOTly2MHq+gP6wKud0Y/mI7hemkCMQgH6HOwzQ=="],
-
-    "sora/@decocms/runtime/@mastra/core/@mastra/schema-compat": ["@mastra/schema-compat@0.11.4", "", { "dependencies": { "json-schema": "^0.4.0", "zod-from-json-schema": "^0.5.0", "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "ai": "^4.0.0 || ^5.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-oh3+enP3oYftZlmJAKQQj5VXR86KgTMwfMnwALZyLk04dPSWfVD2wGytoDg5Qbi3rX9qHj6g0rMNa0CUjR6aTg=="],
-
-    "sora/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5": ["@openrouter/ai-sdk-provider@1.2.0", "", { "peerDependencies": { "ai": "^5.0.0", "zod": "^3.24.1 || ^v4" } }, "sha512-stuIwq7Yb7DNmk3GuCtz+oS3nZOY4TXEV3V5KsknDGQN7Fpu3KRMQVWRc1J073xKdf0FC9EHOctSyzsACmp5Ag=="],
-
-    "sora/@decocms/runtime/@mastra/core/ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
-
-    "sora/@decocms/runtime/@mastra/core/ai-v5": ["ai@5.0.60", "", { "dependencies": { "@ai-sdk/gateway": "1.0.33", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-80U/3kmdBW6g+JkLXpz/P2EwkyEaWlPlYtuLUpx/JYK9F7WZh9NnkYoh1KvUi1Sbpo0NyurBTvX0a2AG9mmbDA=="],
-
-    "sora/@decocms/runtime/@mastra/core/date-fns": ["date-fns@3.6.0", "", {}, "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="],
-
-    "sora/@decocms/runtime/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
     "sora/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "strapi/@decocms/runtime/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
-
-    "tiktok-ads/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "veo/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "virtual-try-on/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
-    "vtex-docs/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "vtex-docs/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
@@ -5271,8 +4393,6 @@
     "vtex/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "whatsapp-management/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
-
-    "whatsapp-management/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "whatsapp-management/deco-cli/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
@@ -5288,8 +4408,6 @@
 
     "whatsappagent/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
-    "whatsappagent/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
-
     "whatsappagent/deco-cli/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "whatsappagent/deco-cli/@supabase/supabase-js/@supabase/auth-js": ["@supabase/auth-js@2.70.0", "", { "dependencies": { "@supabase/node-fetch": "^2.6.14" } }, "sha512-BaAK/tOAZFJtzF1sE3gJ2FwTjLf4ky3PSvcvLGEgEmO4BSBkwWKu8l67rLLIBZPDnCyV7Owk2uPyKHa0kj5QGg=="],
@@ -5302,111 +4420,13 @@
 
     "whatsappagent/deco-cli/@supabase/supabase-js/@supabase/storage-js": ["@supabase/storage-js@2.7.1", "", { "dependencies": { "@supabase/node-fetch": "^2.6.14" } }, "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA=="],
 
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5": ["@ai-sdk/anthropic@2.0.23", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZEBiiv1UhjGjBwUU63pFhLK5LCSlNDb1idY9K1oZHm5/Fda1cuTojf32tOp0opH0RPbPAN/F8fyyNjbU33n9Kw=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/google-v5": ["@ai-sdk/google@2.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-6LyuUrCZuiULg0rUV+kT4T2jG19oUntudorI4ttv1ARkSbwl8A39ue3rA487aDDy6fUScdbGFiV5Yv/o4gidVA=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5": ["@ai-sdk/openai-compatible@1.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5": ["@ai-sdk/openai@2.0.42", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-9mM6QS8k0ooH9qMC27nlrYLQmNDnO6Rk0JTmFo/yUxpABEWOcvQhMWNHbp9lFL6Ty5vkdINrujhsAQfWuEleOg=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils-v5": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5": ["@ai-sdk/xai@2.0.23", "", { "dependencies": { "@ai-sdk/openai-compatible": "1.0.19", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Xo4r5W/Wvi4mkCD98DoafNxj9V3xysUlWOeqAYpqKeKkNQ2xtOTly2MHq+gP6wKud0Y/mI7hemkCMQgH6HOwzQ=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@mastra/schema-compat": ["@mastra/schema-compat@0.11.4", "", { "dependencies": { "json-schema": "^0.4.0", "zod-from-json-schema": "^0.5.0", "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "ai": "^4.0.0 || ^5.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-oh3+enP3oYftZlmJAKQQj5VXR86KgTMwfMnwALZyLk04dPSWfVD2wGytoDg5Qbi3rX9qHj6g0rMNa0CUjR6aTg=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5": ["@openrouter/ai-sdk-provider@1.2.0", "", { "peerDependencies": { "ai": "^5.0.0", "zod": "^3.24.1 || ^v4" } }, "sha512-stuIwq7Yb7DNmk3GuCtz+oS3nZOY4TXEV3V5KsknDGQN7Fpu3KRMQVWRc1J073xKdf0FC9EHOctSyzsACmp5Ag=="],
-
-    "whisper/@decocms/runtime/@mastra/core/ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
-
-    "whisper/@decocms/runtime/@mastra/core/ai-v5": ["ai@5.0.60", "", { "dependencies": { "@ai-sdk/gateway": "1.0.33", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-80U/3kmdBW6g+JkLXpz/P2EwkyEaWlPlYtuLUpx/JYK9F7WZh9NnkYoh1KvUi1Sbpo0NyurBTvX0a2AG9mmbDA=="],
-
-    "whisper/@decocms/runtime/@mastra/core/date-fns": ["date-fns@3.6.0", "", {}, "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww=="],
-
-    "whisper/@decocms/runtime/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
     "whisper/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
-    "data-for-seo/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
+    "@a2a-js/sdk/express/accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/google-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/google-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@1.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema": ["zod-from-json-schema@0.5.2", "", { "dependencies": { "zod": "^4.0.17" } }, "sha512-/dNaicfdhJTOuUd4RImbLUE2g5yrSzzDjI/S6C2vO2ecAGZzn9UcRVgtyLSnENSmAOBRiSpUdzDS6fDWX3Z35g=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai": ["ai@5.0.97", "", { "dependencies": { "@ai-sdk/gateway": "2.0.12", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-8zBx0b/owis4eJI2tAlV8a1Rv0BANmLxontcAelkLNwEHhgfgXeKpDkhNB6OgV+BJSwboIUDkgd9312DdJnCOQ=="],
-
-    "datajud/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/gateway": ["@ai-sdk/gateway@1.0.33", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@vercel/oidc": "^3.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-v9i3GPEo4t3fGcSkQkc07xM6KJN75VUv7C1Mqmmsu2xD8lQwnQfsrgAXyNuWe20yGY0eHuheSPDZhiqsGKtH1g=="],
-
-    "datajud/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "datajud/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/google-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/google-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@1.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema": ["zod-from-json-schema@0.5.2", "", { "dependencies": { "zod": "^4.0.17" } }, "sha512-/dNaicfdhJTOuUd4RImbLUE2g5yrSzzDjI/S6C2vO2ecAGZzn9UcRVgtyLSnENSmAOBRiSpUdzDS6fDWX3Z35g=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai": ["ai@5.0.97", "", { "dependencies": { "@ai-sdk/gateway": "2.0.12", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-8zBx0b/owis4eJI2tAlV8a1Rv0BANmLxontcAelkLNwEHhgfgXeKpDkhNB6OgV+BJSwboIUDkgd9312DdJnCOQ=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/gateway": ["@ai-sdk/gateway@1.0.33", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@vercel/oidc": "^3.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-v9i3GPEo4t3fGcSkQkc07xM6KJN75VUv7C1Mqmmsu2xD8lQwnQfsrgAXyNuWe20yGY0eHuheSPDZhiqsGKtH1g=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
+    "@a2a-js/sdk/express/type-is/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "github/deco-cli/@supabase/supabase-js/@supabase/realtime-js/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
-
-    "grain/@decocms/runtime/@deco/mcp/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "grain/@decocms/runtime/@deco/mcp/@modelcontextprotocol/sdk/zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "inquirer-search-checkbox/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
@@ -5420,176 +4440,6 @@
 
     "inquirer-search-list/inquirer/cli-cursor/restore-cursor/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/google-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/google-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@1.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema": ["zod-from-json-schema@0.5.2", "", { "dependencies": { "zod": "^4.0.17" } }, "sha512-/dNaicfdhJTOuUd4RImbLUE2g5yrSzzDjI/S6C2vO2ecAGZzn9UcRVgtyLSnENSmAOBRiSpUdzDS6fDWX3Z35g=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai": ["ai@5.0.97", "", { "dependencies": { "@ai-sdk/gateway": "2.0.12", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-8zBx0b/owis4eJI2tAlV8a1Rv0BANmLxontcAelkLNwEHhgfgXeKpDkhNB6OgV+BJSwboIUDkgd9312DdJnCOQ=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/gateway": ["@ai-sdk/gateway@1.0.33", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@vercel/oidc": "^3.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-v9i3GPEo4t3fGcSkQkc07xM6KJN75VUv7C1Mqmmsu2xD8lQwnQfsrgAXyNuWe20yGY0eHuheSPDZhiqsGKtH1g=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/google-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/google-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@1.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema": ["zod-from-json-schema@0.5.2", "", { "dependencies": { "zod": "^4.0.17" } }, "sha512-/dNaicfdhJTOuUd4RImbLUE2g5yrSzzDjI/S6C2vO2ecAGZzn9UcRVgtyLSnENSmAOBRiSpUdzDS6fDWX3Z35g=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai": ["ai@5.0.97", "", { "dependencies": { "@ai-sdk/gateway": "2.0.12", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-8zBx0b/owis4eJI2tAlV8a1Rv0BANmLxontcAelkLNwEHhgfgXeKpDkhNB6OgV+BJSwboIUDkgd9312DdJnCOQ=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/gateway": ["@ai-sdk/gateway@1.0.33", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@vercel/oidc": "^3.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-v9i3GPEo4t3fGcSkQkc07xM6KJN75VUv7C1Mqmmsu2xD8lQwnQfsrgAXyNuWe20yGY0eHuheSPDZhiqsGKtH1g=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/google-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/google-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@1.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema": ["zod-from-json-schema@0.5.2", "", { "dependencies": { "zod": "^4.0.17" } }, "sha512-/dNaicfdhJTOuUd4RImbLUE2g5yrSzzDjI/S6C2vO2ecAGZzn9UcRVgtyLSnENSmAOBRiSpUdzDS6fDWX3Z35g=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai": ["ai@5.0.97", "", { "dependencies": { "@ai-sdk/gateway": "2.0.12", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-8zBx0b/owis4eJI2tAlV8a1Rv0BANmLxontcAelkLNwEHhgfgXeKpDkhNB6OgV+BJSwboIUDkgd9312DdJnCOQ=="],
-
-    "reddit/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/gateway": ["@ai-sdk/gateway@1.0.33", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@vercel/oidc": "^3.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-v9i3GPEo4t3fGcSkQkc07xM6KJN75VUv7C1Mqmmsu2xD8lQwnQfsrgAXyNuWe20yGY0eHuheSPDZhiqsGKtH1g=="],
-
-    "reddit/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "reddit/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/google-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/google-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@1.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema": ["zod-from-json-schema@0.5.2", "", { "dependencies": { "zod": "^4.0.17" } }, "sha512-/dNaicfdhJTOuUd4RImbLUE2g5yrSzzDjI/S6C2vO2ecAGZzn9UcRVgtyLSnENSmAOBRiSpUdzDS6fDWX3Z35g=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai": ["ai@5.0.97", "", { "dependencies": { "@ai-sdk/gateway": "2.0.12", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-8zBx0b/owis4eJI2tAlV8a1Rv0BANmLxontcAelkLNwEHhgfgXeKpDkhNB6OgV+BJSwboIUDkgd9312DdJnCOQ=="],
-
-    "replicate/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/gateway": ["@ai-sdk/gateway@1.0.33", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@vercel/oidc": "^3.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-v9i3GPEo4t3fGcSkQkc07xM6KJN75VUv7C1Mqmmsu2xD8lQwnQfsrgAXyNuWe20yGY0eHuheSPDZhiqsGKtH1g=="],
-
-    "replicate/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "replicate/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/google-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/google-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@1.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "sora/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "sora/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema": ["zod-from-json-schema@0.5.2", "", { "dependencies": { "zod": "^4.0.17" } }, "sha512-/dNaicfdhJTOuUd4RImbLUE2g5yrSzzDjI/S6C2vO2ecAGZzn9UcRVgtyLSnENSmAOBRiSpUdzDS6fDWX3Z35g=="],
-
-    "sora/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai": ["ai@5.0.97", "", { "dependencies": { "@ai-sdk/gateway": "2.0.12", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-8zBx0b/owis4eJI2tAlV8a1Rv0BANmLxontcAelkLNwEHhgfgXeKpDkhNB6OgV+BJSwboIUDkgd9312DdJnCOQ=="],
-
-    "sora/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/gateway": ["@ai-sdk/gateway@1.0.33", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@vercel/oidc": "^3.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-v9i3GPEo4t3fGcSkQkc07xM6KJN75VUv7C1Mqmmsu2xD8lQwnQfsrgAXyNuWe20yGY0eHuheSPDZhiqsGKtH1g=="],
-
-    "sora/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "sora/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
     "whatsapp-management/deco-cli/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "whatsapp-management/deco-cli/@supabase/supabase-js/@supabase/realtime-js/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
@@ -5598,122 +4448,8 @@
 
     "whatsappagent/deco-cli/@supabase/supabase-js/@supabase/realtime-js/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/google-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/google-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/openai-compatible-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/openai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/provider-utils-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@1.0.19", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-hnsqPCCSNKgpZRNDOAIXZs7OcUDM4ut5ggWxj2sjB4tNL/aBn/xrM7pJkqu+WuPowyrE60wPVSlw0LvtXAlMXQ=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@ai-sdk/xai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema": ["zod-from-json-schema@0.5.2", "", { "dependencies": { "zod": "^4.0.17" } }, "sha512-/dNaicfdhJTOuUd4RImbLUE2g5yrSzzDjI/S6C2vO2ecAGZzn9UcRVgtyLSnENSmAOBRiSpUdzDS6fDWX3Z35g=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai": ["ai@5.0.97", "", { "dependencies": { "@ai-sdk/gateway": "2.0.12", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-8zBx0b/owis4eJI2tAlV8a1Rv0BANmLxontcAelkLNwEHhgfgXeKpDkhNB6OgV+BJSwboIUDkgd9312DdJnCOQ=="],
-
-    "whisper/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/gateway": ["@ai-sdk/gateway@1.0.33", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.10", "@vercel/oidc": "^3.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-v9i3GPEo4t3fGcSkQkc07xM6KJN75VUv7C1Mqmmsu2xD8lQwnQfsrgAXyNuWe20yGY0eHuheSPDZhiqsGKtH1g=="],
-
-    "whisper/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "whisper/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W+cB1sOWvPcz9qiIsNtD+HxUrBUva2vWv2K1EFukuImX+HA0uZx3EyyOjhYQ9gtf/teqEG80M6OvJ7xx/VLV2A=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W+cB1sOWvPcz9qiIsNtD+HxUrBUva2vWv2K1EFukuImX+HA0uZx3EyyOjhYQ9gtf/teqEG80M6OvJ7xx/VLV2A=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
-
     "inquirer-search-checkbox/inquirer/cli-cursor/restore-cursor/onetime/mimic-fn": ["mimic-fn@1.2.0", "", {}, "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="],
 
     "inquirer-search-list/inquirer/cli-cursor/restore-cursor/onetime/mimic-fn": ["mimic-fn@1.2.0", "", {}, "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W+cB1sOWvPcz9qiIsNtD+HxUrBUva2vWv2K1EFukuImX+HA0uZx3EyyOjhYQ9gtf/teqEG80M6OvJ7xx/VLV2A=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W+cB1sOWvPcz9qiIsNtD+HxUrBUva2vWv2K1EFukuImX+HA0uZx3EyyOjhYQ9gtf/teqEG80M6OvJ7xx/VLV2A=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W+cB1sOWvPcz9qiIsNtD+HxUrBUva2vWv2K1EFukuImX+HA0uZx3EyyOjhYQ9gtf/teqEG80M6OvJ7xx/VLV2A=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W+cB1sOWvPcz9qiIsNtD+HxUrBUva2vWv2K1EFukuImX+HA0uZx3EyyOjhYQ9gtf/teqEG80M6OvJ7xx/VLV2A=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
-
-    "sora/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "sora/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W+cB1sOWvPcz9qiIsNtD+HxUrBUva2vWv2K1EFukuImX+HA0uZx3EyyOjhYQ9gtf/teqEG80M6OvJ7xx/VLV2A=="],
-
-    "sora/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "sora/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@mastra/schema-compat/zod-from-json-schema/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.12", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.17", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W+cB1sOWvPcz9qiIsNtD+HxUrBUva2vWv2K1EFukuImX+HA0uZx3EyyOjhYQ9gtf/teqEG80M6OvJ7xx/VLV2A=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.17", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw=="],
-
-    "datajud/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.0.5", "", {}, "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw=="],
-
-    "gemini-pro-vision/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.0.5", "", {}, "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw=="],
-
-    "pinecone/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.0.5", "", {}, "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw=="],
-
-    "readonly-sql/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.0.5", "", {}, "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw=="],
-
-    "reddit/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.0.5", "", {}, "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw=="],
-
-    "replicate/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.0.5", "", {}, "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw=="],
-
-    "sora/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.0.5", "", {}, "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw=="],
-
-    "whisper/@decocms/runtime/@mastra/core/@openrouter/ai-sdk-provider-v5/ai/@ai-sdk/gateway/@vercel/oidc": ["@vercel/oidc@3.0.5", "", {}, "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw=="],
   }
 }

--- a/content-scraper/package.json
+++ b/content-scraper/package.json
@@ -16,7 +16,7 @@
     "cli": "bun cli.ts"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.6",
+    "@decocms/runtime": "1.4.0",
     "@supabase/supabase-js": "^2.49.0",
     "zod": "^4.0.0"
   },

--- a/content-scraper/server/tools/content-scrape.ts
+++ b/content-scraper/server/tools/content-scrape.ts
@@ -5,7 +5,7 @@
  */
 
 import { z } from "zod";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import type { Env } from "../types/env.ts";
 import { createDatabaseClient, type DatabaseClient } from "../lib/db-client.ts";
 
@@ -115,7 +115,7 @@ async function queryTable(
  * Get content scrape tool - fetches scraped content from database tables
  */
 export const getContentScrapeTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "LIST_SCRAPED_CONTENT",
     description:
       "Lists content that has been collected and saved to the database. " +
@@ -183,7 +183,8 @@ export const getContentScrapeTool = (env: Env) =>
         .describe("Whether high score filter (>85%) was applied"),
       error: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { table, startIndex, endIndex, onlyThisWeek, highScoreOnly } =
         context;
 

--- a/content-scraper/server/tools/content-tools.ts
+++ b/content-scraper/server/tools/content-tools.ts
@@ -5,7 +5,7 @@
  */
 
 import { z } from "zod";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import type { Env } from "../types/env.ts";
 import {
   createDatabaseClient,
@@ -47,7 +47,7 @@ function createDbClient(env: Env): {
 // =============================================================================
 
 export const getListArticlesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "LIST_ARTICLES",
     description: "Lists scraped blog articles, ordered by score.",
     inputSchema: z.object({
@@ -88,7 +88,8 @@ export const getListArticlesTool = (env: Env) =>
         .optional(),
       error: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { limit, include_blog_info } = context;
 
       const { client, error: dbError } = createDbClient(env);
@@ -184,7 +185,7 @@ export const getListArticlesTool = (env: Env) =>
 // =============================================================================
 
 export const getListLinkedInPostsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "LIST_LINKEDIN_POSTS",
     description: "Lists scraped LinkedIn posts, ordered by relevance score.",
     inputSchema: z.object({
@@ -227,7 +228,8 @@ export const getListLinkedInPostsTool = (env: Env) =>
         .optional(),
       error: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { limit, week } = context;
 
       const { client, error: dbError } = createDbClient(env);
@@ -296,7 +298,7 @@ export const getListLinkedInPostsTool = (env: Env) =>
 // =============================================================================
 
 export const getListRedditPostsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "LIST_REDDIT_POSTS",
     description: "Lists scraped Reddit posts, ordered by relevance score.",
     inputSchema: z.object({
@@ -336,7 +338,8 @@ export const getListRedditPostsTool = (env: Env) =>
         .optional(),
       error: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { limit, subreddit } = context;
 
       const { client, error: dbError } = createDbClient(env);
@@ -400,7 +403,7 @@ export const getListRedditPostsTool = (env: Env) =>
 // =============================================================================
 
 export const getGetStatsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "GET_STATS",
     description:
       "Returns general system statistics: total sources, scraped posts, etc.",
@@ -426,7 +429,8 @@ export const getGetStatsTool = (env: Env) =>
       averageAuthority: z.string().optional(),
       error: z.string().optional(),
     }),
-    execute: async () => {
+    execute: async (_input, ctx) => {
+      ensureAuthenticated(ctx!);
       const { client, error: dbError } = createDbClient(env);
       if (!client) {
         return { success: false, error: dbError ?? "Database error" };

--- a/content-scraper/server/tools/scraping.ts
+++ b/content-scraper/server/tools/scraping.ts
@@ -5,7 +5,7 @@
  */
 
 import { z } from "zod";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import type { Env } from "../types/env.ts";
 import { createDatabaseClient, type DatabaseClient } from "../lib/db-client.ts";
 import { scrapeAllBlogs } from "../lib/blog-scraper.ts";
@@ -65,7 +65,7 @@ function getApifyApiToken(env: Env): string | null {
 // =============================================================================
 
 export const getScrapeAllTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "SCRAPE_ALL",
     description:
       "Executes scraping of ALL registered sources (blogs, LinkedIn and Reddit). May take several minutes.",
@@ -112,7 +112,8 @@ export const getScrapeAllTool = (env: Env) =>
         .optional(),
       error: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { linkedin_max_posts, reddit_limit } = context;
 
       const { client, error: dbError } = createDbClient(env);
@@ -233,7 +234,7 @@ export const getScrapeAllTool = (env: Env) =>
 // =============================================================================
 
 export const getScrapeBlogsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "SCRAPE_BLOGS",
     description:
       "Executes scraping only of registered blogs. Searches for new articles about MCP.",
@@ -244,7 +245,8 @@ export const getScrapeBlogsTool = (env: Env) =>
       totalSaved: z.number().optional(),
       error: z.string().optional(),
     }),
-    execute: async () => {
+    execute: async (_input, ctx) => {
+      ensureAuthenticated(ctx!);
       const { client, error: dbError } = createDbClient(env);
       if (!client) {
         return { success: false, error: dbError ?? "Database error" };
@@ -275,7 +277,7 @@ export const getScrapeBlogsTool = (env: Env) =>
 // =============================================================================
 
 export const getScrapeLinkedInTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "SCRAPE_LINKEDIN",
     description:
       "Executes scraping of registered LinkedIn profiles. Requires APIFY_API_TOKEN configured.",
@@ -305,7 +307,8 @@ export const getScrapeLinkedInTool = (env: Env) =>
       total_relevant: z.number().optional(),
       error: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { max_posts, profile_url } = context;
 
       const { client, error: dbError } = createDbClient(env);
@@ -372,7 +375,7 @@ export const getScrapeLinkedInTool = (env: Env) =>
 // =============================================================================
 
 export const getScrapeRedditTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "SCRAPE_REDDIT",
     description:
       "Executes scraping of registered subreddits. Searches for relevant posts about MCP/AI.",
@@ -402,7 +405,8 @@ export const getScrapeRedditTool = (env: Env) =>
       total_relevant: z.number().optional(),
       error: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { limit, subreddit } = context;
 
       const { client, error: dbError } = createDbClient(env);

--- a/content-scraper/server/tools/sources.ts
+++ b/content-scraper/server/tools/sources.ts
@@ -5,7 +5,7 @@
  */
 
 import { z } from "zod";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import type { Env } from "../types/env.ts";
 import { createDatabaseClient, type DatabaseClient } from "../lib/db-client.ts";
 import type { Blog, LinkedInSource, RedditSource } from "../types/content.ts";
@@ -43,7 +43,7 @@ function createDbClient(env: Env): {
 // =============================================================================
 
 export const getListBlogSourcesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "LIST_BLOG_SOURCES",
     description: "Lists all blogs registered as content sources.",
     inputSchema: z.object({}),
@@ -63,7 +63,8 @@ export const getListBlogSourcesTool = (env: Env) =>
         .optional(),
       error: z.string().optional(),
     }),
-    execute: async () => {
+    execute: async (_input, ctx) => {
+      ensureAuthenticated(ctx!);
       const { client, error: dbError } = createDbClient(env);
       if (!client) {
         return { success: false, error: dbError ?? "Database error" };
@@ -103,7 +104,7 @@ export const getListBlogSourcesTool = (env: Env) =>
 // =============================================================================
 
 export const getListLinkedInSourcesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "LIST_LINKEDIN_SOURCES",
     description: "Lists all LinkedIn profiles registered for monitoring.",
     inputSchema: z.object({
@@ -131,7 +132,8 @@ export const getListLinkedInSourcesTool = (env: Env) =>
         .optional(),
       error: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { active_only } = context;
 
       const { client, error: dbError } = createDbClient(env);
@@ -177,7 +179,7 @@ export const getListLinkedInSourcesTool = (env: Env) =>
 // =============================================================================
 
 export const getListRedditSourcesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "LIST_REDDIT_SOURCES",
     description: "Lists all subreddits registered for monitoring.",
     inputSchema: z.object({
@@ -205,7 +207,8 @@ export const getListRedditSourcesTool = (env: Env) =>
         .optional(),
       error: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { active_only } = context;
 
       const { client, error: dbError } = createDbClient(env);

--- a/content-scraper/tsconfig.json
+++ b/content-scraper/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023"],

--- a/data-for-seo/package.json
+++ b/data-for-seo/package.json
@@ -12,7 +12,7 @@
     "dev:link": "deco link -p 3003 -- PORT=3003 bun run dev"
   },
   "dependencies": {
-    "@decocms/runtime": "^1.2.6",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/data-for-seo/server/tools/backlinks.ts
+++ b/data-for-seo/server/tools/backlinks.ts
@@ -1,7 +1,7 @@
 import type { Env } from "../types/env.ts";
 import { logToolExecution, logToolSuccess } from "./_helpers.ts";
 import { getClientFromEnv } from "../lib/dataforseo.ts";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import {
   backlinksOverviewInputSchema,
   backlinksOverviewOutputSchema,
@@ -12,13 +12,14 @@ import {
 } from "./schemas.ts";
 
 export const createBacklinksOverviewTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DATAFORSEO_GET_BACKLINKS_OVERVIEW",
     description:
       "[ASYNC - Backlinks Summary] Get comprehensive backlinks overview for any domain or URL. Returns total backlinks count, referring domains, dofollow/nofollow ratio, gov/edu domains, domain rank, and broken backlinks. Takes 2-4 seconds. Cost: ~0.05 credits per request. Available in all plans.",
     inputSchema: backlinksOverviewInputSchema,
     outputSchema: backlinksOverviewOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       logToolExecution("DATAFORSEO_GET_BACKLINKS_OVERVIEW", env);
       const client = getClientFromEnv(env);
       const result = await client.getBacklinksOverview(context.target);
@@ -28,13 +29,14 @@ export const createBacklinksOverviewTool = (env: Env) =>
   });
 
 export const createBacklinksTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DATAFORSEO_GET_BACKLINKS",
     description:
       "[ASYNC - Detailed Backlinks] Get paginated detailed list of individual backlinks pointing to a domain or URL. Returns source URL, anchor text, dofollow/nofollow status, domain rank, first seen date, and more. Use limit/offset for pagination (max 1000 per request). Takes 3-8 seconds. Cost: ~0.05 credits per request. Available in all plans.",
     inputSchema: backlinksInputSchema,
     outputSchema: backlinksOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       logToolExecution("DATAFORSEO_GET_BACKLINKS", env);
       const client = getClientFromEnv(env);
       const result = await client.getBacklinks(
@@ -48,13 +50,14 @@ export const createBacklinksTool = (env: Env) =>
   });
 
 export const createReferringDomainsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DATAFORSEO_GET_REFERRING_DOMAINS",
     description:
       "[ASYNC - Referring Domains] Get paginated list of unique domains that link to the target domain/URL. Returns domain name, domain rank, total backlinks from that domain, dofollow/nofollow counts, and first seen date. Use limit/offset for pagination (max 1000 per request). Takes 3-8 seconds. Cost: ~0.05 credits per request. Available in all plans.",
     inputSchema: referringDomainsInputSchema,
     outputSchema: referringDomainsOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       logToolExecution("DATAFORSEO_GET_REFERRING_DOMAINS", env);
       const client = getClientFromEnv(env);
       const result = await client.getReferringDomains(

--- a/data-for-seo/server/tools/domain-analysis.ts
+++ b/data-for-seo/server/tools/domain-analysis.ts
@@ -1,7 +1,7 @@
 import type { Env } from "../types/env.ts";
 import { logToolExecution, logToolSuccess } from "./_helpers.ts";
 import { getClientFromEnv } from "../lib/dataforseo.ts";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import {
   rankedKeywordsInputSchema,
   rankedKeywordsOutputSchema,
@@ -12,13 +12,14 @@ import {
 } from "./schemas.ts";
 
 export const createRankedKeywordsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DATAFORSEO_RANKED_KEYWORDS",
     description:
       "[ASYNC - DataForSEO Labs] Get ALL keywords a domain ranks for in Google, with positions, search volume, and estimated traffic. Perfect for competitive analysis and discovering keyword opportunities. Response time: 5-15 seconds. Cost: ~0.02 credits per request (excellent value for comprehensive keyword data!).",
     inputSchema: rankedKeywordsInputSchema,
     outputSchema: rankedKeywordsOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       logToolExecution("DATAFORSEO_RANKED_KEYWORDS", env);
       const client = getClientFromEnv(env);
       const result = await client.getRankedKeywords(
@@ -36,13 +37,14 @@ export const createRankedKeywordsTool = (env: Env) =>
   });
 
 export const createDomainRankTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DATAFORSEO_DOMAIN_RANK",
     description:
       "[ASYNC - DataForSEO Labs] Get comprehensive domain authority metrics including rank score, total organic keywords count, estimated traffic, and visibility metrics. Complements backlinks data with overall domain authority assessment. Response time: 2-5 seconds. Cost: ~0.01 credits per request (very affordable!).",
     inputSchema: domainRankInputSchema,
     outputSchema: domainRankOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       logToolExecution("DATAFORSEO_DOMAIN_RANK", env);
       const client = getClientFromEnv(env);
       const result = await client.getDomainRank(context.target);
@@ -52,13 +54,14 @@ export const createDomainRankTool = (env: Env) =>
   });
 
 export const createCompetitorsDomainTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DATAFORSEO_COMPETITORS_DOMAIN",
     description:
       "[ASYNC - DataForSEO Labs] Automatically discover competitor domains based on common keyword rankings. Returns domains that compete for the same keywords with metrics on keyword overlap, estimated traffic, and competitive strength. Perfect for competitive intelligence and market analysis. Response time: 5-12 seconds. Cost: ~0.05 credits per request (great value for automated competitor discovery!).",
     inputSchema: competitorsDomainInputSchema,
     outputSchema: competitorsDomainOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       logToolExecution("DATAFORSEO_COMPETITORS_DOMAIN", env);
       const client = getClientFromEnv(env);
       const result = await client.getCompetitorsDomain(

--- a/data-for-seo/server/tools/google-trends.ts
+++ b/data-for-seo/server/tools/google-trends.ts
@@ -1,7 +1,7 @@
 import type { Env } from "../types/env.ts";
 import { logToolExecution, logToolSuccess } from "./_helpers.ts";
 import { getClientFromEnv } from "../lib/dataforseo.ts";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import {
   googleTrendsInputSchema,
   googleTrendsOutputSchema,
@@ -10,13 +10,14 @@ import {
 } from "./schemas.ts";
 
 export const createGoogleTrendsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DATAFORSEO_GOOGLE_TRENDS",
     description:
       "[ASYNC] Get Google Trends data for up to 5 keywords including interest over time, regional interest, and related queries. Perfect for tracking keyword popularity trends and seasonal patterns. Response time: 3-8 seconds. Available in all DataForSEO plans. Cost: ~0.01 credits per request (very affordable!).",
     inputSchema: googleTrendsInputSchema,
     outputSchema: googleTrendsOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       logToolExecution("DATAFORSEO_GOOGLE_TRENDS", env);
       const client = getClientFromEnv(env);
       const result = await client.getGoogleTrends(
@@ -32,13 +33,14 @@ export const createGoogleTrendsTool = (env: Env) =>
   });
 
 export const createKeywordDifficultyTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DATAFORSEO_KEYWORD_DIFFICULTY",
     description:
       "[ASYNC - DataForSEO Labs] Get keyword difficulty scores (0-100) for up to 100 keywords at once. Returns difficulty score, competitive metrics, and ranking data. Lower score = easier to rank. Response time: 3-10 seconds. Uses DataForSEO Labs API. Cost: ~0.05 credits per keyword (excellent value for competitive analysis!).",
     inputSchema: keywordDifficultyInputSchema,
     outputSchema: keywordDifficultyOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       logToolExecution("DATAFORSEO_KEYWORD_DIFFICULTY", env);
       const client = getClientFromEnv(env);
       const result = await client.getKeywordDifficulty(

--- a/data-for-seo/server/tools/keyword-suggestions.ts
+++ b/data-for-seo/server/tools/keyword-suggestions.ts
@@ -1,7 +1,7 @@
 import type { Env } from "../types/env.ts";
 import { logToolExecution, logToolSuccess } from "./_helpers.ts";
 import { getClientFromEnv } from "../lib/dataforseo.ts";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import {
   keywordSuggestionsInputSchema,
   keywordSuggestionsOutputSchema,
@@ -10,13 +10,14 @@ import {
 } from "./schemas.ts";
 
 export const createKeywordSuggestionsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DATAFORSEO_KEYWORD_SUGGESTIONS",
     description:
       "[ASYNC] Get keyword suggestions from Google Autocomplete with search volume data. Returns actual suggestions that users see when typing in Google search. Perfect for discovering long-tail keywords and understanding user search intent. Response time: 2-5 seconds. Cost: ~0.003 credits per request (extremely affordable!).",
     inputSchema: keywordSuggestionsInputSchema,
     outputSchema: keywordSuggestionsOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       logToolExecution("DATAFORSEO_KEYWORD_SUGGESTIONS", env);
       const client = getClientFromEnv(env);
       const result = await client.getKeywordSuggestions(
@@ -33,13 +34,14 @@ export const createKeywordSuggestionsTool = (env: Env) =>
   });
 
 export const createKeywordIdeasTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DATAFORSEO_KEYWORD_IDEAS",
     description:
       "[ASYNC] Get keyword ideas based on 1-5 seed keywords using Google's internal keyword matching algorithm. Returns related keywords with search volume, competition level, and CPC data. Alternative to Related Keywords with different matching logic. Response time: 3-8 seconds. Cost: ~0.003 credits per request (very cheap alternative to Related Keywords!).",
     inputSchema: keywordIdeasInputSchema,
     outputSchema: keywordIdeasOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       logToolExecution("DATAFORSEO_KEYWORD_IDEAS", env);
       const client = getClientFromEnv(env);
       const result = await client.getKeywordIdeas(

--- a/data-for-seo/server/tools/keywords.ts
+++ b/data-for-seo/server/tools/keywords.ts
@@ -1,6 +1,6 @@
 import type { Env } from "../types/env.ts";
 import { getClientFromEnv } from "../lib/dataforseo.ts";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import {
   searchVolumeInputSchema,
   searchVolumeOutputSchema,
@@ -10,13 +10,14 @@ import {
 import { logToolExecution, logToolSuccess } from "./_helpers.ts";
 
 export const createSearchVolumeTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DATAFORSEO_GET_SEARCH_VOLUME",
     description:
       "[ASYNC] Get search volume, CPC, and competition data for up to 1000 keywords at once. Returns detailed metrics including monthly search trends, competition level, and cost-per-click. This is a live API call that takes 2-5 seconds. Available in all DataForSEO plans. Cost: ~0.002 credits per keyword.",
     inputSchema: searchVolumeInputSchema,
     outputSchema: searchVolumeOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       logToolExecution("DATAFORSEO_GET_SEARCH_VOLUME", env);
       const client = getClientFromEnv(env);
       const result = await client.getSearchVolume(
@@ -32,13 +33,14 @@ export const createSearchVolumeTool = (env: Env) =>
   });
 
 export const createRelatedKeywordsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DATAFORSEO_GET_RELATED_KEYWORDS",
     description:
       "[ASYNC - DataForSEO Labs] Get keyword suggestions related to a seed keyword with semantic and contextual relationships. Returns up to 1000 related terms with search volume, competition, and SERP data. This uses DataForSEO Labs API which may have higher costs. Takes 3-10 seconds depending on depth parameter. Cost: ~0.1 credits per request.",
     inputSchema: relatedKeywordsInputSchema,
     outputSchema: relatedKeywordsOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       logToolExecution("DATAFORSEO_GET_RELATED_KEYWORDS", env);
       const client = getClientFromEnv(env);
       const result = await client.getRelatedKeywords(

--- a/data-for-seo/server/tools/serp.ts
+++ b/data-for-seo/server/tools/serp.ts
@@ -1,7 +1,7 @@
 import type { Env } from "../types/env.ts";
 import { logToolExecution, logToolSuccess } from "./_helpers.ts";
 import { getClientFromEnv } from "../lib/dataforseo.ts";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import {
   organicSerpInputSchema,
   organicSerpOutputSchema,
@@ -12,13 +12,14 @@ import {
 } from "./schemas.ts";
 
 export const createOrganicSerpTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DATAFORSEO_GET_ORGANIC_SERP",
     description:
       "[ASYNC - Live SERP] Get real-time organic search results from Google. Returns detailed SERP data including rankings, URLs, titles, descriptions, and SERP features (featured snippets, knowledge panels, etc.). Specify device (desktop/mobile) and depth (number of results). Takes 3-8 seconds for live results. Cost: ~0.003 credits per request. Available in all plans.",
     inputSchema: organicSerpInputSchema,
     outputSchema: organicSerpOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       logToolExecution("DATAFORSEO_GET_ORGANIC_SERP", env);
       const client = getClientFromEnv(env);
       const result = await client.getOrganicSerpLive(
@@ -34,13 +35,14 @@ export const createOrganicSerpTool = (env: Env) =>
   });
 
 export const createNewsSerpTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DATAFORSEO_GET_NEWS_SERP",
     description:
       "[ASYNC - Live SERP] Get real-time Google News results for a keyword. Returns news articles with titles, sources, timestamps, snippets, and thumbnail images. Filter by time range (1h, 1d, 1w, 1m, 1y) and sort by relevance or date. Takes 2-5 seconds. Cost: ~0.003 credits per request. Available in all plans.",
     inputSchema: newsSerpInputSchema,
     outputSchema: newsSerpOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       logToolExecution("DATAFORSEO_GET_NEWS_SERP", env);
       const client = getClientFromEnv(env);
       const result = await client.getNewsSerpLive(
@@ -56,13 +58,14 @@ export const createNewsSerpTool = (env: Env) =>
   });
 
 export const createHistoricalSerpTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DATAFORSEO_HISTORICAL_SERP",
     description:
       "[ASYNC - DataForSEO Labs] Get historical SERP ranking data for a keyword over time. Shows how rankings changed for top domains, useful for analyzing algorithm updates, seasonal trends, and SERP volatility. Supports custom date ranges (default: last 30 days). Response time: 5-12 seconds. Cost: ~0.05 credits per request (valuable for trend analysis!).",
     inputSchema: historicalSerpInputSchema,
     outputSchema: historicalSerpOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       logToolExecution("DATAFORSEO_HISTORICAL_SERP", env);
       const client = getClientFromEnv(env);
       const result = await client.getHistoricalSerp(

--- a/data-for-seo/tsconfig.json
+++ b/data-for-seo/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],

--- a/datajud/package.json
+++ b/datajud/package.json
@@ -13,7 +13,7 @@
     "build": "bun --bun vite build"
   },
   "dependencies": {
-    "@decocms/runtime": "0.25.1",
+    "@decocms/runtime": "1.4.0",
     "zod": "^3.24.3"
   },
   "devDependencies": {

--- a/datajud/server/tools/datajud.ts
+++ b/datajud/server/tools/datajud.ts
@@ -8,7 +8,7 @@
  */
 import type { Env } from "../main.ts";
 import { createDatajudClient } from "./utils/datajud.ts";
-import { createPrivateTool } from "@decocms/runtime/mastra";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import {
   searchProcessesInputSchema,
   searchProcessesOutputSchema,
@@ -35,13 +35,14 @@ function resolveTribunal(
  * SEARCH_PROCESSES - Search processes in Datajud with filters
  */
 export const createSearchProcessesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "SEARCH_PROCESSES",
     description:
       "Search judicial processes in Datajud with filters. Allows filtering by class, subject, court, filing date, and other fields from the Data Transfer Model (MTD). Returns a list of processes with their metadata.",
     inputSchema: searchProcessesInputSchema,
     outputSchema: searchProcessesOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { tribunal: customTribunal, filters, size, from, sort } = context;
       const state = env.DECO_REQUEST_CONTEXT.state;
 
@@ -79,13 +80,14 @@ export const createSearchProcessesTool = (env: Env) =>
  * GET_PROCESS - Search for a specific process by number
  */
 export const createGetProcessTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "GET_PROCESS",
     description:
       "Search for a specific judicial process by process number in Datajud. Returns all available process metadata, including class, subjects, movements, court, etc.",
     inputSchema: getProcessInputSchema,
     outputSchema: getProcessOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { tribunal: customTribunal, numeroProcesso } = context;
       const state = env.DECO_REQUEST_CONTEXT.state;
 
@@ -117,13 +119,14 @@ export const createGetProcessTool = (env: Env) =>
  * AGGREGATE_STATISTICS - Execute aggregations and generate statistics
  */
 export const createAggregateStatisticsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "AGGREGATE_STATISTICS",
     description:
       "Execute aggregations and generate statistics about judicial processes in Datajud. Allows calculating counts, averages, sums, and other metrics grouped by fields such as class, subject, court, filing year, etc. Uses Elasticsearch aggregation syntax.",
     inputSchema: aggregateStatisticsInputSchema,
     outputSchema: aggregateStatisticsOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { tribunal: customTribunal, aggregations, filters } = context;
       const state = env.DECO_REQUEST_CONTEXT.state;
 

--- a/datajud/tsconfig.json
+++ b/datajud/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],

--- a/deco-llm/package.json
+++ b/deco-llm/package.json
@@ -15,7 +15,7 @@
     "@ai-sdk/provider": "^3.0.2",
     "@ai-sdk/provider-utils": "^4.0.4",
     "@decocms/bindings": "^1.1.1",
-    "@decocms/runtime": "1.1.3",
+    "@decocms/runtime": "1.4.0",
     "@openrouter/ai-sdk-provider": "^1.5.4",
     "@openrouter/sdk": "^0.3.11",
     "ai": "^6.0.3",

--- a/deco-llm/server/main.ts
+++ b/deco-llm/server/main.ts
@@ -57,7 +57,6 @@ const runtime = withRuntime<
   Registry
 >({
   tools: (env) => {
-    // @ts-expect-error: TODO: fix this later
     return tools(env, {
       start: async (modelInfo, params) => {
         const amount = calculatePreAuthAmount(modelInfo, params);

--- a/deco-llm/tsconfig.json
+++ b/deco-llm/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "ES2024", "DOM", "DOM.Iterable"],

--- a/deco-news-weekly-digest/package.json
+++ b/deco-news-weekly-digest/package.json
@@ -14,7 +14,7 @@
     "build": "bun run build:server"
   },
   "dependencies": {
-    "@decocms/runtime": "1.1.3",
+    "@decocms/runtime": "1.4.0",
     "@supabase/supabase-js": "^2.49.0",
     "zod": "^4.0.0"
   },

--- a/deco-news-weekly-digest/server/tools/skills.ts
+++ b/deco-news-weekly-digest/server/tools/skills.ts
@@ -5,7 +5,7 @@
  */
 
 import { z } from "zod";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import type { Env } from "../types/env.ts";
 import { BLOG_POSTS_SKILL } from "../skills/blog-posts.ts";
 
@@ -13,7 +13,7 @@ import { BLOG_POSTS_SKILL } from "../skills/blog-posts.ts";
  * GET_BLOG_POST_SKILL - Returns the complete guide for writing weekly digest articles
  */
 export const getBlogPostSkillTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "GET_BLOG_POST_SKILL",
     description:
       "Returns the complete guide for creating weekly digest articles for decoNews. " +
@@ -43,7 +43,8 @@ export const getBlogPostSkillTool = (_env: Env) =>
         .describe("The weekly digest writing skill/guide content"),
       section: z.string().describe("The section that was returned"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { section } = context;
 
       if (section === "all") {

--- a/deco-news-weekly-digest/server/tools/weekly-digest.ts
+++ b/deco-news-weekly-digest/server/tools/weekly-digest.ts
@@ -5,7 +5,7 @@
  */
 
 import { z } from "zod";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import type { Env } from "../types/env.ts";
 import { createDatabaseClient, type DatabaseClient } from "../lib/db-client.ts";
 
@@ -109,7 +109,7 @@ function getDbClient(env: Env): {
  * LIST_WEEKLY_DIGEST - Lists articles from the weekly digest
  */
 export const listWeeklyDigestTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "LIST_WEEKLY_DIGEST",
     description:
       "Lists articles from the deco weekly digest. " +
@@ -148,7 +148,8 @@ export const listWeeklyDigestTool = (env: Env) =>
       totalCount: z.number().optional(),
       error: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const {
         limit,
         offset,
@@ -227,7 +228,7 @@ export const listWeeklyDigestTool = (env: Env) =>
  * SAVE_WEEKLY_DIGEST_ARTICLE - Creates a new article in the weekly digest
  */
 export const saveWeeklyDigestArticleTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "SAVE_WEEKLY_DIGEST_ARTICLE",
     description:
       "Saves a new article to the deco weekly digest. " +
@@ -278,7 +279,8 @@ export const saveWeeklyDigestArticleTool = (env: Env) =>
       article: ArticleSchema.optional(),
       error: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { client, error } = getDbClient(env);
       if (!client) {
         return { success: false, error: error! };
@@ -364,7 +366,7 @@ export const saveWeeklyDigestArticleTool = (env: Env) =>
  * UPDATE_WEEKLY_DIGEST_ARTICLE - Updates an existing article
  */
 export const updateWeeklyDigestArticleTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "UPDATE_WEEKLY_DIGEST_ARTICLE",
     description:
       "Updates an existing article in the deco weekly digest. " +
@@ -399,7 +401,8 @@ export const updateWeeklyDigestArticleTool = (env: Env) =>
       article: ArticleSchema.optional(),
       error: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { id, url, updates } = context;
 
       if (!id && !url) {
@@ -482,7 +485,7 @@ export const updateWeeklyDigestArticleTool = (env: Env) =>
  * GET_WEEKLY_DIGEST_ARTICLE - Gets a single article by ID, URL, or slug
  */
 export const getWeeklyDigestArticleTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "GET_WEEKLY_DIGEST_ARTICLE",
     description:
       "Gets a single article from the deco weekly digest by ID, URL, or slug.",
@@ -496,7 +499,8 @@ export const getWeeklyDigestArticleTool = (env: Env) =>
       article: ArticleSchema.optional(),
       error: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { id, url, slug } = context;
 
       if (!id && !url && !slug) {
@@ -558,7 +562,7 @@ export const getWeeklyDigestArticleTool = (env: Env) =>
  * DELETE_WEEKLY_DIGEST_ARTICLE - Deletes an article by ID or URL
  */
 export const deleteWeeklyDigestArticleTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DELETE_WEEKLY_DIGEST_ARTICLE",
     description: "Deletes an article from the deco weekly digest by ID or URL.",
     inputSchema: z.object({
@@ -570,7 +574,8 @@ export const deleteWeeklyDigestArticleTool = (env: Env) =>
       message: z.string().optional(),
       error: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { id, url } = context;
 
       if (!id && !url) {
@@ -629,7 +634,7 @@ export const deleteWeeklyDigestArticleTool = (env: Env) =>
  * PUBLISH_WEEKLY_DIGEST_ARTICLE - Publishes an article (changes status to published)
  */
 export const publishWeeklyDigestArticleTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "PUBLISH_WEEKLY_DIGEST_ARTICLE",
     description:
       "Publishes an article in the deco weekly digest. " +
@@ -643,7 +648,8 @@ export const publishWeeklyDigestArticleTool = (env: Env) =>
       article: ArticleSchema.optional(),
       error: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { id, url } = context;
 
       if (!id && !url) {

--- a/deco-news-weekly-digest/tsconfig.json
+++ b/deco-news-weekly-digest/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023"],

--- a/discord-read/package.json
+++ b/discord-read/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@decocms/bindings": "^1.0.8",
-    "@decocms/runtime": "^1.3.0",
+    "@decocms/runtime": "1.4.0",
     "@discordjs/voice": "^0.19.0",
     "@supabase/supabase-js": "^2.47.10",
     "discord.js": "14.25.1",

--- a/discord-read/server/tools/bot.ts
+++ b/discord-read/server/tools/bot.ts
@@ -6,7 +6,7 @@
  * All operations are scoped to the calling connection (multi-tenant).
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../types/env.ts";
 import { isBotRunning, shutdownBot } from "../bot-manager.ts";
@@ -16,7 +16,7 @@ import { getDiscordClient } from "../discord/client.ts";
  * Stop the Discord bot
  */
 export const createStopBotTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_BOT_STOP",
     description: "Stop the Discord bot and disconnect from Discord Gateway.",
     annotations: { destructiveHint: true },
@@ -52,7 +52,7 @@ export const createStopBotTool = (env: Env) =>
  * Get bot status
  */
 export const createBotStatusTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_BOT_STATUS",
     description:
       "Get the current status of the Discord bot (running, stopped, guilds, etc.)",

--- a/discord-read/server/tools/config.ts
+++ b/discord-read/server/tools/config.ts
@@ -4,7 +4,7 @@
  * Tools for saving and managing Discord bot configuration.
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../types/env.ts";
 import {
@@ -21,7 +21,7 @@ import { isSupabaseConfigured } from "../lib/supabase-client.ts";
  * Save Discord bot configuration
  */
 export const createSaveConfigTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_SAVE_CONFIG",
     description:
       "Save Discord bot configuration (token, authorized guilds, AI model settings). This persists configuration so you don't need to provide the token again.",
@@ -160,7 +160,7 @@ export const createSaveConfigTool = (env: Env) =>
  * Update Discord bot configuration (partial update)
  */
 export const createUpdateConfigTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_UPDATE_CONFIG",
     description:
       "Update specific fields in Discord bot configuration without needing to provide all fields. Use this to update system prompt, model settings, etc.",
@@ -282,7 +282,7 @@ export const createUpdateConfigTool = (env: Env) =>
  * Load Discord bot configuration
  */
 export const createLoadConfigTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_LOAD_CONFIG",
     description:
       "Load saved Discord bot configuration from Supabase. Returns the stored bot token and settings.",
@@ -365,7 +365,7 @@ export const createLoadConfigTool = (env: Env) =>
  * Delete Discord bot configuration
  */
 export const createDeleteConfigTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_DELETE_CONFIG",
     description:
       "Delete saved Discord bot configuration from Supabase. This will remove the stored token and settings.",
@@ -409,7 +409,7 @@ export const createDeleteConfigTool = (env: Env) =>
  * Get cache statistics
  */
 export const createCacheStatsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_CONFIG_CACHE_STATS",
     description: "Get Discord configuration cache statistics",
     annotations: { readOnlyHint: true },
@@ -422,7 +422,8 @@ export const createCacheStatsTool = (env: Env) =>
         ttl: z.number(),
       })
       .strict(),
-    execute: async () => {
+    execute: async (_input, ctx) => {
+      ensureAuthenticated(ctx!);
       return getCacheStats();
     },
   });
@@ -431,7 +432,7 @@ export const createCacheStatsTool = (env: Env) =>
  * Clear configuration cache
  */
 export const createClearCacheTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_CONFIG_CLEAR_CACHE",
     description:
       "Clear Discord configuration cache. Forces reload from Supabase on next access.",
@@ -443,7 +444,8 @@ export const createClearCacheTool = (env: Env) =>
         message: z.string(),
       })
       .strict(),
-    execute: async () => {
+    execute: async (_input, ctx) => {
+      ensureAuthenticated(ctx!);
       clearConfigCache();
       return {
         success: true,
@@ -460,7 +462,7 @@ export const createClearCacheTool = (env: Env) =>
  * "session expired" problem.
  */
 export const createGenerateApiKeyTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_GENERATE_API_KEY",
     description:
       "Generate a persistent Mesh API Key for this Discord bot. This solves the 'session expired' problem by creating a key that never expires. The bot will automatically use this key for LLM and other API calls.",

--- a/discord-read/server/tools/database.ts
+++ b/discord-read/server/tools/database.ts
@@ -5,7 +5,7 @@
  * Only accesses data from the current connection/organization.
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../types/env.ts";
 import { getSupabaseClient } from "../lib/supabase-client.ts";
@@ -16,7 +16,7 @@ import { invalidateAutoRespondCache } from "../discord/client.ts";
  * Query Discord messages (read-only, scoped to connection)
  */
 export const createQueryMessagesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_QUERY_MESSAGES",
     description:
       "Query Discord messages from the database. Only returns messages from guilds this bot has access to. Useful for searching message history, deleted messages, edit history, etc.",
@@ -160,7 +160,7 @@ export const createQueryMessagesTool = (env: Env) =>
  * Query Discord guilds (read-only)
  */
 export const createQueryGuildsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_QUERY_GUILDS",
     description: "Query Discord guilds (servers) from the database.",
     annotations: { readOnlyHint: true },
@@ -183,7 +183,8 @@ export const createQueryGuildsTool = (env: Env) =>
         message: z.string().optional(),
       })
       .strict(),
-    execute: async () => {
+    execute: async (_input, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = getSupabaseClient();
       if (!client) {
         return {
@@ -229,7 +230,7 @@ export const createQueryGuildsTool = (env: Env) =>
  * Query message statistics
  */
 export const createMessageStatsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_MESSAGE_STATS",
     description:
       "Get statistics about Discord messages (total, by channel, by author, etc.)",
@@ -334,7 +335,7 @@ export const createMessageStatsTool = (env: Env) =>
  * Query channel contexts (custom prompts per channel)
  */
 export const createQueryChannelContextsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_QUERY_CHANNEL_CONTEXTS",
     description:
       "Query channel contexts (custom system prompts and auto-respond settings) from the database.",
@@ -426,7 +427,7 @@ export const createQueryChannelContextsTool = (env: Env) =>
  * Set channel auto-respond setting
  */
 export const createSetChannelAutoRespondTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_SET_CHANNEL_AUTO_RESPOND",
     description:
       "Enable or disable auto-respond for a channel. When enabled, the bot will respond to ALL messages in the channel without needing to be mentioned.",

--- a/discord-read/server/tools/slash-commands.ts
+++ b/discord-read/server/tools/slash-commands.ts
@@ -5,7 +5,7 @@
  * Commands are stored in Supabase and registered with Discord API.
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import z from "zod";
 import type { Env } from "../types/env.ts";
 import { getSupabaseClient } from "../lib/supabase-client.ts";
@@ -240,7 +240,7 @@ async function deleteCommandFromDiscord(params: {
 // ============================================================================
 
 export const createListSlashCommandsTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_LIST_SLASH_COMMANDS",
     description:
       "List slash commands from database, Discord API, or both. Use 'source' parameter to choose.",
@@ -509,7 +509,7 @@ export const createListSlashCommandsTool = (_env: Env) =>
 // ============================================================================
 
 export const createRegisterSlashCommandTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_REGISTER_SLASH_COMMAND",
     description:
       "Register a new slash command with Discord. The command will be saved to database and registered with Discord API.",
@@ -651,7 +651,7 @@ export const createRegisterSlashCommandTool = (_env: Env) =>
 // ============================================================================
 
 export const createDeleteSlashCommandTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_DELETE_SLASH_COMMAND",
     description:
       "Delete a slash command from Discord and database. Use the command ID from DISCORD_LIST_SLASH_COMMANDS.",
@@ -761,7 +761,7 @@ export const createDeleteSlashCommandTool = (_env: Env) =>
 // ============================================================================
 
 export const createToggleSlashCommandTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_TOGGLE_SLASH_COMMAND",
     description:
       "Enable or disable a slash command. Disabled commands are not deleted but won't be processed.",
@@ -834,7 +834,7 @@ export const createToggleSlashCommandTool = (_env: Env) =>
 // ============================================================================
 
 export const createSyncSlashCommandsTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DISCORD_SYNC_SLASH_COMMANDS",
     description:
       "Sync slash commands between Discord API and database. Can import missing commands from Discord to DB, or clean orphaned commands from DB.",

--- a/farmrio-reorder-collection-db/package.json
+++ b/farmrio-reorder-collection-db/package.json
@@ -11,7 +11,7 @@
     "build": "bun run build:server"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "kysely": "^0.28.11",
     "pg": "^8.19.0",
     "zod": "^4.0.0"

--- a/farmrio-reorder-collection-db/server/tools/collections/collection-create.ts
+++ b/farmrio-reorder-collection-db/server/tools/collections/collection-create.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import z from "zod";
 import { getDb } from "../../database/index.ts";
 import type { CollectionInsert } from "../../database/schema.ts";
@@ -28,12 +28,13 @@ const outputSchema = z
   .strict();
 
 export const collectionCreateTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "collection_create",
     description: "Cria uma nova collection.",
     inputSchema,
     outputSchema,
-    execute: async ({ context }: { context: unknown }) => {
+    execute: async ({ context }: { context: unknown }, ctx) => {
+      ensureAuthenticated(ctx!);
       try {
         validateToken(env);
         const input = inputSchema.parse(context);

--- a/farmrio-reorder-collection-db/server/tools/collections/collection-get.ts
+++ b/farmrio-reorder-collection-db/server/tools/collections/collection-get.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import z from "zod";
 import { getDb } from "../../database/index.ts";
 import type { Env } from "../../types/env.ts";
@@ -24,13 +24,14 @@ const outputSchema = z
   .strict();
 
 export const collectionGetTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "collection_get",
     description:
       "Busca uma collection pelo farm_collection_id (identificador VTEX/Farm).",
     inputSchema,
     outputSchema,
-    execute: async ({ context }: { context: unknown }) => {
+    execute: async ({ context }: { context: unknown }, ctx) => {
+      ensureAuthenticated(ctx!);
       try {
         validateToken(env);
         const input = inputSchema.parse(context);

--- a/farmrio-reorder-collection-db/server/tools/collections/collection-list.ts
+++ b/farmrio-reorder-collection-db/server/tools/collections/collection-list.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import z from "zod";
 import { getDb } from "../../database/index.ts";
 import type { Env } from "../../types/env.ts";
@@ -27,12 +27,13 @@ const outputSchema = z
   .strict();
 
 export const collectionListTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "collection_list",
     description: "Lista collections com filtros opcionais.",
     inputSchema,
     outputSchema,
-    execute: async ({ context }: { context: unknown }) => {
+    execute: async ({ context }: { context: unknown }, ctx) => {
+      ensureAuthenticated(ctx!);
       try {
         validateToken(env);
         const input = inputSchema.parse(context);

--- a/farmrio-reorder-collection-db/server/tools/collections/collection-update.ts
+++ b/farmrio-reorder-collection-db/server/tools/collections/collection-update.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import z from "zod";
 import { getDb } from "../../database/index.ts";
 import type { CollectionUpdate } from "../../database/schema.ts";
@@ -35,13 +35,14 @@ const outputSchema = z
   .strict();
 
 export const collectionUpdateTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "collection_update",
     description:
       "Atualiza uma collection existente pelo farm_collection_id (identificador VTEX/Farm).",
     inputSchema,
     outputSchema,
-    execute: async ({ context }: { context: unknown }) => {
+    execute: async ({ context }: { context: unknown }, ctx) => {
+      ensureAuthenticated(ctx!);
       try {
         validateToken(env);
         const input = inputSchema.parse(context);

--- a/farmrio-reorder-collection-db/server/tools/reports/report-create.ts
+++ b/farmrio-reorder-collection-db/server/tools/reports/report-create.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import z from "zod";
 import { getDb } from "../../database/index.ts";
 import type { ReportInsert } from "../../database/schema.ts";
@@ -31,13 +31,14 @@ const outputSchema = z
   .strict();
 
 export const reportCreateTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "report_create",
     description:
       "Cria um novo report. Use report_section_save para adicionar seções após criar o report.",
     inputSchema,
     outputSchema,
-    execute: async ({ context }: { context: unknown }) => {
+    execute: async ({ context }: { context: unknown }, ctx) => {
+      ensureAuthenticated(ctx!);
       try {
         validateToken(env);
         const input = inputSchema.parse(context);

--- a/farmrio-reorder-collection-db/server/tools/reports/report-get.ts
+++ b/farmrio-reorder-collection-db/server/tools/reports/report-get.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import z from "zod";
 import { getDb } from "../../database/index.ts";
 import type { Env } from "../../types/env.ts";
@@ -25,13 +25,14 @@ const outputSchema = z
   .strict();
 
 export const reportGetTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "report_get",
     description:
       "Busca um report por id, incluindo todas as seções e seus itens.",
     inputSchema,
     outputSchema,
-    execute: async ({ context }: { context: unknown }) => {
+    execute: async ({ context }: { context: unknown }, ctx) => {
+      ensureAuthenticated(ctx!);
       try {
         validateToken(env);
         const input = inputSchema.parse(context);

--- a/farmrio-reorder-collection-db/server/tools/reports/report-list.ts
+++ b/farmrio-reorder-collection-db/server/tools/reports/report-list.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import z from "zod";
 import { getDb } from "../../database/index.ts";
 import type { Env } from "../../types/env.ts";
@@ -29,12 +29,13 @@ const outputSchema = z
   .strict();
 
 export const reportListTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "report_list",
     description: "Lista reports com filtros opcionais.",
     inputSchema,
     outputSchema,
-    execute: async ({ context }: { context: unknown }) => {
+    execute: async ({ context }: { context: unknown }, ctx) => {
+      ensureAuthenticated(ctx!);
       try {
         validateToken(env);
         const input = inputSchema.parse(context);

--- a/farmrio-reorder-collection-db/server/tools/reports/report-section-save.ts
+++ b/farmrio-reorder-collection-db/server/tools/reports/report-section-save.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import z from "zod";
 import { getDb } from "../../database/index.ts";
 import type { Env } from "../../types/env.ts";
@@ -26,13 +26,14 @@ const outputSchema = z
   .strict();
 
 export const reportSectionSaveTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "report_section_save",
     description:
       "Substitui todas as seções de um report. Apaga as seções existentes e insere as novas com seus itens (criteria, metrics, ranked-list ou note).",
     inputSchema,
     outputSchema,
-    execute: async ({ context }: { context: unknown }) => {
+    execute: async ({ context }: { context: unknown }, ctx) => {
+      ensureAuthenticated(ctx!);
       try {
         validateToken(env);
         const input = inputSchema.parse(context);

--- a/farmrio-reorder-collection-db/server/tools/reports/report-update.ts
+++ b/farmrio-reorder-collection-db/server/tools/reports/report-update.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import z from "zod";
 import { getDb } from "../../database/index.ts";
 import type { ReportUpdate } from "../../database/schema.ts";
@@ -41,12 +41,13 @@ const outputSchema = z
   .strict();
 
 export const reportUpdateTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "report_update",
     description: "Atualiza campos de um report existente.",
     inputSchema,
     outputSchema,
-    execute: async ({ context }: { context: unknown }) => {
+    execute: async ({ context }: { context: unknown }, ctx) => {
+      ensureAuthenticated(ctx!);
       try {
         validateToken(env);
         const input = inputSchema.parse(context);

--- a/farmrio-reorder-collection-db/tsconfig.json
+++ b/farmrio-reorder-collection-db/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "ES2024"],

--- a/flux/package.json
+++ b/flux/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/flux/server/tools/generate.ts
+++ b/flux/server/tools/generate.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { getFluxApiKey } from "../lib/env.ts";
@@ -17,7 +17,7 @@ const FluxModels = [
 ] as const;
 
 export const createSubmitImageTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "submit_image",
     description:
       "Submit an image generation request using FLUX models from Black Forest Labs. Returns a request_id immediately — use get_image_result to poll for the result.",
@@ -98,7 +98,8 @@ export const createSubmitImageTool = (env: Env) =>
         ),
       model: z.string().describe("The model used for generation"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const apiKey = getFluxApiKey(env);
       const client = createFluxClient({ apiKey });
       const model = context.model ?? "flux-kontext-max";
@@ -135,7 +136,7 @@ export const createSubmitImageTool = (env: Env) =>
   });
 
 export const createGetImageResultTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_image_result",
     description:
       "Check the status of a FLUX image generation request. Returns the current status and, when ready, the image URL (valid for 10 minutes — download it promptly). Poll this tool until status is 'Ready'. Stop polling if status is 'Error', 'Task not found', 'Request Moderated', or 'Content Moderated' — these are terminal failures.",
@@ -161,7 +162,8 @@ export const createGetImageResultTool = (env: Env) =>
         .optional()
         .describe("Generation progress (0-1), available while Pending"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const apiKey = getFluxApiKey(env);
       const client = createFluxClient({ apiKey });
 

--- a/flux/tsconfig.json
+++ b/flux/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "ES2024", "DOM", "DOM.Iterable"],

--- a/gemini-pro-vision/package.json
+++ b/gemini-pro-vision/package.json
@@ -13,7 +13,7 @@
     "build": "bun --bun vite build"
   },
   "dependencies": {
-    "@decocms/runtime": "0.24.0",
+    "@decocms/runtime": "1.4.0",
     "zod": "^3.24.3"
   },
   "devDependencies": {

--- a/gemini-pro-vision/tsconfig.json
+++ b/gemini-pro-vision/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],

--- a/github-repo-reports/package.json
+++ b/github-repo-reports/package.json
@@ -11,7 +11,7 @@
     "build": "bun run build:server"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "@octokit/rest": "^22.0.1",
     "yaml": "^2.8.2",
     "zod": "^4.0.0"

--- a/github-repo-reports/server/tools/reports-get.ts
+++ b/github-repo-reports/server/tools/reports-get.ts
@@ -6,7 +6,7 @@
  * and merges lifecycle status.
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../types/env.ts";
 import {
@@ -78,7 +78,7 @@ const ReportSectionSchema = z.discriminatedUnion("type", [
 ]);
 
 export const createReportsGetTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "REPORTS_GET",
     description:
       "Get a specific report with full content including all sections.",
@@ -99,7 +99,8 @@ export const createReportsGetTool = (env: Env) =>
       lifecycleStatus: z.enum(["unread", "read", "dismissed"]).optional(),
       sections: z.array(ReportSectionSchema),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const config = getRepoConfig(env);
       const client = getGitHubClient(env);
 

--- a/github-repo-reports/server/tools/reports-list.ts
+++ b/github-repo-reports/server/tools/reports-list.ts
@@ -6,7 +6,7 @@
  * parses YAML frontmatter for metadata, and merges lifecycle statuses.
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../types/env.ts";
 import {
@@ -25,7 +25,7 @@ import {
 const ReportStatusEnum = z.enum(["passing", "warning", "failing", "info"]);
 
 export const createReportsListTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "REPORTS_LIST",
     description:
       "List available reports with optional filters. Returns report summaries (metadata only, no sections).",
@@ -53,7 +53,8 @@ export const createReportsListTool = (env: Env) =>
         }),
       ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const config = getRepoConfig(env);
       const client = getGitHubClient(env);
 

--- a/github-repo-reports/server/tools/reports-update-status.ts
+++ b/github-repo-reports/server/tools/reports-update-status.ts
@@ -6,7 +6,7 @@
  * directory in the GitHub repository.
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../types/env.ts";
 import {
@@ -21,7 +21,7 @@ import {
 } from "../lib/report-parser.ts";
 
 export const createReportsUpdateStatusTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "REPORTS_UPDATE_STATUS",
     description:
       "Update the lifecycle status of a report (unread, read, or dismissed).",
@@ -35,7 +35,8 @@ export const createReportsUpdateStatusTool = (env: Env) =>
       success: z.boolean(),
       message: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const config = getRepoConfig(env);
       const client = getGitHubClient(env);
 

--- a/github-repo-reports/tsconfig.json
+++ b/github-repo-reports/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "ES2024"],

--- a/github/tsconfig.json
+++ b/github/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": [

--- a/google-apps-script/package.json
+++ b/google-apps-script/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/google-apps-script/server/tools/deployments.ts
+++ b/google-apps-script/server/tools/deployments.ts
@@ -1,7 +1,7 @@
 /**
  * Google Apps Script Deployments Tools
  */
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../../shared/deco.gen.ts";
 import { AppsScriptClient, getAccessToken } from "../lib/apps-script-client.ts";
@@ -10,7 +10,7 @@ import { AppsScriptClient, getAccessToken } from "../lib/apps-script-client.ts";
 // Create Deployment Tool
 // ============================================
 export const createCreateDeploymentTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_deployment",
     description:
       "Creates a deployment of an Apps Script project. A deployment makes a specific version accessible as a web app, API executable, or add-on.",
@@ -44,7 +44,8 @@ export const createCreateDeploymentTool = (env: Env) =>
         }),
       ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });
@@ -71,7 +72,7 @@ export const createCreateDeploymentTool = (env: Env) =>
 // Get Deployment Tool
 // ============================================
 export const createGetDeploymentTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_deployment",
     description:
       "Gets a specific deployment of an Apps Script project by deployment ID.",
@@ -91,7 +92,8 @@ export const createGetDeploymentTool = (env: Env) =>
         }),
       ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });
@@ -117,7 +119,7 @@ export const createGetDeploymentTool = (env: Env) =>
 // List Deployments Tool
 // ============================================
 export const createListDeploymentsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_deployments",
     description:
       "Lists all deployments of an Apps Script project. Returns deployment IDs, versions, and entry point URLs.",
@@ -150,7 +152,8 @@ export const createListDeploymentsTool = (env: Env) =>
       deploymentCount: z.number(),
       nextPageToken: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });
@@ -179,7 +182,7 @@ export const createListDeploymentsTool = (env: Env) =>
 // Update Deployment Tool
 // ============================================
 export const createUpdateDeploymentTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "update_deployment",
     description:
       "Updates a deployment of an Apps Script project. Can change the version number, description, or manifest file.",
@@ -208,7 +211,8 @@ export const createUpdateDeploymentTool = (env: Env) =>
       updateTime: z.string().optional(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });
@@ -238,7 +242,7 @@ export const createUpdateDeploymentTool = (env: Env) =>
 // Delete Deployment Tool
 // ============================================
 export const createDeleteDeploymentTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_deployment",
     description: "Deletes a deployment of an Apps Script project.",
     inputSchema: z.object({
@@ -249,7 +253,8 @@ export const createDeleteDeploymentTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });

--- a/google-apps-script/server/tools/processes.ts
+++ b/google-apps-script/server/tools/processes.ts
@@ -1,7 +1,7 @@
 /**
  * Google Apps Script Processes Tools (Monitoring)
  */
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../../shared/deco.gen.ts";
 import { AppsScriptClient, getAccessToken } from "../lib/apps-script-client.ts";
@@ -35,7 +35,7 @@ const ProcessStatusEnum = z.enum([
 // List User Processes Tool
 // ============================================
 export const createListUserProcessesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_user_processes",
     description:
       "Lists information about processes (script executions) made by or on behalf of the authenticated user across all scripts.",
@@ -87,7 +87,8 @@ export const createListUserProcessesTool = (env: Env) =>
       processCount: z.number(),
       nextPageToken: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });
@@ -124,7 +125,7 @@ export const createListUserProcessesTool = (env: Env) =>
 // List Script Processes Tool
 // ============================================
 export const createListScriptProcessesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_script_processes",
     description:
       "Lists information about processes (script executions) for a specific script project.",
@@ -173,7 +174,8 @@ export const createListScriptProcessesTool = (env: Env) =>
       processCount: z.number(),
       nextPageToken: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });
@@ -209,7 +211,7 @@ export const createListScriptProcessesTool = (env: Env) =>
 // Get Running Processes Tool
 // ============================================
 export const createGetRunningProcessesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_running_processes",
     description:
       "Gets all currently running processes for the authenticated user. Paginates through all results to ensure no running processes are missed. Useful for monitoring active script executions.",
@@ -231,7 +233,8 @@ export const createGetRunningProcessesTool = (env: Env) =>
       ),
       runningCount: z.number(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });

--- a/google-apps-script/server/tools/projects.ts
+++ b/google-apps-script/server/tools/projects.ts
@@ -1,7 +1,7 @@
 /**
  * Google Apps Script Projects Tools
  */
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../../shared/deco.gen.ts";
 import { AppsScriptClient, getAccessToken } from "../lib/apps-script-client.ts";
@@ -10,7 +10,7 @@ import { AppsScriptClient, getAccessToken } from "../lib/apps-script-client.ts";
 // Create Project Tool
 // ============================================
 export const createCreateProjectTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_project",
     description:
       "Creates a new, empty Apps Script project with no script files and a base manifest file.",
@@ -30,7 +30,8 @@ export const createCreateProjectTool = (env: Env) =>
       createTime: z.string().optional(),
       updateTime: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });
@@ -52,7 +53,7 @@ export const createCreateProjectTool = (env: Env) =>
 // Get Project Tool
 // ============================================
 export const createGetProjectTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_project",
     description:
       "Gets a script project's metadata including title, creator, and timestamps.",
@@ -68,7 +69,8 @@ export const createGetProjectTool = (env: Env) =>
       creatorEmail: z.string().optional(),
       lastModifyUserEmail: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });
@@ -89,7 +91,7 @@ export const createGetProjectTool = (env: Env) =>
 // Get Project Content Tool
 // ============================================
 export const createGetProjectContentTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_project_content",
     description:
       "Gets the content of the script project, including the code source and metadata for each script file.",
@@ -109,7 +111,8 @@ export const createGetProjectContentTool = (env: Env) =>
       ),
       fileCount: z.number(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });
@@ -134,7 +137,7 @@ export const createGetProjectContentTool = (env: Env) =>
 // Update Project Content Tool
 // ============================================
 export const createUpdateProjectContentTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "update_project_content",
     description:
       "Updates the content of the specified script project. This replaces all script files with the provided files.",
@@ -162,7 +165,8 @@ export const createUpdateProjectContentTool = (env: Env) =>
       fileCount: z.number(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });
@@ -182,7 +186,7 @@ export const createUpdateProjectContentTool = (env: Env) =>
 // Get Project Metrics Tool
 // ============================================
 export const createGetProjectMetricsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_project_metrics",
     description:
       "Get metrics data for a script project including active users, total executions, and failed executions.",
@@ -220,7 +224,8 @@ export const createGetProjectMetricsTool = (env: Env) =>
         }),
       ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });

--- a/google-apps-script/server/tools/scripts.ts
+++ b/google-apps-script/server/tools/scripts.ts
@@ -1,7 +1,7 @@
 /**
  * Google Apps Script Execution Tools
  */
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../../shared/deco.gen.ts";
 import { AppsScriptClient, getAccessToken } from "../lib/apps-script-client.ts";
@@ -10,7 +10,7 @@ import { AppsScriptClient, getAccessToken } from "../lib/apps-script-client.ts";
 // Run Script Tool
 // ============================================
 export const createRunScriptTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "run_script",
     description:
       "Runs a function in an Apps Script project. The script must be deployed as an API executable. Returns the function's return value.",
@@ -36,7 +36,8 @@ export const createRunScriptTool = (env: Env) =>
         })
         .optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });
@@ -64,7 +65,7 @@ export const createRunScriptTool = (env: Env) =>
 // Run Script in Dev Mode Tool
 // ============================================
 export const createRunScriptDevModeTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "run_script_dev_mode",
     description:
       "Runs a function in an Apps Script project in development mode. Uses the most recently saved code instead of a deployed version. Only works if the user is an owner of the script.",
@@ -90,7 +91,8 @@ export const createRunScriptDevModeTool = (env: Env) =>
         })
         .optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });

--- a/google-apps-script/server/tools/versions.ts
+++ b/google-apps-script/server/tools/versions.ts
@@ -1,7 +1,7 @@
 /**
  * Google Apps Script Versions Tools
  */
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../../shared/deco.gen.ts";
 import { AppsScriptClient, getAccessToken } from "../lib/apps-script-client.ts";
@@ -10,7 +10,7 @@ import { AppsScriptClient, getAccessToken } from "../lib/apps-script-client.ts";
 // Create Version Tool
 // ============================================
 export const createCreateVersionTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_version",
     description:
       "Creates a new immutable version using the current code. Versions are snapshots of the script that can be deployed.",
@@ -27,7 +27,8 @@ export const createCreateVersionTool = (env: Env) =>
       description: z.string().optional(),
       createTime: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });
@@ -47,7 +48,7 @@ export const createCreateVersionTool = (env: Env) =>
 // Get Version Tool
 // ============================================
 export const createGetVersionTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_version",
     description:
       "Gets a specific version of a script project by version number.",
@@ -65,7 +66,8 @@ export const createGetVersionTool = (env: Env) =>
       description: z.string().optional(),
       createTime: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });
@@ -86,7 +88,7 @@ export const createGetVersionTool = (env: Env) =>
 // List Versions Tool
 // ============================================
 export const createListVersionsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_versions",
     description:
       "Lists all versions of a script project. Returns version numbers, descriptions, and creation times.",
@@ -115,7 +117,8 @@ export const createListVersionsTool = (env: Env) =>
       versionCount: z.number(),
       nextPageToken: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new AppsScriptClient({
         accessToken: getAccessToken(env),
       });

--- a/google-big-query/package.json
+++ b/google-big-query/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/google-big-query/server/tools/bigquery.ts
+++ b/google-big-query/server/tools/bigquery.ts
@@ -4,7 +4,7 @@
  * Tools for querying, listing datasets/tables, and exploring schemas
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { BigQueryClient, getAccessToken } from "../lib/bigquery-client.ts";
@@ -68,7 +68,7 @@ const TableInfoSchema = z.object({
 // ============================================================================
 
 export const createQueryTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "bigquery_query",
     description:
       "Execute a SQL query against Google BigQuery and return results with schema information. " +
@@ -135,7 +135,8 @@ export const createQueryTool = (env: Env) =>
           "Pass this as pageToken in the next call to fetch the next page. Absent on the last page.",
         ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new BigQueryClient({
         accessToken: getAccessToken(env),
       });
@@ -222,7 +223,7 @@ export const createQueryTool = (env: Env) =>
 // ============================================================================
 
 export const createGetDatasetTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "bigquery_get_dataset",
     description:
       "Get detailed information about a specific BigQuery dataset. Returns dataset metadata including location, creation time, and description.",
@@ -238,7 +239,8 @@ export const createGetDatasetTool = (env: Env) =>
         .optional()
         .describe("Last modification time"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new BigQueryClient({
         accessToken: getAccessToken(env),
       });
@@ -268,7 +270,7 @@ export const createGetDatasetTool = (env: Env) =>
 // ============================================================================
 
 export const createListDatasetsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "bigquery_list_datasets",
     description:
       "List all datasets in a Google BigQuery project. Returns dataset IDs, names, and metadata.",
@@ -297,7 +299,8 @@ export const createListDatasetsTool = (env: Env) =>
         .optional()
         .describe("Token for fetching next page"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new BigQueryClient({
         accessToken: getAccessToken(env),
       });
@@ -329,7 +332,7 @@ export const createListDatasetsTool = (env: Env) =>
 // ============================================================================
 
 export const createListTablesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "bigquery_list_tables",
     description:
       "List all tables in a Google BigQuery dataset. Returns table IDs, types, and metadata.",
@@ -356,7 +359,8 @@ export const createListTablesTool = (env: Env) =>
         .describe("Token for fetching next page"),
       totalItems: z.number().optional().describe("Total number of tables"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new BigQueryClient({
         accessToken: getAccessToken(env),
       });
@@ -438,7 +442,7 @@ function parseTableRef(ref: string): {
 }
 
 export const createGetTableSchemaTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "bigquery_get_table_schema",
     description:
       "Get the schema of a specific BigQuery table. Returns all fields with their types, modes, and descriptions.",
@@ -518,7 +522,8 @@ export const createGetTableSchemaTool = (env: Env) =>
         })
         .describe("Table schema"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new BigQueryClient({
         accessToken: getAccessToken(env),
       });

--- a/google-big-query/server/tools/jobs.ts
+++ b/google-big-query/server/tools/jobs.ts
@@ -4,7 +4,7 @@
  * Tools for listing and getting job information
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { BigQueryClient, getAccessToken } from "../lib/bigquery-client.ts";
@@ -51,7 +51,7 @@ const JobSchema = z.object({
 // ============================================================================
 
 export const createListJobsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "bigquery_list_jobs",
     description:
       "List BigQuery jobs in a project. Returns information about query jobs and their status. Useful for monitoring queries, checking job history, and debugging.",
@@ -88,7 +88,8 @@ export const createListJobsTool = (env: Env) =>
         .optional()
         .describe("Token for fetching next page"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new BigQueryClient({
         accessToken: getAccessToken(env),
       });
@@ -121,7 +122,7 @@ export const createListJobsTool = (env: Env) =>
 // ============================================================================
 
 export const createGetJobTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "bigquery_get_job",
     description:
       "Get detailed information about a specific BigQuery job. Returns job status, configuration, statistics, and error information if any. Useful for monitoring query execution and debugging failures.",
@@ -152,7 +153,8 @@ export const createGetJobTool = (env: Env) =>
         .optional()
         .describe("Job configuration"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new BigQueryClient({
         accessToken: getAccessToken(env),
       });

--- a/google-big-query/server/tools/projects.ts
+++ b/google-big-query/server/tools/projects.ts
@@ -4,7 +4,7 @@
  * Tools for listing projects
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { BigQueryClient, getAccessToken } from "../lib/bigquery-client.ts";
@@ -25,7 +25,7 @@ const ProjectSchema = z.object({
 // ============================================================================
 
 export const createListProjectsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "bigquery_list_projects",
     description:
       "List all Google Cloud projects accessible to the authenticated user. Returns project IDs and friendly names. Use this to discover which projects you can query.",
@@ -50,7 +50,8 @@ export const createListProjectsTool = (env: Env) =>
         .describe("Token for fetching next page"),
       totalItems: z.number().optional().describe("Total number of projects"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new BigQueryClient({
         accessToken: getAccessToken(env),
       });

--- a/google-big-query/tsconfig.json
+++ b/google-big-query/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "ES2024", "DOM", "DOM.Iterable"],

--- a/google-calendar-sa/package.json
+++ b/google-calendar-sa/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@decocms/runtime": "^1.2.6",
+    "@decocms/runtime": "1.4.0",
     "google-calendar": "workspace:*",
     "zod": "^4.0.0"
   },

--- a/google-calendar-sa/tsconfig.json
+++ b/google-calendar-sa/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "ES2024", "DOM", "DOM.Iterable"],

--- a/google-calendar/package.json
+++ b/google-calendar/package.json
@@ -17,7 +17,7 @@
     "./constants": "./server/constants.ts"
   },
   "dependencies": {
-    "@decocms/runtime": "^1.2.6",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/google-calendar/server/tools/advanced.ts
+++ b/google-calendar/server/tools/advanced.ts
@@ -7,7 +7,7 @@
  * - duplicate_event: Create a copy of an existing event
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { GoogleCalendarClient, getAccessToken } from "../lib/google-client.ts";
@@ -63,7 +63,7 @@ const EventSchema = z.object({
 // ============================================================================
 
 export const createMoveEventTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "move_event",
     description:
       "Move an event from one calendar to another. The event will be removed from the source calendar and added to the destination calendar.",
@@ -84,7 +84,8 @@ export const createMoveEventTool = (env: Env) =>
       event: EventSchema.describe("The moved event with its new details"),
       message: z.string().describe("Success message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });
@@ -120,7 +121,7 @@ export const createMoveEventTool = (env: Env) =>
 // ============================================================================
 
 export const createFindAvailableSlotsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "find_available_slots",
     description:
       "Find available time slots across one or more calendars. Useful for scheduling meetings by finding times when all participants are free.",
@@ -169,7 +170,8 @@ export const createFindAvailableSlotsTool = (env: Env) =>
         end: z.string().describe("End of search range"),
       }),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });
@@ -203,7 +205,7 @@ export const createFindAvailableSlotsTool = (env: Env) =>
 // ============================================================================
 
 export const createDuplicateEventTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "duplicate_event",
     description:
       "Create a copy of an existing event. You can optionally change the date/time and target calendar.",
@@ -240,7 +242,8 @@ export const createDuplicateEventTool = (env: Env) =>
       originalEvent: EventSchema.describe("The original event"),
       newEvent: EventSchema.describe("The newly created duplicate event"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });
@@ -341,7 +344,7 @@ export const createDuplicateEventTool = (env: Env) =>
 // ============================================================================
 
 export const createWatchCalendarTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "watch_calendar",
     description:
       "Set up push notifications (webhook) to receive real-time updates when events in a calendar change. The webhook URL will receive POST requests when events are created, updated, or deleted.",
@@ -382,7 +385,8 @@ export const createWatchCalendarTool = (env: Env) =>
         .optional()
         .describe("When the watch expires (ISO 8601 timestamp)"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });
@@ -415,7 +419,7 @@ export const createWatchCalendarTool = (env: Env) =>
 // ============================================================================
 
 export const createStopWatchTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "stop_watch",
     description:
       "Stop receiving push notifications for a previously created watch channel. Use the channelId and resourceId returned by watch_calendar.",
@@ -427,7 +431,8 @@ export const createStopWatchTool = (env: Env) =>
       success: z.boolean().describe("Whether the watch was stopped"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });

--- a/google-calendar/server/tools/calendars.ts
+++ b/google-calendar/server/tools/calendars.ts
@@ -4,7 +4,7 @@
  * Tools for listing, getting, creating, and deleting calendars
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { GoogleCalendarClient, getAccessToken } from "../lib/google-client.ts";
@@ -33,7 +33,7 @@ const CalendarSchema = z.object({
 // ============================================================================
 
 export const createListCalendarsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_calendars",
     description:
       "List all calendars accessible by the authenticated user. Returns calendar IDs, names, colors, and access roles.",
@@ -63,7 +63,8 @@ export const createListCalendarsTool = (env: Env) =>
           "Total deduplicated calendars (set by service-account fan-out)",
         ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });
@@ -95,7 +96,7 @@ export const createListCalendarsTool = (env: Env) =>
 // ============================================================================
 
 export const createGetCalendarTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_calendar",
     description:
       "Get detailed information about a specific calendar by its ID.",
@@ -109,7 +110,8 @@ export const createGetCalendarTool = (env: Env) =>
     outputSchema: z.object({
       calendar: CalendarSchema.describe("Calendar details"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });
@@ -137,7 +139,7 @@ export const createGetCalendarTool = (env: Env) =>
 // ============================================================================
 
 export const createCreateCalendarTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_calendar",
     description:
       "Create a new secondary calendar. Note: You cannot create a new primary calendar.",
@@ -165,7 +167,8 @@ export const createCreateCalendarTool = (env: Env) =>
         timeZone: z.string().optional(),
       }),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });
@@ -194,7 +197,7 @@ export const createCreateCalendarTool = (env: Env) =>
 // ============================================================================
 
 export const createDeleteCalendarTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_calendar",
     description:
       "Delete a secondary calendar. Note: You cannot delete the primary calendar.",
@@ -207,7 +210,8 @@ export const createDeleteCalendarTool = (env: Env) =>
       success: z.boolean().describe("Whether the deletion was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       if (context.calendarId === "primary") {
         throw new Error("Cannot delete the primary calendar");
       }

--- a/google-calendar/server/tools/events.ts
+++ b/google-calendar/server/tools/events.ts
@@ -4,7 +4,7 @@
  * Tools for listing, getting, creating, updating, and deleting events
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { GoogleCalendarClient, getAccessToken } from "../lib/google-client.ts";
@@ -181,7 +181,7 @@ function mapEvent(event: import("../lib/types.ts").Event) {
 // ============================================================================
 
 export const createListEventsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_events",
     description:
       "List events from a calendar with optional filters for date range, search query, and pagination.",
@@ -229,7 +229,8 @@ export const createListEventsTool = (env: Env) =>
         .optional()
         .describe("Total deduplicated events (set by service-account fan-out)"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });
@@ -268,7 +269,7 @@ export const createListEventsTool = (env: Env) =>
 // ============================================================================
 
 export const createGetEventTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_event",
     description: "Get detailed information about a specific event by its ID.",
     inputSchema: z.object({
@@ -281,7 +282,8 @@ export const createGetEventTool = (env: Env) =>
     outputSchema: z.object({
       event: EventSchema.describe("Event details"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });
@@ -300,7 +302,7 @@ export const createGetEventTool = (env: Env) =>
 // ============================================================================
 
 export const createCreateEventTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_event",
     description:
       "Create a new event in a calendar. Supports attendees, reminders, and all-day or timed events.",
@@ -368,7 +370,8 @@ export const createCreateEventTool = (env: Env) =>
     outputSchema: z.object({
       event: EventSchema.describe("Created event"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });
@@ -412,7 +415,7 @@ export const createCreateEventTool = (env: Env) =>
 // ============================================================================
 
 export const createUpdateEventTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "update_event",
     description:
       "Update an existing event. Only provided fields will be updated.",
@@ -458,7 +461,8 @@ export const createUpdateEventTool = (env: Env) =>
     outputSchema: z.object({
       event: EventSchema.describe("Updated event"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });
@@ -491,7 +495,7 @@ export const createUpdateEventTool = (env: Env) =>
 // ============================================================================
 
 export const createDeleteEventTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_event",
     description: "Delete an event from a calendar.",
     inputSchema: z.object({
@@ -509,7 +513,8 @@ export const createDeleteEventTool = (env: Env) =>
       success: z.boolean().describe("Whether deletion was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });
@@ -535,7 +540,7 @@ export const createDeleteEventTool = (env: Env) =>
 // ============================================================================
 
 export const createQuickAddEventTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "quick_add_event",
     description:
       "Create an event using natural language text. Google Calendar will parse the text to extract event details like date, time, and title. Examples: 'Meeting with John tomorrow at 3pm', 'Dentist appointment on Friday at 10am'",
@@ -557,7 +562,8 @@ export const createQuickAddEventTool = (env: Env) =>
     outputSchema: z.object({
       event: EventSchema.describe("Created event"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });
@@ -580,7 +586,7 @@ export const createQuickAddEventTool = (env: Env) =>
 // ============================================================================
 
 export const createRespondToEventTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "respond_to_event",
     description:
       "Respond to an event invitation (accept, decline, or tentative). Updates your RSVP status for the event.",
@@ -605,7 +611,8 @@ export const createRespondToEventTool = (env: Env) =>
         .optional()
         .describe("Your previous response status"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });
@@ -665,7 +672,7 @@ export const createRespondToEventTool = (env: Env) =>
 // ============================================================================
 
 export const createListEventInstancesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_event_instances",
     description:
       "List individual instances of a recurring event. Useful for seeing when a weekly meeting occurs, modifying specific instances, etc.",
@@ -698,7 +705,8 @@ export const createListEventInstancesTool = (env: Env) =>
       instances: z.array(EventSchema).describe("List of event instances"),
       nextPageToken: z.string().optional().describe("Token for next page"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });
@@ -724,7 +732,7 @@ export const createListEventInstancesTool = (env: Env) =>
 // ============================================================================
 
 export const createCheckUpcomingEventsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "check_upcoming_events",
     description:
       "Check for calendar events starting within the next N minutes and emit them to the event bus. Designed to be called periodically by the mesh.",
@@ -791,7 +799,8 @@ export const createCheckUpcomingEventsTool = (env: Env) =>
         .optional()
         .describe("Total deduplicated events (set by service-account fan-out)"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });

--- a/google-calendar/server/tools/freebusy.ts
+++ b/google-calendar/server/tools/freebusy.ts
@@ -4,7 +4,7 @@
  * Tool for checking availability across calendars
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { GoogleCalendarClient, getAccessToken } from "../lib/google-client.ts";
@@ -38,7 +38,7 @@ const CalendarFreeBusySchema = z.object({
 // ============================================================================
 
 export const createGetFreeBusyTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_freebusy",
     description:
       "Check free/busy information for one or more calendars within a time range. Useful for finding available meeting times or checking someone's availability.",
@@ -71,7 +71,8 @@ export const createGetFreeBusyTool = (env: Env) =>
         .array(CalendarFreeBusySchema)
         .describe("Free/busy information for each calendar"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GoogleCalendarClient({
         accessToken: getAccessToken(env),
       });

--- a/google-calendar/server/tools/utils.ts
+++ b/google-calendar/server/tools/utils.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 
@@ -19,7 +19,7 @@ function formatInTimeZone(date: Date, timeZone: string): string {
 }
 
 export const createGetCurrentTimeTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_current_time",
     description:
       "Get the current date and time. If a timezone is provided, returns the time in that timezone. If no timezone is provided, returns UTC and a list of common timezones with their current times.",
@@ -48,7 +48,8 @@ export const createGetCurrentTimeTool = (_env: Env) =>
         .optional()
         .describe("List of common timezones with current times"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const now = new Date();
       const utc = now.toISOString();
 

--- a/google-calendar/tsconfig.json
+++ b/google-calendar/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "ES2024", "DOM", "DOM.Iterable"],

--- a/google-docs/package.json
+++ b/google-docs/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/google-docs/server/tools/content.ts
+++ b/google-docs/server/tools/content.ts
@@ -2,13 +2,13 @@
  * Content Operations Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { DocsClient, getAccessToken } from "../lib/docs-client.ts";
 
 export const createInsertTextTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "insert_text",
     description:
       "Insert text at a specific position in the document. Index 1 is the beginning.",
@@ -24,7 +24,8 @@ export const createInsertTextTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DocsClient({ accessToken: getAccessToken(env) });
       await client.insertText(context.documentId, context.text, context.index);
       return {
@@ -35,7 +36,7 @@ export const createInsertTextTool = (env: Env) =>
   });
 
 export const createDeleteContentTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_content",
     description: "Delete content from a range in the document.",
     inputSchema: z
@@ -51,7 +52,8 @@ export const createDeleteContentTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DocsClient({ accessToken: getAccessToken(env) });
       await client.deleteContent(
         context.documentId,
@@ -66,7 +68,7 @@ export const createDeleteContentTool = (env: Env) =>
   });
 
 export const createReplaceTextTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "replace_text",
     description: "Find and replace all occurrences of text in the document.",
     inputSchema: z.object({
@@ -82,7 +84,8 @@ export const createReplaceTextTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DocsClient({ accessToken: getAccessToken(env) });
       const result = await client.replaceAllText(
         context.documentId,
@@ -97,7 +100,7 @@ export const createReplaceTextTool = (env: Env) =>
   });
 
 export const createAppendTextTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "append_text",
     description: "Append text to the end of the document.",
     inputSchema: z.object({
@@ -108,7 +111,8 @@ export const createAppendTextTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DocsClient({ accessToken: getAccessToken(env) });
       const doc = await client.getDocument(context.documentId);
       const endIndex = client.getEndIndex(doc) - 1;

--- a/google-docs/server/tools/documents.ts
+++ b/google-docs/server/tools/documents.ts
@@ -2,13 +2,13 @@
  * Document Management Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { DocsClient, getAccessToken } from "../lib/docs-client.ts";
 
 export const createCreateDocumentTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_document",
     description: "Create a new empty Google Document.",
     inputSchema: z.object({
@@ -19,7 +19,8 @@ export const createCreateDocumentTool = (env: Env) =>
       title: z.string(),
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DocsClient({ accessToken: getAccessToken(env) });
       const doc = await client.createDocument(context.title);
       return { documentId: doc.documentId, title: doc.title, success: true };
@@ -27,7 +28,7 @@ export const createCreateDocumentTool = (env: Env) =>
   });
 
 export const createGetDocumentTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_document",
     description: "Get document metadata and content.",
     inputSchema: z.object({
@@ -39,7 +40,8 @@ export const createGetDocumentTool = (env: Env) =>
       content: z.string(),
       endIndex: z.number(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DocsClient({ accessToken: getAccessToken(env) });
       const doc = await client.getDocument(context.documentId);
       return {

--- a/google-docs/server/tools/elements.ts
+++ b/google-docs/server/tools/elements.ts
@@ -2,13 +2,13 @@
  * Element Insertion Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { DocsClient, getAccessToken } from "../lib/docs-client.ts";
 
 export const createInsertTableTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "insert_table",
     description: "Insert a table at a specific position.",
     inputSchema: z.object({
@@ -21,7 +21,8 @@ export const createInsertTableTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DocsClient({ accessToken: getAccessToken(env) });
       await client.insertTable(
         context.documentId,
@@ -37,7 +38,7 @@ export const createInsertTableTool = (env: Env) =>
   });
 
 export const createInsertImageTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "insert_image",
     description: "Insert an image from URL at a specific position.",
     inputSchema: z.object({
@@ -54,7 +55,8 @@ export const createInsertImageTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DocsClient({ accessToken: getAccessToken(env) });
       await client.insertImage(
         context.documentId,
@@ -68,7 +70,7 @@ export const createInsertImageTool = (env: Env) =>
   });
 
 export const createInsertPageBreakTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "insert_page_break",
     description: "Insert a page break at a specific position.",
     inputSchema: z.object({
@@ -79,7 +81,8 @@ export const createInsertPageBreakTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DocsClient({ accessToken: getAccessToken(env) });
       await client.insertPageBreak(context.documentId, context.index);
       return { success: true, message: "Page break inserted" };

--- a/google-docs/server/tools/formatting.ts
+++ b/google-docs/server/tools/formatting.ts
@@ -2,14 +2,14 @@
  * Formatting Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { DocsClient, getAccessToken } from "../lib/docs-client.ts";
 import { NAMED_STYLE_TYPE, BULLET_GLYPH_PRESET } from "../constants.ts";
 
 export const createFormatTextTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "format_text",
     description:
       "Apply text formatting (bold, italic, underline, font size) to a range.",
@@ -26,7 +26,8 @@ export const createFormatTextTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DocsClient({ accessToken: getAccessToken(env) });
       await client.formatText(
         context.documentId,
@@ -44,7 +45,7 @@ export const createFormatTextTool = (env: Env) =>
   });
 
 export const createInsertHeadingTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "insert_heading",
     description:
       "Insert a heading at a position. Inserts text and applies heading style.",
@@ -58,7 +59,8 @@ export const createInsertHeadingTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DocsClient({ accessToken: getAccessToken(env) });
       const headingText = context.text + "\n";
       await client.insertText(context.documentId, headingText, context.index);
@@ -75,7 +77,7 @@ export const createInsertHeadingTool = (env: Env) =>
   });
 
 export const createInsertListTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "insert_list",
     description: "Create a bullet or numbered list from existing paragraphs.",
     inputSchema: z.object({
@@ -88,7 +90,8 @@ export const createInsertListTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DocsClient({ accessToken: getAccessToken(env) });
       const preset =
         context.listType === "numbered"
@@ -105,7 +108,7 @@ export const createInsertListTool = (env: Env) =>
   });
 
 export const createRemoveListTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "remove_list",
     description: "Remove bullet/numbered list formatting from paragraphs.",
     inputSchema: z.object({
@@ -117,7 +120,8 @@ export const createRemoveListTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DocsClient({ accessToken: getAccessToken(env) });
       await client.removeBulletList(
         context.documentId,

--- a/google-drive/package.json
+++ b/google-drive/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/google-drive/server/tools/files.ts
+++ b/google-drive/server/tools/files.ts
@@ -2,7 +2,7 @@
  * File Operations Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { DriveClient, getAccessToken } from "../lib/drive-client.ts";
@@ -28,7 +28,7 @@ const FileSchema = z.object({
 });
 
 export const createListFilesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_files",
     description: "List files in Google Drive. Can filter with query syntax.",
     inputSchema: z.object({
@@ -51,7 +51,8 @@ export const createListFilesTool = (env: Env) =>
       files: z.array(FileSchema),
       count: z.number(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DriveClient({ accessToken: getAccessToken(env) });
       const result = await client.listFiles({
         q: context.query,
@@ -63,7 +64,7 @@ export const createListFilesTool = (env: Env) =>
   });
 
 export const createGetFileTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_file",
     description: "Get metadata about a specific file.",
     inputSchema: z.object({
@@ -72,7 +73,8 @@ export const createGetFileTool = (env: Env) =>
     outputSchema: z.object({
       file: FileSchema,
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DriveClient({ accessToken: getAccessToken(env) });
       const file = await client.getFile(context.fileId);
       return { file };
@@ -80,7 +82,7 @@ export const createGetFileTool = (env: Env) =>
   });
 
 export const createCreateFileTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_file",
     description:
       "Create a new file (empty). Use specific MIME types for Google Docs/Sheets/Slides.",
@@ -99,7 +101,8 @@ export const createCreateFileTool = (env: Env) =>
       file: FileSchema,
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DriveClient({ accessToken: getAccessToken(env) });
       const file = await client.createFile({
         name: context.name,
@@ -112,7 +115,7 @@ export const createCreateFileTool = (env: Env) =>
   });
 
 export const createUpdateFileTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "update_file",
     description:
       "Update file metadata (name, description, move to folder, star/trash).",
@@ -135,7 +138,8 @@ export const createUpdateFileTool = (env: Env) =>
       file: FileSchema,
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DriveClient({ accessToken: getAccessToken(env) });
       const file = await client.updateFile(
         context.fileId,
@@ -153,7 +157,7 @@ export const createUpdateFileTool = (env: Env) =>
   });
 
 export const createDeleteFileTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_file",
     description: "Permanently delete a file. WARNING: This cannot be undone.",
     inputSchema: z.object({
@@ -163,7 +167,8 @@ export const createDeleteFileTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DriveClient({ accessToken: getAccessToken(env) });
       await client.deleteFile(context.fileId);
       return { success: true, message: "File deleted permanently" };
@@ -171,7 +176,7 @@ export const createDeleteFileTool = (env: Env) =>
   });
 
 export const createCopyFileTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "copy_file",
     description: "Create a copy of a file.",
     inputSchema: z.object({
@@ -183,7 +188,8 @@ export const createCopyFileTool = (env: Env) =>
       file: FileSchema,
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DriveClient({ accessToken: getAccessToken(env) });
       const file = await client.copyFile(
         context.fileId,
@@ -195,7 +201,7 @@ export const createCopyFileTool = (env: Env) =>
   });
 
 export const createSearchFilesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "search_files",
     description:
       "Search files using Drive query syntax. Supports name, type, content, owner filters.",
@@ -214,7 +220,8 @@ export const createSearchFilesTool = (env: Env) =>
       files: z.array(FileSchema),
       count: z.number(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DriveClient({ accessToken: getAccessToken(env) });
       const files = await client.searchFiles(
         context.query,
@@ -233,7 +240,7 @@ const GOOGLE_EXPORT_MAP: Record<string, { mimeType: string; label: string }> = {
 };
 
 export const createReadFileContentTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "read_file_content",
     description:
       "Read the text content of a file. For Google Docs/Sheets/Slides, exports as text/CSV. For regular files (txt, json, csv, etc.), downloads the content directly.",
@@ -252,7 +259,8 @@ export const createReadFileContentTool = (env: Env) =>
       mimeType: z.string(),
       exportedAs: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DriveClient({ accessToken: getAccessToken(env) });
       const file = await client.getFile(context.fileId);
 

--- a/google-drive/server/tools/folders.ts
+++ b/google-drive/server/tools/folders.ts
@@ -2,7 +2,7 @@
  * Folder Operations Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { DriveClient, getAccessToken } from "../lib/drive-client.ts";
@@ -29,7 +29,7 @@ const FileSchema = z.object({
 });
 
 export const createCreateFolderTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_folder",
     description: "Create a new folder in Google Drive.",
     inputSchema: z.object({
@@ -43,7 +43,8 @@ export const createCreateFolderTool = (env: Env) =>
       folder: FileSchema,
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DriveClient({ accessToken: getAccessToken(env) });
       const folder = await client.createFolder(context.name, context.parentId);
       return { folder, success: true };
@@ -51,7 +52,7 @@ export const createCreateFolderTool = (env: Env) =>
   });
 
 export const createListFolderContentsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_folder_contents",
     description: "List all files and folders inside a specific folder.",
     inputSchema: z.object({
@@ -69,7 +70,8 @@ export const createListFolderContentsTool = (env: Env) =>
       folders: z.array(FileSchema),
       totalCount: z.number(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DriveClient({ accessToken: getAccessToken(env) });
       // Escape single quotes in folderId to prevent query injection
       const safeFolderId = context.folderId.replace(/'/g, "\\'");

--- a/google-drive/server/tools/permissions.ts
+++ b/google-drive/server/tools/permissions.ts
@@ -2,7 +2,7 @@
  * Permission and Sharing Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { DriveClient, getAccessToken } from "../lib/drive-client.ts";
@@ -24,7 +24,7 @@ const PermissionSchema = z.object({
 });
 
 export const createListPermissionsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_permissions",
     description: "List all permissions for a file/folder.",
     inputSchema: z.object({
@@ -34,7 +34,8 @@ export const createListPermissionsTool = (env: Env) =>
       permissions: z.array(PermissionSchema),
       count: z.number(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DriveClient({ accessToken: getAccessToken(env) });
       const permissions = await client.listPermissions(context.fileId);
       return { permissions, count: permissions.length };
@@ -42,7 +43,7 @@ export const createListPermissionsTool = (env: Env) =>
   });
 
 export const createCreatePermissionTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_permission",
     description:
       "Share a file/folder with a user, group, domain, or make it public.",
@@ -98,7 +99,8 @@ export const createCreatePermissionTool = (env: Env) =>
       permission: PermissionSchema,
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DriveClient({ accessToken: getAccessToken(env) });
       const permission = await client.createPermission(
         context.fileId,
@@ -116,7 +118,7 @@ export const createCreatePermissionTool = (env: Env) =>
   });
 
 export const createDeletePermissionTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_permission",
     description: "Remove a permission from a file/folder (unshare).",
     inputSchema: z.object({
@@ -127,7 +129,8 @@ export const createDeletePermissionTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DriveClient({ accessToken: getAccessToken(env) });
       await client.deletePermission(context.fileId, context.permissionId);
       return { success: true, message: "Permission removed" };
@@ -135,7 +138,7 @@ export const createDeletePermissionTool = (env: Env) =>
   });
 
 export const createShareFileTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "share_file",
     description: "Quick share: share a file with a user by email.",
     inputSchema: z.object({
@@ -154,7 +157,8 @@ export const createShareFileTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DriveClient({ accessToken: getAccessToken(env) });
       await client.createPermission(
         context.fileId,
@@ -170,7 +174,7 @@ export const createShareFileTool = (env: Env) =>
   });
 
 export const createGetSharingLinkTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_sharing_link",
     description:
       "Get the sharing link for a file (optionally make it public first).",
@@ -186,7 +190,8 @@ export const createGetSharingLinkTool = (env: Env) =>
       webContentLink: z.string().optional(),
       isPublic: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new DriveClient({ accessToken: getAccessToken(env) });
       if (context.makePublic) {
         await client.createPermission(

--- a/google-forms/package.json
+++ b/google-forms/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/google-forms/server/tools/forms.ts
+++ b/google-forms/server/tools/forms.ts
@@ -2,7 +2,7 @@
  * Form Management Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { FormsClient, getAccessToken } from "../lib/forms-client.ts";
@@ -16,7 +16,7 @@ const FormSchema = z.object({
 });
 
 export const createCreateFormTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_form",
     description: "Create a new Google Form.",
     inputSchema: z.object({
@@ -27,7 +27,8 @@ export const createCreateFormTool = (env: Env) =>
       formLink: z.string(),
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new FormsClient({ accessToken: getAccessToken(env) });
       const form = await client.createForm(context.title);
       return {
@@ -45,7 +46,7 @@ export const createCreateFormTool = (env: Env) =>
   });
 
 export const createGetFormTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_form",
     description: "Get form details and questions.",
     inputSchema: z.object({
@@ -63,7 +64,8 @@ export const createGetFormTool = (env: Env) =>
         }),
       ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new FormsClient({ accessToken: getAccessToken(env) });
       const form = await client.getForm(context.formId);
       return {
@@ -105,7 +107,7 @@ export const createGetFormTool = (env: Env) =>
   });
 
 export const createUpdateFormTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "update_form",
     description: "Update form title or description.",
     inputSchema: z.object({
@@ -117,7 +119,8 @@ export const createUpdateFormTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new FormsClient({ accessToken: getAccessToken(env) });
       await client.updateFormInfo(
         context.formId,
@@ -129,7 +132,7 @@ export const createUpdateFormTool = (env: Env) =>
   });
 
 export const createGetResponderUrlTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_responder_url",
     description: "Get the URL where users can fill out the form.",
     inputSchema: z.object({
@@ -138,7 +141,8 @@ export const createGetResponderUrlTool = (env: Env) =>
     outputSchema: z.object({
       responderUrl: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new FormsClient({ accessToken: getAccessToken(env) });
       const form = await client.getForm(context.formId);
       return { responderUrl: form.responderUri || "" };

--- a/google-forms/server/tools/questions.ts
+++ b/google-forms/server/tools/questions.ts
@@ -2,13 +2,13 @@
  * Question Management Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { FormsClient, getAccessToken } from "../lib/forms-client.ts";
 
 export const createAddQuestionTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "add_question",
     description: "Add a question to the form.",
     inputSchema: z
@@ -66,7 +66,8 @@ export const createAddQuestionTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new FormsClient({ accessToken: getAccessToken(env) });
       await client.addQuestion(
         context.formId,
@@ -87,7 +88,7 @@ export const createAddQuestionTool = (env: Env) =>
   });
 
 export const createUpdateQuestionTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "update_question",
     description: "Update a question's title or required status.",
     inputSchema: z
@@ -107,7 +108,8 @@ export const createUpdateQuestionTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new FormsClient({ accessToken: getAccessToken(env) });
       await client.updateQuestion(
         context.formId,
@@ -120,7 +122,7 @@ export const createUpdateQuestionTool = (env: Env) =>
   });
 
 export const createDeleteQuestionTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_question",
     description: "Delete a question from the form.",
     inputSchema: z.object({
@@ -131,7 +133,8 @@ export const createDeleteQuestionTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new FormsClient({ accessToken: getAccessToken(env) });
       await client.deleteQuestion(context.formId, context.index);
       return { success: true, message: "Question deleted" };

--- a/google-forms/server/tools/responses.ts
+++ b/google-forms/server/tools/responses.ts
@@ -2,7 +2,7 @@
  * Response Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { FormsClient, getAccessToken } from "../lib/forms-client.ts";
@@ -16,7 +16,7 @@ const ResponseSchema = z.object({
 });
 
 export const createListResponsesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_responses",
     description: "List all responses for a form.",
     inputSchema: z.object({
@@ -26,7 +26,8 @@ export const createListResponsesTool = (env: Env) =>
       responses: z.array(ResponseSchema),
       count: z.number(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new FormsClient({ accessToken: getAccessToken(env) });
       const responses = await client.listResponses(context.formId);
       return {
@@ -48,7 +49,7 @@ export const createListResponsesTool = (env: Env) =>
   });
 
 export const createGetResponseTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_response",
     description: "Get a specific response by ID.",
     inputSchema: z.object({
@@ -58,7 +59,8 @@ export const createGetResponseTool = (env: Env) =>
     outputSchema: z.object({
       response: ResponseSchema,
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new FormsClient({ accessToken: getAccessToken(env) });
       const r = await client.getResponse(context.formId, context.responseId);
       return {

--- a/google-gemini/package.json
+++ b/google-gemini/package.json
@@ -14,7 +14,7 @@
     "@ai-sdk/google": "^2.0.40",
     "@ai-sdk/provider": "^3.0.2",
     "@decocms/bindings": "^1.1.1",
-    "@decocms/runtime": "1.1.3",
+    "@decocms/runtime": "1.4.0",
     "ai": "^6.0.3",
     "zod": "^4.0.0"
   },

--- a/google-gemini/server/tools/llm-binding.ts
+++ b/google-gemini/server/tools/llm-binding.ts
@@ -15,10 +15,7 @@ import {
   type ModelCollectionEntitySchema,
 } from "@decocms/bindings/llm";
 import { streamToResponse } from "@decocms/runtime/bindings";
-import {
-  createPrivateTool,
-  createStreamableTool,
-} from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { getGeminiApiKey } from "server/lib/env.ts";
 import type { z } from "zod";
@@ -273,14 +270,15 @@ function sortModelsByWellKnown(models: ListedModel[]): ListedModel[] {
  * COLLECTION_LLM_LIST - Lists all available models with filtering and pagination
  */
 export const createListLLMTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_LLM_LIST",
     description:
       "List all available models from Google Gemini with filtering and pagination support. " +
       "Returns comprehensive information about each model including capabilities, pricing, and limits.",
     inputSchema: LIST_BINDING.inputSchema,
     outputSchema: LIST_BINDING.outputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { where, orderBy, limit = 50, offset = 0 } = context;
       const client = new GeminiClient({
         apiKey: getGeminiApiKey(env),
@@ -322,14 +320,15 @@ export const createListLLMTool = (env: Env) =>
  * COLLECTION_LLM_GET - Retrieves a single model by its ID
  */
 export const createGetLLMTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_LLM_GET",
     description:
       "Get detailed information about a specific Google Gemini model including " +
       "pricing, capabilities, context length, and provider information.",
     inputSchema: GET_BINDING.inputSchema,
     outputSchema: GET_BINDING.outputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { id } = context;
       const client = new GeminiClient({
         apiKey: getGeminiApiKey(env),
@@ -354,14 +353,15 @@ export const createGetLLMTool = (env: Env) =>
  * LLM_METADATA - Returns metadata about a specific model's capabilities
  */
 export const createLLMMetadataTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "LLM_METADATA",
     description:
       "Get metadata about a specific model's capabilities including supported URL patterns " +
       "for different media types (images, files, etc.).",
     inputSchema: METADATA_BINDING.inputSchema,
     outputSchema: METADATA_BINDING.outputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { modelId } = context;
       const client = new GeminiClient({
         apiKey: getGeminiApiKey(env),
@@ -439,13 +439,14 @@ const isAPICallError = (error: unknown): error is APICallError =>
  * LLM_DO_STREAM - Streams a language model response in real-time
  */
 export const createLLMStreamTool = (usageHooks?: UsageHooks) => (env: Env) =>
-  createStreamableTool({
+  createTool({
     id: "LLM_DO_STREAM",
     description:
       "Stream a language model response in real-time using Google Gemini. " +
       "Returns a streaming response for interactive chat experiences.",
     inputSchema: STREAM_BINDING.inputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const {
         modelId,
         callOptions: { abortSignal: _abortSignal, ...callOptions },
@@ -634,14 +635,15 @@ function transformGenerateResult(result: unknown): Record<string, unknown> {
  * LLM_DO_GENERATE - Generates a complete response in a single call (non-streaming)
  */
 export const createLLMGenerateTool = (usageHooks?: UsageHooks) => (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "LLM_DO_GENERATE",
     description:
       "Generate a complete language model response using Google Gemini (non-streaming). " +
       "Returns the full response with usage statistics.",
     inputSchema: GENERATE_BINDING.inputSchema,
     outputSchema: GENERATE_BINDING.outputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const {
         modelId,
         callOptions: { abortSignal: _abortSignal, ...callOptions },

--- a/google-gemini/server/tools/models/compare.ts
+++ b/google-gemini/server/tools/models/compare.ts
@@ -3,7 +3,7 @@
  * Compare multiple models side-by-side to help choose the best one
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { getGeminiApiKey } from "server/lib/env.ts";
 import { z } from "zod";
 import { GeminiClient } from "../../lib/gemini-client.ts";
@@ -11,7 +11,7 @@ import type { Env } from "../../main.ts";
 import { compareModels } from "./utils.ts";
 
 export const createCompareModelsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COMPARE_MODELS",
     description:
       "Compare multiple Google Gemini models side-by-side to help choose the best model for a specific use case. " +
@@ -48,7 +48,8 @@ export const createCompareModelsTool = (env: Env) =>
         .optional()
         .describe("Automated recommendation based on comparison"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { modelIds, criteria } = context;
       const client = new GeminiClient({
         apiKey: getGeminiApiKey(env),

--- a/google-gemini/server/tools/models/recommend.ts
+++ b/google-gemini/server/tools/models/recommend.ts
@@ -3,7 +3,7 @@
  * Get AI model recommendations based on task requirements
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { getGeminiApiKey } from "server/lib/env.ts";
 import { z } from "zod";
 import { GeminiClient } from "../../lib/gemini-client.ts";
@@ -11,7 +11,7 @@ import type { Env } from "../../main.ts";
 import { recommendModelsForTask } from "./utils.ts";
 
 export const createRecommendModelTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "RECOMMEND_MODEL",
     description:
       "Get intelligent model recommendations based on your task description and requirements. " +
@@ -88,7 +88,8 @@ export const createRecommendModelTool = (env: Env) =>
         )
         .describe("Top recommended models ordered by score"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { taskDescription, requirements = {} } = context;
       const client = new GeminiClient({
         apiKey: getGeminiApiKey(env),

--- a/google-gemini/tsconfig.json
+++ b/google-gemini/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "ES2024", "DOM", "DOM.Iterable"],

--- a/google-gmail/package.json
+++ b/google-gmail/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/google-gmail/server/tools/drafts.ts
+++ b/google-gmail/server/tools/drafts.ts
@@ -4,7 +4,7 @@
  * Tools for listing, creating, updating, sending, and deleting drafts
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { GmailClient, getAccessToken } from "../lib/gmail-client.ts";
@@ -38,7 +38,7 @@ const ParsedDraftSchema = z.object({
 // ============================================================================
 
 export const createListDraftsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_list_drafts",
     description:
       "List all draft emails saved in Gmail. Drafts are unsent emails that can be edited or sent later.",
@@ -57,7 +57,8 @@ export const createListDraftsTool = (env: Env) =>
       drafts: z.array(DraftSchema).describe("List of drafts"),
       nextPageToken: z.string().optional().describe("Token for next page"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -83,7 +84,7 @@ export const createListDraftsTool = (env: Env) =>
 // ============================================================================
 
 export const createGetDraftTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_get_draft",
     description:
       "Get a specific draft email with its full content including recipient, subject, and body.",
@@ -93,7 +94,8 @@ export const createGetDraftTool = (env: Env) =>
     outputSchema: z.object({
       draft: ParsedDraftSchema.describe("Draft details"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -120,7 +122,7 @@ export const createGetDraftTool = (env: Env) =>
 // ============================================================================
 
 export const createCreateDraftTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_create_draft",
     description:
       "Create a new draft email in Gmail. The draft will be saved but not sent until you use gmail_send_draft.",
@@ -139,7 +141,8 @@ export const createCreateDraftTool = (env: Env) =>
       draft: DraftSchema.describe("Created draft"),
       success: z.boolean().describe("Whether creation was successful"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -172,7 +175,7 @@ export const createCreateDraftTool = (env: Env) =>
 // ============================================================================
 
 export const createUpdateDraftTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_update_draft",
     description:
       "Update an existing draft email's content including recipient, subject, and body.",
@@ -188,7 +191,8 @@ export const createUpdateDraftTool = (env: Env) =>
       draft: DraftSchema.describe("Updated draft"),
       success: z.boolean().describe("Whether update was successful"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -219,7 +223,7 @@ export const createUpdateDraftTool = (env: Env) =>
 // ============================================================================
 
 export const createSendDraftTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_send_draft",
     description:
       "Send an existing draft email. The draft will be sent and moved from Drafts folder to Sent folder.",
@@ -231,7 +235,8 @@ export const createSendDraftTool = (env: Env) =>
       threadId: z.string().describe("Thread ID of the sent message"),
       success: z.boolean().describe("Whether sending was successful"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -251,7 +256,7 @@ export const createSendDraftTool = (env: Env) =>
 // ============================================================================
 
 export const createDeleteDraftTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_delete_draft",
     description:
       "Permanently delete a draft email from Gmail. This cannot be undone.",
@@ -262,7 +267,8 @@ export const createDeleteDraftTool = (env: Env) =>
       success: z.boolean().describe("Whether deletion was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });

--- a/google-gmail/server/tools/labels.ts
+++ b/google-gmail/server/tools/labels.ts
@@ -4,7 +4,7 @@
  * Tools for listing, creating, updating, and deleting labels
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { GmailClient, getAccessToken } from "../lib/gmail-client.ts";
@@ -42,7 +42,7 @@ const LabelSchema = z.object({
 // ============================================================================
 
 export const createListLabelsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_list_labels",
     description:
       "List all Gmail labels including system labels (INBOX, SENT, TRASH, etc.) and custom user-created labels.",
@@ -54,7 +54,8 @@ export const createListLabelsTool = (env: Env) =>
         .describe("System labels (INBOX, SENT, etc.)"),
       userLabels: z.array(LabelSchema).describe("User-created labels"),
     }),
-    execute: async ({ context: _context }) => {
+    execute: async ({ context: _context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -77,7 +78,7 @@ export const createListLabelsTool = (env: Env) =>
 // ============================================================================
 
 export const createGetLabelTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_get_label_details",
     description:
       "Get details of a specific Gmail label including message counts, unread counts, and visibility settings.",
@@ -87,7 +88,8 @@ export const createGetLabelTool = (env: Env) =>
     outputSchema: z.object({
       label: LabelSchema.describe("Label details"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -103,7 +105,7 @@ export const createGetLabelTool = (env: Env) =>
 // ============================================================================
 
 export const createCreateLabelTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_create_label",
     description:
       "Create a new custom Gmail label for organizing emails. You can set colors and visibility options.",
@@ -130,7 +132,8 @@ export const createCreateLabelTool = (env: Env) =>
       label: LabelSchema.describe("Created label"),
       success: z.boolean().describe("Whether creation was successful"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -163,7 +166,7 @@ export const createCreateLabelTool = (env: Env) =>
 // ============================================================================
 
 export const createUpdateLabelTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_update_label",
     description:
       "Update a Gmail label's name, color, or visibility settings. Note: Only custom user-created labels can be modified, not system labels.",
@@ -185,7 +188,8 @@ export const createUpdateLabelTool = (env: Env) =>
       label: LabelSchema.describe("Updated label"),
       success: z.boolean().describe("Whether update was successful"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -219,7 +223,7 @@ export const createUpdateLabelTool = (env: Env) =>
 // ============================================================================
 
 export const createDeleteLabelTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_delete_label",
     description:
       "Delete a custom Gmail label. Note: System labels (INBOX, SENT, etc.) cannot be deleted. Emails with this label will keep their content but lose the label.",
@@ -230,7 +234,8 @@ export const createDeleteLabelTool = (env: Env) =>
       success: z.boolean().describe("Whether deletion was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });

--- a/google-gmail/server/tools/messages.ts
+++ b/google-gmail/server/tools/messages.ts
@@ -4,7 +4,7 @@
  * Tools for listing, getting, sending, searching, and managing messages
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { GmailClient, getAccessToken } from "../lib/gmail-client.ts";
@@ -44,7 +44,7 @@ const ParsedMessageSchema = z.object({
 // ============================================================================
 
 export const createListMessagesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_list_emails",
     description:
       "List emails from Gmail inbox with subject, sender, and recipient information. Perfect for checking recent emails or filtering by labels.",
@@ -93,7 +93,8 @@ export const createListMessagesTool = (env: Env) =>
         .describe("Token for fetching the next page"),
       totalEmails: z.number().describe("Number of emails returned"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -139,7 +140,7 @@ export const createListMessagesTool = (env: Env) =>
 // ============================================================================
 
 export const createGetMessageTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_get_email_details",
     description:
       "Get the full content of a specific email including subject, body text, HTML, sender, recipients, and attachments. Use the email ID from gmail_list_emails.",
@@ -157,7 +158,8 @@ export const createGetMessageTool = (env: Env) =>
         "Full email details including body and attachments",
       ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -178,7 +180,7 @@ export const createGetMessageTool = (env: Env) =>
 // ============================================================================
 
 export const createSendMessageTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_send_email",
     description:
       "Send a new email from Gmail. Supports HTML content, CC, BCC, and replies to existing conversations.",
@@ -214,7 +216,8 @@ export const createSendMessageTool = (env: Env) =>
       success: z.boolean().describe("Whether the email was sent successfully"),
       message: z.string().describe("Confirmation message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -244,7 +247,7 @@ export const createSendMessageTool = (env: Env) =>
 // ============================================================================
 
 export const createSearchMessagesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_search_emails",
     description: `Search emails in Gmail using powerful query syntax. Returns full email details including subject, sender, body, and attachments.
 
@@ -282,7 +285,8 @@ Search Examples:
       nextPageToken: z.string().optional().describe("Token for next page"),
       totalResults: z.number().describe("Number of emails found"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -315,7 +319,7 @@ Search Examples:
 // ============================================================================
 
 export const createTrashMessageTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_move_email_to_trash",
     description:
       "Move an email to the Gmail trash. The email can be recovered later from trash.",
@@ -326,7 +330,8 @@ export const createTrashMessageTool = (env: Env) =>
       success: z.boolean().describe("Whether the email was moved to trash"),
       message: z.string().describe("Confirmation message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -345,7 +350,7 @@ export const createTrashMessageTool = (env: Env) =>
 // ============================================================================
 
 export const createUntrashMessageTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_restore_email_from_trash",
     description: "Restore an email from Gmail trash back to the inbox.",
     inputSchema: z.object({
@@ -355,7 +360,8 @@ export const createUntrashMessageTool = (env: Env) =>
       success: z.boolean().describe("Whether the email was restored"),
       message: z.string().describe("Confirmation message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -374,7 +380,7 @@ export const createUntrashMessageTool = (env: Env) =>
 // ============================================================================
 
 export const createDeleteMessageTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_permanently_delete_email",
     description:
       "PERMANENTLY delete an email from Gmail. WARNING: This cannot be undone! Use gmail_move_email_to_trash instead if you might need to recover the email later.",
@@ -385,7 +391,8 @@ export const createDeleteMessageTool = (env: Env) =>
       success: z.boolean().describe("Whether the email was deleted"),
       message: z.string().describe("Confirmation message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -404,7 +411,7 @@ export const createDeleteMessageTool = (env: Env) =>
 // ============================================================================
 
 export const createModifyMessageTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_update_email_labels",
     description: `Add or remove labels from an email. Use this to:
 - Mark as read: remove 'UNREAD' label
@@ -432,7 +439,8 @@ export const createModifyMessageTool = (env: Env) =>
         .describe("Updated list of labels on the email"),
       message: z.string().describe("Confirmation message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -456,7 +464,7 @@ export const createModifyMessageTool = (env: Env) =>
 // ============================================================================
 
 export const createBatchModifyMessagesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_batch_update_email_labels",
     description: `Add or remove labels from multiple emails at once in a single API call. Much more efficient than updating one email at a time. Use this to:
 - Mark multiple emails as read: remove 'UNREAD' label
@@ -490,7 +498,8 @@ Supports up to 1000 email IDs per call.`,
       count: z.number().describe("Number of emails modified"),
       message: z.string().describe("Confirmation message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });

--- a/google-gmail/server/tools/threads.ts
+++ b/google-gmail/server/tools/threads.ts
@@ -4,7 +4,7 @@
  * Tools for listing, getting, and managing email threads (conversations)
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { GmailClient, getAccessToken } from "../lib/gmail-client.ts";
@@ -40,7 +40,7 @@ const ThreadSchema = z.object({
 // ============================================================================
 
 export const createListThreadsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_list_conversations",
     description:
       "List email conversations (threads) from Gmail. A conversation groups all related emails together (replies, forwards, etc.).",
@@ -80,7 +80,8 @@ export const createListThreadsTool = (env: Env) =>
         .describe("List of threads"),
       nextPageToken: z.string().optional().describe("Token for next page"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -105,7 +106,7 @@ export const createListThreadsTool = (env: Env) =>
 // ============================================================================
 
 export const createGetThreadTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_get_conversation",
     description:
       "Get a complete email conversation with all messages in the thread. Perfect for viewing entire email exchanges.",
@@ -119,7 +120,8 @@ export const createGetThreadTool = (env: Env) =>
     outputSchema: z.object({
       thread: ThreadSchema.describe("Thread with all messages"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -161,7 +163,7 @@ export const createGetThreadTool = (env: Env) =>
 // ============================================================================
 
 export const createTrashThreadTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_move_conversation_to_trash",
     description:
       "Move an entire email conversation (all messages in the thread) to trash.",
@@ -172,7 +174,8 @@ export const createTrashThreadTool = (env: Env) =>
       success: z.boolean().describe("Whether operation was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -191,7 +194,7 @@ export const createTrashThreadTool = (env: Env) =>
 // ============================================================================
 
 export const createUntrashThreadTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_restore_conversation_from_trash",
     description:
       "Restore an entire email conversation from trash back to inbox.",
@@ -202,7 +205,8 @@ export const createUntrashThreadTool = (env: Env) =>
       success: z.boolean().describe("Whether operation was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -221,7 +225,7 @@ export const createUntrashThreadTool = (env: Env) =>
 // ============================================================================
 
 export const createModifyThreadTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_update_conversation_labels",
     description:
       "Add or remove labels from an entire email conversation. Use to archive, mark as read/unread, star, or organize conversations.",
@@ -242,7 +246,8 @@ export const createModifyThreadTool = (env: Env) =>
       success: z.boolean().describe("Whether operation was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });
@@ -265,7 +270,7 @@ export const createModifyThreadTool = (env: Env) =>
 // ============================================================================
 
 export const createDeleteThreadTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "gmail_permanently_delete_conversation",
     description:
       "PERMANENTLY delete an entire email conversation. WARNING: This cannot be undone! Use gmail_move_conversation_to_trash instead if you might need to recover later.",
@@ -276,7 +281,8 @@ export const createDeleteThreadTool = (env: Env) =>
       success: z.boolean().describe("Whether deletion was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GmailClient({
         accessToken: getAccessToken(env),
       });

--- a/google-meet/package.json
+++ b/google-meet/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/google-meet/server/tools/conferences.ts
+++ b/google-meet/server/tools/conferences.ts
@@ -2,7 +2,7 @@
  * Conference Records and Participants Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { MeetClient, getAccessToken } from "../lib/meet-client.ts";
@@ -23,7 +23,7 @@ const ParticipantSchema = z.object({
 });
 
 export const createListConferenceRecordsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_conference_records",
     description: "List conference records (past meetings).",
     inputSchema: z.object({
@@ -40,7 +40,8 @@ export const createListConferenceRecordsTool = (env: Env) =>
       conferences: z.array(ConferenceSchema),
       count: z.number(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new MeetClient({ accessToken: getAccessToken(env) });
       const records = await client.listConferenceRecords(
         context.filter,
@@ -59,7 +60,7 @@ export const createListConferenceRecordsTool = (env: Env) =>
   });
 
 export const createGetConferenceRecordTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_conference_record",
     description: "Get details about a specific conference record.",
     inputSchema: z.object({
@@ -70,7 +71,8 @@ export const createGetConferenceRecordTool = (env: Env) =>
     outputSchema: z.object({
       conference: ConferenceSchema,
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new MeetClient({ accessToken: getAccessToken(env) });
       const record = await client.getConferenceRecord(context.name);
       return {
@@ -85,7 +87,7 @@ export const createGetConferenceRecordTool = (env: Env) =>
   });
 
 export const createListParticipantsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_participants",
     description: "List participants of a conference.",
     inputSchema: z.object({
@@ -96,7 +98,8 @@ export const createListParticipantsTool = (env: Env) =>
       participants: z.array(ParticipantSchema),
       count: z.number(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new MeetClient({ accessToken: getAccessToken(env) });
       const participants = await client.listParticipants(
         context.conferenceRecord,
@@ -125,7 +128,7 @@ export const createListParticipantsTool = (env: Env) =>
   });
 
 export const createGetParticipantSessionsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_participant_sessions",
     description:
       "Get session details for a participant (when they joined/left).",
@@ -141,7 +144,8 @@ export const createGetParticipantSessionsTool = (env: Env) =>
         }),
       ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new MeetClient({ accessToken: getAccessToken(env) });
       const sessions = await client.listParticipantSessions(
         context.participantName,

--- a/google-meet/server/tools/recordings.ts
+++ b/google-meet/server/tools/recordings.ts
@@ -2,7 +2,7 @@
  * Recordings and Transcripts Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { MeetClient, getAccessToken } from "../lib/meet-client.ts";
@@ -26,7 +26,7 @@ const TranscriptSchema = z.object({
 });
 
 export const createListRecordingsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_recordings",
     description: "List recordings for a conference.",
     inputSchema: z.object({
@@ -36,7 +36,8 @@ export const createListRecordingsTool = (env: Env) =>
       recordings: z.array(RecordingSchema),
       count: z.number(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new MeetClient({ accessToken: getAccessToken(env) });
       const recordings = await client.listRecordings(context.conferenceRecord);
       return {
@@ -54,7 +55,7 @@ export const createListRecordingsTool = (env: Env) =>
   });
 
 export const createGetRecordingTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_recording",
     description: "Get details about a specific recording.",
     inputSchema: z.object({
@@ -63,7 +64,8 @@ export const createGetRecordingTool = (env: Env) =>
     outputSchema: z.object({
       recording: RecordingSchema,
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new MeetClient({ accessToken: getAccessToken(env) });
       const recording = await client.getRecording(context.name);
       return {
@@ -80,7 +82,7 @@ export const createGetRecordingTool = (env: Env) =>
   });
 
 export const createListTranscriptsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_transcripts",
     description: "List transcripts for a conference.",
     inputSchema: z.object({
@@ -90,7 +92,8 @@ export const createListTranscriptsTool = (env: Env) =>
       transcripts: z.array(TranscriptSchema),
       count: z.number(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new MeetClient({ accessToken: getAccessToken(env) });
       const transcripts = await client.listTranscripts(
         context.conferenceRecord,
@@ -110,7 +113,7 @@ export const createListTranscriptsTool = (env: Env) =>
   });
 
 export const createListTranscriptEntriesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_transcript_entries",
     description: "Get transcript entries (what was said during the meeting).",
     inputSchema: z.object({
@@ -130,7 +133,8 @@ export const createListTranscriptEntriesTool = (env: Env) =>
       ),
       count: z.number(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new MeetClient({ accessToken: getAccessToken(env) });
       const entries = await client.listTranscriptEntries(
         context.transcriptName,

--- a/google-meet/server/tools/spaces.ts
+++ b/google-meet/server/tools/spaces.ts
@@ -2,7 +2,7 @@
  * Meeting Space Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { MeetClient, getAccessToken } from "../lib/meet-client.ts";
@@ -17,7 +17,7 @@ const SpaceSchema = z.object({
 });
 
 export const createCreateMeetingTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_meeting",
     description: "Create a new Google Meet meeting space.",
     inputSchema: z.object({
@@ -37,7 +37,8 @@ export const createCreateMeetingTool = (env: Env) =>
       meetingLink: z.string(),
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new MeetClient({ accessToken: getAccessToken(env) });
       const space = await client.createSpace({
         accessType: context.accessType,
@@ -59,7 +60,7 @@ export const createCreateMeetingTool = (env: Env) =>
   });
 
 export const createGetMeetingTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_meeting",
     description: "Get details about a meeting space.",
     inputSchema: z.object({
@@ -68,7 +69,8 @@ export const createGetMeetingTool = (env: Env) =>
     outputSchema: z.object({
       meeting: SpaceSchema,
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new MeetClient({ accessToken: getAccessToken(env) });
       const space = await client.getSpace(context.spaceName);
       return {
@@ -85,7 +87,7 @@ export const createGetMeetingTool = (env: Env) =>
   });
 
 export const createEndMeetingTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "end_meeting",
     description: "End an active conference in a meeting space.",
     inputSchema: z.object({
@@ -95,7 +97,8 @@ export const createEndMeetingTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new MeetClient({ accessToken: getAccessToken(env) });
       await client.endActiveConference(context.spaceName);
       return { success: true, message: "Conference ended" };
@@ -103,7 +106,7 @@ export const createEndMeetingTool = (env: Env) =>
   });
 
 export const createUpdateMeetingTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "update_meeting",
     description: "Update meeting space settings.",
     inputSchema: z.object({
@@ -121,7 +124,8 @@ export const createUpdateMeetingTool = (env: Env) =>
       meeting: SpaceSchema,
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new MeetClient({ accessToken: getAccessToken(env) });
       const space = await client.updateSpace(context.spaceName, {
         accessType: context.accessType,

--- a/google-search-console/package.json
+++ b/google-search-console/package.json
@@ -12,7 +12,7 @@
     "publish": "cat app.json | deco registry publish -w /shared/deco -y"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/google-search-console/server/tools/search-analytics.ts
+++ b/google-search-console/server/tools/search-analytics.ts
@@ -4,7 +4,7 @@
  * Tools for querying search analytics data
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import {
@@ -34,7 +34,7 @@ const SearchAnalyticsRowSchema = z.object({
 // ============================================================================
 
 export const createQuerySearchAnalyticsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "query_search_analytics",
     description:
       "Query search analytics data (clicks, impressions, CTR, position) with filters by date, query, page, country, device, and search type",
@@ -136,7 +136,8 @@ export const createQuerySearchAnalyticsTool = (env: Env) =>
         .array(SearchAnalyticsRowSchema)
         .describe("Search analytics data rows"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SearchConsoleClient({
         accessToken: getAccessToken(env),
       });

--- a/google-search-console/server/tools/sitemaps.ts
+++ b/google-search-console/server/tools/sitemaps.ts
@@ -4,7 +4,7 @@
  * Tools for listing, getting, submitting, and deleting sitemaps
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import {
@@ -43,7 +43,7 @@ const SitemapSchema = z.object({
 // ============================================================================
 
 export const createListSitemapsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_sitemaps",
     description: "List all sitemaps for a site",
     inputSchema: z.object({
@@ -56,7 +56,8 @@ export const createListSitemapsTool = (env: Env) =>
     outputSchema: z.object({
       sitemaps: z.array(SitemapSchema).describe("List of sitemaps"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SearchConsoleClient({
         accessToken: getAccessToken(env),
       });
@@ -87,7 +88,7 @@ export const createListSitemapsTool = (env: Env) =>
 // ============================================================================
 
 export const createGetSitemapTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_sitemap",
     description: "Get information about a specific sitemap",
     inputSchema: z.object({
@@ -101,7 +102,8 @@ export const createGetSitemapTool = (env: Env) =>
     outputSchema: z.object({
       sitemap: SitemapSchema,
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SearchConsoleClient({
         accessToken: getAccessToken(env),
       });
@@ -134,7 +136,7 @@ export const createGetSitemapTool = (env: Env) =>
 // ============================================================================
 
 export const createSubmitSitemapTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "submit_sitemap",
     description: "Submit a sitemap to Google Search Console",
     inputSchema: z.object({
@@ -152,7 +154,8 @@ export const createSubmitSitemapTool = (env: Env) =>
       siteUrl: z.string().describe("The site URL"),
       feedpath: z.string().describe("The sitemap feedpath that was submitted"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SearchConsoleClient({
         accessToken: getAccessToken(env),
       });
@@ -172,7 +175,7 @@ export const createSubmitSitemapTool = (env: Env) =>
 // ============================================================================
 
 export const createDeleteSitemapTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_sitemap",
     description: "Delete a sitemap from Google Search Console",
     inputSchema: z.object({
@@ -190,7 +193,8 @@ export const createDeleteSitemapTool = (env: Env) =>
       siteUrl: z.string().describe("The site URL"),
       feedpath: z.string().describe("The sitemap feedpath that was deleted"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SearchConsoleClient({
         accessToken: getAccessToken(env),
       });

--- a/google-search-console/server/tools/sites.ts
+++ b/google-search-console/server/tools/sites.ts
@@ -4,7 +4,7 @@
  * Tools for listing, getting, adding, and removing sites
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import {
@@ -33,7 +33,7 @@ const SiteEntrySchema = z.object({
 // ============================================================================
 
 export const createListSitesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_sites",
     description:
       "List all sites in Google Search Console for the authenticated user",
@@ -41,7 +41,8 @@ export const createListSitesTool = (env: Env) =>
     outputSchema: z.object({
       sites: z.array(SiteEntrySchema).describe("List of sites"),
     }),
-    execute: async () => {
+    execute: async (_input, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SearchConsoleClient({
         accessToken: getAccessToken(env),
       });
@@ -63,7 +64,7 @@ export const createListSitesTool = (env: Env) =>
 // ============================================================================
 
 export const createGetSiteTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_site",
     description: "Get information about a specific site",
     inputSchema: z.object({
@@ -76,7 +77,8 @@ export const createGetSiteTool = (env: Env) =>
     outputSchema: z.object({
       site: SiteEntrySchema,
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SearchConsoleClient({
         accessToken: getAccessToken(env),
       });
@@ -97,7 +99,7 @@ export const createGetSiteTool = (env: Env) =>
 // ============================================================================
 
 export const createAddSiteTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "add_site",
     description: "Add a new site to Google Search Console",
     inputSchema: z.object({
@@ -111,7 +113,8 @@ export const createAddSiteTool = (env: Env) =>
       success: z.boolean().describe("Whether the site was added successfully"),
       siteUrl: z.string().describe("The site URL that was added"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SearchConsoleClient({
         accessToken: getAccessToken(env),
       });
@@ -130,7 +133,7 @@ export const createAddSiteTool = (env: Env) =>
 // ============================================================================
 
 export const createRemoveSiteTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "remove_site",
     description: "Remove a site from Google Search Console",
     inputSchema: z.object({
@@ -146,7 +149,8 @@ export const createRemoveSiteTool = (env: Env) =>
         .describe("Whether the site was removed successfully"),
       siteUrl: z.string().describe("The site URL that was removed"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SearchConsoleClient({
         accessToken: getAccessToken(env),
       });

--- a/google-search-console/server/tools/url-inspection.ts
+++ b/google-search-console/server/tools/url-inspection.ts
@@ -4,7 +4,7 @@
  * Tools for inspecting URL index status
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import {
@@ -138,7 +138,7 @@ const UrlInspectionResultSchema = z.object({
 // ============================================================================
 
 export const createInspectUrlTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "inspect_url",
     description:
       "Inspect a URL's Google index status, including indexing state, mobile usability, AMP status, and rich results",
@@ -157,7 +157,8 @@ export const createInspectUrlTool = (env: Env) =>
     outputSchema: z.object({
       inspectionResult: UrlInspectionResultSchema,
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SearchConsoleClient({
         accessToken: getAccessToken(env),
       });

--- a/google-sheets/package.json
+++ b/google-sheets/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/google-sheets/server/tools/advanced.ts
+++ b/google-sheets/server/tools/advanced.ts
@@ -2,7 +2,7 @@
  * Advanced Tools (Charts, Data Validation, Conditional Formatting, Protected Ranges)
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { SheetsClient, getAccessToken } from "../lib/sheets-client.ts";
@@ -18,7 +18,7 @@ const ColorSchema = z.object({
 // ============================================
 
 export const createCreateChartTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_chart",
     description:
       "Create a chart (bar, line, column, area, or pie) from spreadsheet data.",
@@ -62,7 +62,8 @@ export const createCreateChartTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.addChart(
         context.spreadsheetId,
@@ -93,7 +94,7 @@ export const createCreateChartTool = (env: Env) =>
   });
 
 export const createDeleteChartTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_chart",
     description: "Delete a chart from a spreadsheet by its ID.",
     inputSchema: z.object({
@@ -104,7 +105,8 @@ export const createDeleteChartTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.deleteChart(context.spreadsheetId, context.chartId);
       return { success: true, message: `Chart ${context.chartId} deleted` };
@@ -116,7 +118,7 @@ export const createDeleteChartTool = (env: Env) =>
 // ============================================
 
 export const createAddDataValidationTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "add_data_validation",
     description:
       "Add data validation (dropdown list, checkbox, number constraints, etc.) to a cell range.",
@@ -162,7 +164,8 @@ export const createAddDataValidationTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.setDataValidation(
         context.spreadsheetId,
@@ -187,7 +190,7 @@ export const createAddDataValidationTool = (env: Env) =>
   });
 
 export const createClearDataValidationTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "clear_data_validation",
     description: "Remove data validation from a cell range.",
     inputSchema: z.object({
@@ -202,7 +205,8 @@ export const createClearDataValidationTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.clearDataValidation(
         context.spreadsheetId,
@@ -221,7 +225,7 @@ export const createClearDataValidationTool = (env: Env) =>
 // ============================================
 
 export const createAddConditionalFormattingTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "add_conditional_formatting",
     description:
       "Add a conditional formatting rule that applies formatting when a condition is met.",
@@ -287,7 +291,8 @@ export const createAddConditionalFormattingTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.addConditionalFormatRule(
         context.spreadsheetId,
@@ -316,7 +321,7 @@ export const createAddConditionalFormattingTool = (env: Env) =>
   });
 
 export const createClearConditionalFormattingTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "clear_conditional_formatting",
     description: "Remove a conditional formatting rule by its index.",
     inputSchema: z.object({
@@ -330,7 +335,8 @@ export const createClearConditionalFormattingTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.deleteConditionalFormatRule(
         context.spreadsheetId,
@@ -349,7 +355,7 @@ export const createClearConditionalFormattingTool = (env: Env) =>
 // ============================================
 
 export const createProtectRangeTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "protect_range",
     description:
       "Protect a range of cells from editing. Use this to prevent accidental changes to formulas or important data.",
@@ -375,7 +381,8 @@ export const createProtectRangeTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.addProtectedRange(
         context.spreadsheetId,
@@ -394,7 +401,7 @@ export const createProtectRangeTool = (env: Env) =>
   });
 
 export const createUnprotectRangeTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "unprotect_range",
     description: "Remove protection from a range by its protected range ID.",
     inputSchema: z.object({
@@ -407,7 +414,8 @@ export const createUnprotectRangeTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.deleteProtectedRange(
         context.spreadsheetId,

--- a/google-sheets/server/tools/analysis.ts
+++ b/google-sheets/server/tools/analysis.ts
@@ -2,7 +2,7 @@
  * Analysis Tools (Named Ranges, Pivot Tables)
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { SheetsClient, getAccessToken } from "../lib/sheets-client.ts";
@@ -12,7 +12,7 @@ import { SheetsClient, getAccessToken } from "../lib/sheets-client.ts";
 // ============================================
 
 export const createAddNamedRangeTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_named_range",
     description:
       "Create a named range. Named ranges allow you to reference a range by a friendly name in formulas (e.g., =SUM(SalesData) instead of =SUM(A1:A100)).",
@@ -33,7 +33,8 @@ export const createAddNamedRangeTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.addNamedRange(
         context.spreadsheetId,
@@ -52,7 +53,7 @@ export const createAddNamedRangeTool = (env: Env) =>
   });
 
 export const createDeleteNamedRangeTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_named_range",
     description: "Delete a named range by its ID.",
     inputSchema: z.object({
@@ -63,7 +64,8 @@ export const createDeleteNamedRangeTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.deleteNamedRange(
         context.spreadsheetId,
@@ -116,7 +118,7 @@ const PivotValueSchema = z.object({
 });
 
 export const createPivotTableTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_pivot_table",
     description:
       "Create a pivot table to summarize and analyze data. Pivot tables can group, aggregate, and cross-tabulate data.",
@@ -165,7 +167,8 @@ export const createPivotTableTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.createPivotTable(
         context.spreadsheetId,

--- a/google-sheets/server/tools/dimensions.ts
+++ b/google-sheets/server/tools/dimensions.ts
@@ -2,14 +2,14 @@
  * Dimension Operations Tools (Insert/Delete/Move/Hide/Resize Rows and Columns)
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { SheetsClient, getAccessToken } from "../lib/sheets-client.ts";
 
 // Insert Rows
 export const createInsertRowsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "insert_rows",
     description: "Insert empty rows at a specific position in a sheet.",
     inputSchema: z.object({
@@ -28,7 +28,8 @@ export const createInsertRowsTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.insertDimension(
         context.spreadsheetId,
@@ -47,7 +48,7 @@ export const createInsertRowsTool = (env: Env) =>
 
 // Insert Columns
 export const createInsertColumnsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "insert_columns",
     description: "Insert empty columns at a specific position in a sheet.",
     inputSchema: z.object({
@@ -68,7 +69,8 @@ export const createInsertColumnsTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.insertDimension(
         context.spreadsheetId,
@@ -87,7 +89,7 @@ export const createInsertColumnsTool = (env: Env) =>
 
 // Delete Rows
 export const createDeleteRowsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_rows",
     description: "Delete rows from a sheet.",
     inputSchema: z.object({
@@ -100,7 +102,8 @@ export const createDeleteRowsTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.deleteDimension(
         context.spreadsheetId,
@@ -118,7 +121,7 @@ export const createDeleteRowsTool = (env: Env) =>
 
 // Delete Columns
 export const createDeleteColumnsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_columns",
     description: "Delete columns from a sheet.",
     inputSchema: z.object({
@@ -133,7 +136,8 @@ export const createDeleteColumnsTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.deleteDimension(
         context.spreadsheetId,
@@ -151,7 +155,7 @@ export const createDeleteColumnsTool = (env: Env) =>
 
 // Move Rows
 export const createMoveRowsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "move_rows",
     description: "Move rows to a different position in the sheet.",
     inputSchema: z.object({
@@ -169,7 +173,8 @@ export const createMoveRowsTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.moveDimension(
         context.spreadsheetId,
@@ -188,7 +193,7 @@ export const createMoveRowsTool = (env: Env) =>
 
 // Move Columns
 export const createMoveColumnsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "move_columns",
     description: "Move columns to a different position in the sheet.",
     inputSchema: z.object({
@@ -206,7 +211,8 @@ export const createMoveColumnsTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.moveDimension(
         context.spreadsheetId,
@@ -225,7 +231,7 @@ export const createMoveColumnsTool = (env: Env) =>
 
 // Hide Rows
 export const createHideRowsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "hide_rows",
     description: "Hide rows in a sheet.",
     inputSchema: z.object({
@@ -242,7 +248,8 @@ export const createHideRowsTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       const hidden = context.hidden ?? true;
       await client.updateDimensionProperties(
@@ -262,7 +269,7 @@ export const createHideRowsTool = (env: Env) =>
 
 // Hide Columns
 export const createHideColumnsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "hide_columns",
     description: "Hide columns in a sheet.",
     inputSchema: z.object({
@@ -281,7 +288,8 @@ export const createHideColumnsTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       const hidden = context.hidden ?? true;
       await client.updateDimensionProperties(
@@ -301,7 +309,7 @@ export const createHideColumnsTool = (env: Env) =>
 
 // Resize Rows
 export const createResizeRowsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "resize_rows",
     description: "Set the height of rows in pixels.",
     inputSchema: z.object({
@@ -315,7 +323,8 @@ export const createResizeRowsTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.updateDimensionProperties(
         context.spreadsheetId,
@@ -334,7 +343,7 @@ export const createResizeRowsTool = (env: Env) =>
 
 // Resize Columns
 export const createResizeColumnsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "resize_columns",
     description: "Set the width of columns in pixels.",
     inputSchema: z.object({
@@ -350,7 +359,8 @@ export const createResizeColumnsTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.updateDimensionProperties(
         context.spreadsheetId,

--- a/google-sheets/server/tools/filters.ts
+++ b/google-sheets/server/tools/filters.ts
@@ -2,7 +2,7 @@
  * Filter Operations Tools (Basic Filters, Filter Views, Slicers)
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { SheetsClient, getAccessToken } from "../lib/sheets-client.ts";
@@ -18,7 +18,7 @@ const ColorSchema = z.object({
 // ============================================
 
 export const createSetBasicFilterTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "set_basic_filter",
     description:
       "Create or update a basic filter on a range. Basic filters add dropdown arrows to column headers for filtering data.",
@@ -50,7 +50,8 @@ export const createSetBasicFilterTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.setBasicFilter(
         context.spreadsheetId,
@@ -66,7 +67,7 @@ export const createSetBasicFilterTool = (env: Env) =>
   });
 
 export const createClearBasicFilterTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "clear_basic_filter",
     description: "Remove the basic filter from a sheet.",
     inputSchema: z.object({
@@ -77,7 +78,8 @@ export const createClearBasicFilterTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.clearBasicFilter(context.spreadsheetId, context.sheetId);
       return { success: true, message: "Basic filter cleared" };
@@ -89,7 +91,7 @@ export const createClearBasicFilterTool = (env: Env) =>
 // ============================================
 
 export const createAddFilterViewTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_filter_view",
     description:
       "Create a named filter view. Filter views are saved filter configurations that can be accessed from the Data menu.",
@@ -118,7 +120,8 @@ export const createAddFilterViewTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.addFilterView(
         context.spreadsheetId,
@@ -138,7 +141,7 @@ export const createAddFilterViewTool = (env: Env) =>
   });
 
 export const createDeleteFilterViewTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_filter_view",
     description: "Delete a filter view by its ID.",
     inputSchema: z.object({
@@ -149,7 +152,8 @@ export const createDeleteFilterViewTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.deleteFilterView(context.spreadsheetId, context.filterId);
       return {
@@ -164,7 +168,7 @@ export const createDeleteFilterViewTool = (env: Env) =>
 // ============================================
 
 export const createAddSlicerTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "add_slicer",
     description:
       "Add a slicer (visual filter control) to the sheet. Slicers provide a visual way to filter data in tables and pivot tables.",
@@ -212,7 +216,8 @@ export const createAddSlicerTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.addSlicer(
         context.spreadsheetId,

--- a/google-sheets/server/tools/formatting.ts
+++ b/google-sheets/server/tools/formatting.ts
@@ -2,13 +2,13 @@
  * Formatting and Data Operations Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { SheetsClient, getAccessToken } from "../lib/sheets-client.ts";
 
 export const createFormatCellsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "format_cells",
     description:
       "Apply formatting to a range of cells (bold, italic, colors, font size).",
@@ -45,7 +45,8 @@ export const createFormatCellsTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.formatCells(
         context.spreadsheetId,
@@ -67,7 +68,7 @@ export const createFormatCellsTool = (env: Env) =>
   });
 
 export const createAutoResizeColumnsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "auto_resize_columns",
     description: "Auto-resize columns to fit their content.",
     inputSchema: z.object({
@@ -82,7 +83,8 @@ export const createAutoResizeColumnsTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.autoResizeColumns(
         context.spreadsheetId,
@@ -95,7 +97,7 @@ export const createAutoResizeColumnsTool = (env: Env) =>
   });
 
 export const createSortRangeTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "sort_range",
     description: "Sort a range of data by a specific column.",
     inputSchema: z.object({
@@ -117,7 +119,8 @@ export const createSortRangeTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.sortRange(
         context.spreadsheetId,
@@ -134,7 +137,7 @@ export const createSortRangeTool = (env: Env) =>
   });
 
 export const createFindReplaceTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "find_replace",
     description:
       "Find and replace text across a spreadsheet or specific sheet.",
@@ -158,7 +161,8 @@ export const createFindReplaceTool = (env: Env) =>
       sheetsChanged: z.number(),
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       const result = await client.findReplace(
         context.spreadsheetId,
@@ -186,7 +190,7 @@ export const createFindReplaceTool = (env: Env) =>
 // ============================================
 
 export const createMergeCellsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "merge_cells",
     description:
       "Merge multiple cells into one. Useful for creating titles or headers spanning multiple columns.",
@@ -208,7 +212,8 @@ export const createMergeCellsTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.mergeCells(
         context.spreadsheetId,
@@ -224,7 +229,7 @@ export const createMergeCellsTool = (env: Env) =>
   });
 
 export const createUnmergeCellsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "unmerge_cells",
     description: "Unmerge previously merged cells.",
     inputSchema: z.object({
@@ -239,7 +244,8 @@ export const createUnmergeCellsTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.unmergeCells(
         context.spreadsheetId,
@@ -277,7 +283,7 @@ const BorderSchema = z.object({
 });
 
 export const createSetBordersTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "set_borders",
     description: "Add or update borders around and within a range of cells.",
     inputSchema: z.object({
@@ -302,7 +308,8 @@ export const createSetBordersTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.updateBorders(
         context.spreadsheetId,
@@ -329,7 +336,7 @@ export const createSetBordersTool = (env: Env) =>
 // ============================================
 
 export const createAddBandingTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "add_banding",
     description:
       "Add alternating row colors (banding) to a range. Great for making tables easier to read.",
@@ -349,7 +356,8 @@ export const createAddBandingTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.addBanding(
         context.spreadsheetId,
@@ -377,7 +385,7 @@ export const createAddBandingTool = (env: Env) =>
 // ============================================
 
 export const createSetNumberFormatTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "set_number_format",
     description:
       "Set the number format for a range of cells (currency, percentage, date, etc.).",
@@ -411,7 +419,8 @@ export const createSetNumberFormatTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.setNumberFormat(
         context.spreadsheetId,
@@ -437,7 +446,7 @@ export const createSetNumberFormatTool = (env: Env) =>
 // ============================================
 
 export const createAddNoteTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "add_note",
     description:
       "Add a note (comment) to a cell. Notes appear when hovering over the cell.",
@@ -452,7 +461,8 @@ export const createAddNoteTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.addNote(
         context.spreadsheetId,

--- a/google-sheets/server/tools/spreadsheets.ts
+++ b/google-sheets/server/tools/spreadsheets.ts
@@ -2,7 +2,7 @@
  * Spreadsheet and Sheet Management Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { SheetsClient, getAccessToken } from "../lib/sheets-client.ts";
@@ -23,7 +23,7 @@ const SpreadsheetSchema = z.object({
 });
 
 export const createCreateSpreadsheetTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_spreadsheet",
     description: "Create a new Google Spreadsheet.",
     inputSchema: z.object({
@@ -33,7 +33,8 @@ export const createCreateSpreadsheetTool = (env: Env) =>
       spreadsheet: SpreadsheetSchema,
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       const result = await client.createSpreadsheet(context.title);
       return {
@@ -55,7 +56,7 @@ export const createCreateSpreadsheetTool = (env: Env) =>
   });
 
 export const createGetSpreadsheetTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_spreadsheet",
     description: "Get metadata about a spreadsheet including all sheet names.",
     inputSchema: z.object({
@@ -64,7 +65,8 @@ export const createGetSpreadsheetTool = (env: Env) =>
     outputSchema: z.object({
       spreadsheet: SpreadsheetSchema,
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       const result = await client.getSpreadsheet(context.spreadsheetId);
       return {
@@ -85,7 +87,7 @@ export const createGetSpreadsheetTool = (env: Env) =>
   });
 
 export const createAddSheetTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "add_sheet",
     description: "Add a new sheet/tab to an existing spreadsheet.",
     inputSchema: z.object({
@@ -96,7 +98,8 @@ export const createAddSheetTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.addSheet(context.spreadsheetId, context.title);
       return {
@@ -107,7 +110,7 @@ export const createAddSheetTool = (env: Env) =>
   });
 
 export const createDeleteSheetTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_sheet",
     description: "Delete a sheet/tab from a spreadsheet.",
     inputSchema: z.object({
@@ -120,7 +123,8 @@ export const createDeleteSheetTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.deleteSheet(context.spreadsheetId, context.sheetId);
       return {
@@ -131,7 +135,7 @@ export const createDeleteSheetTool = (env: Env) =>
   });
 
 export const createRenameSheetTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "rename_sheet",
     description: "Rename a sheet/tab in a spreadsheet.",
     inputSchema: z.object({
@@ -143,7 +147,8 @@ export const createRenameSheetTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.renameSheet(
         context.spreadsheetId,
@@ -162,7 +167,7 @@ export const createRenameSheetTool = (env: Env) =>
 // ============================================
 
 export const createDuplicateSheetTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "duplicate_sheet",
     description:
       "Create a copy of an existing sheet within the same spreadsheet.",
@@ -186,7 +191,8 @@ export const createDuplicateSheetTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.duplicateSheet(
         context.spreadsheetId,
@@ -208,7 +214,7 @@ export const createDuplicateSheetTool = (env: Env) =>
 // ============================================
 
 export const createFreezeRowsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "freeze_rows",
     description:
       "Freeze rows at the top of a sheet. Frozen rows stay visible when scrolling down. Useful for keeping headers visible.",
@@ -225,7 +231,8 @@ export const createFreezeRowsTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.freezeRows(
         context.spreadsheetId,
@@ -243,7 +250,7 @@ export const createFreezeRowsTool = (env: Env) =>
   });
 
 export const createFreezeColumnsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "freeze_columns",
     description:
       "Freeze columns at the left of a sheet. Frozen columns stay visible when scrolling right. Useful for keeping row labels visible.",
@@ -260,7 +267,8 @@ export const createFreezeColumnsTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       await client.freezeColumns(
         context.spreadsheetId,
@@ -282,7 +290,7 @@ export const createFreezeColumnsTool = (env: Env) =>
 // ============================================
 
 export const createGetSpreadsheetMetadataTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_spreadsheet_metadata",
     description:
       "Get enhanced metadata about a spreadsheet including actual data ranges and filled cell counts for each sheet. More detailed than get_spreadsheet - shows where data actually exists.",
@@ -305,7 +313,8 @@ export const createGetSpreadsheetMetadataTool = (env: Env) =>
         }),
       ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       const { spreadsheet, dataRanges } =
         await client.getSpreadsheetWithDataRanges(context.spreadsheetId);
@@ -337,7 +346,7 @@ export const createGetSpreadsheetMetadataTool = (env: Env) =>
 // ============================================
 
 export const createCopySheetTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "copy_sheet",
     description:
       "Copy a sheet to the same spreadsheet or to a different spreadsheet. Uses the native copyTo API endpoint.",
@@ -359,7 +368,8 @@ export const createCopySheetTool = (env: Env) =>
       newSheetTitle: z.string(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       const result = await client.copySheetTo(
         context.spreadsheetId,

--- a/google-sheets/server/tools/values.ts
+++ b/google-sheets/server/tools/values.ts
@@ -2,14 +2,14 @@
  * Value/Data Operations Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { SheetsClient, getAccessToken } from "../lib/sheets-client.ts";
 import { processHeaders } from "../lib/utils.ts";
 
 export const createReadRangeTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "read_range",
     description:
       "Read values from a range in a spreadsheet. Use A1 notation (e.g., 'Sheet1!A1:D10' or 'A1:D10').",
@@ -27,7 +27,8 @@ export const createReadRangeTool = (env: Env) =>
       rowCount: z.number(),
       columnCount: z.number(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       const result = await client.readRange(
         context.spreadsheetId,
@@ -47,7 +48,7 @@ export const createReadRangeTool = (env: Env) =>
   });
 
 export const createWriteRangeTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "write_range",
     description:
       "Write values to a range in a spreadsheet. Overwrites existing data.",
@@ -71,7 +72,8 @@ export const createWriteRangeTool = (env: Env) =>
       updatedCells: z.number(),
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       const result = await client.writeRange(
         context.spreadsheetId,
@@ -90,7 +92,7 @@ export const createWriteRangeTool = (env: Env) =>
   });
 
 export const createAppendRowsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "append_rows",
     description:
       "Append rows to the end of a table/range in a spreadsheet. Automatically finds the last row.",
@@ -109,7 +111,8 @@ export const createAppendRowsTool = (env: Env) =>
       updatedCells: z.number(),
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       const result = await client.appendRows(
         context.spreadsheetId,
@@ -128,7 +131,7 @@ export const createAppendRowsTool = (env: Env) =>
   });
 
 export const createClearRangeTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "clear_range",
     description: "Clear all values from a range (keeps formatting).",
     inputSchema: z.object({
@@ -139,7 +142,8 @@ export const createClearRangeTool = (env: Env) =>
       clearedRange: z.string(),
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       const result = await client.clearRange(
         context.spreadsheetId,
@@ -150,7 +154,7 @@ export const createClearRangeTool = (env: Env) =>
   });
 
 export const createBatchReadTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "batch_read",
     description: "Read multiple ranges from a spreadsheet in a single request.",
     inputSchema: z.object({
@@ -169,7 +173,8 @@ export const createBatchReadTool = (env: Env) =>
         }),
       ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       const result = await client.batchGetValues(
         context.spreadsheetId,
@@ -186,7 +191,7 @@ export const createBatchReadTool = (env: Env) =>
   });
 
 export const createBatchWriteTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "batch_write",
     description:
       "Write to multiple ranges in a spreadsheet in a single request.",
@@ -209,7 +214,8 @@ export const createBatchWriteTool = (env: Env) =>
       totalUpdatedSheets: z.number(),
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       const result = await client.batchUpdateValues(
         context.spreadsheetId,
@@ -231,7 +237,7 @@ export const createBatchWriteTool = (env: Env) =>
 // ============================================
 
 export const createReadFormulasTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "read_formulas",
     description:
       "Read formulas from a range in a spreadsheet. Unlike read_range which returns calculated values, this returns the actual formulas (e.g., '=SUM(A1:A10)' instead of '100').",
@@ -253,7 +259,8 @@ export const createReadFormulasTool = (env: Env) =>
       rowCount: z.number(),
       columnCount: z.number(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       const result = await client.readFormulas(
         context.spreadsheetId,
@@ -277,7 +284,7 @@ export const createReadFormulasTool = (env: Env) =>
 // ============================================
 
 export const createGetSheetHeadersTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_sheet_headers",
     description:
       "Get structured header information from a sheet. Returns column labels, header-to-index mapping, and header values array. Useful for understanding column structure before querying data.",
@@ -305,7 +312,8 @@ export const createGetSheetHeadersTool = (env: Env) =>
       headerValues: z.array(z.string()).describe("Array of header values"),
       columnCount: z.number().describe("Number of columns with headers"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       const result = await client.getSheetHeaders(
         context.spreadsheetId,
@@ -331,7 +339,7 @@ export const createGetSheetHeadersTool = (env: Env) =>
 // ============================================
 
 export const createSearchDataTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "search_data",
     description:
       "Search for a term across columns in a sheet. Returns matching rows with row numbers. Useful for finding specific data without knowing the exact location.",
@@ -370,7 +378,8 @@ export const createSearchDataTool = (env: Env) =>
         .describe("Matching rows"),
       totalMatches: z.number().describe("Total number of matches found"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SheetsClient({ accessToken: getAccessToken(env) });
       const result = await client.searchInSheet(
         context.spreadsheetId,

--- a/google-slides/package.json
+++ b/google-slides/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/google-slides/server/tools/elements.ts
+++ b/google-slides/server/tools/elements.ts
@@ -2,7 +2,7 @@
  * Element Insertion Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { SlidesClient, getAccessToken } from "../lib/slides-client.ts";
@@ -24,7 +24,7 @@ const ShapeEnum = z.enum([
 ]);
 
 export const createInsertTextTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "insert_text",
     description:
       "Insert a text box on a slide. Positions are in points (72 points = 1 inch).",
@@ -41,7 +41,8 @@ export const createInsertTextTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SlidesClient({ accessToken: getAccessToken(env) });
       await client.insertTextBox(
         context.presentationId,
@@ -57,7 +58,7 @@ export const createInsertTextTool = (env: Env) =>
   });
 
 export const createInsertImageTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "insert_image",
     description: "Insert an image on a slide from URL.",
     inputSchema: z.object({
@@ -76,7 +77,8 @@ export const createInsertImageTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SlidesClient({ accessToken: getAccessToken(env) });
       await client.insertImage(
         context.presentationId,
@@ -92,7 +94,7 @@ export const createInsertImageTool = (env: Env) =>
   });
 
 export const createInsertShapeTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "insert_shape",
     description: "Insert a shape on a slide.",
     inputSchema: z.object({
@@ -108,7 +110,8 @@ export const createInsertShapeTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SlidesClient({ accessToken: getAccessToken(env) });
       await client.insertShape(
         context.presentationId,
@@ -124,7 +127,7 @@ export const createInsertShapeTool = (env: Env) =>
   });
 
 export const createInsertTableTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "insert_table",
     description: "Insert a table on a slide.",
     inputSchema: z.object({
@@ -141,7 +144,8 @@ export const createInsertTableTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SlidesClient({ accessToken: getAccessToken(env) });
       await client.insertTable(
         context.presentationId,
@@ -161,7 +165,7 @@ export const createInsertTableTool = (env: Env) =>
   });
 
 export const createDeleteElementTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_element",
     description: "Delete an element from a slide.",
     inputSchema: z.object({
@@ -172,7 +176,8 @@ export const createDeleteElementTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SlidesClient({ accessToken: getAccessToken(env) });
       await client.deleteElement(context.presentationId, context.elementId);
       return { success: true, message: "Element deleted" };
@@ -180,7 +185,7 @@ export const createDeleteElementTool = (env: Env) =>
   });
 
 export const createReplaceTextTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "replace_text",
     description: "Find and replace text across all slides.",
     inputSchema: z.object({
@@ -193,7 +198,8 @@ export const createReplaceTextTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SlidesClient({ accessToken: getAccessToken(env) });
       const result = await client.replaceAllText(
         context.presentationId,

--- a/google-slides/server/tools/presentations.ts
+++ b/google-slides/server/tools/presentations.ts
@@ -2,7 +2,7 @@
  * Presentation Management Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { SlidesClient, getAccessToken } from "../lib/slides-client.ts";
@@ -20,7 +20,7 @@ const SlideSchema = z.object({
 });
 
 export const createCreatePresentationTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_presentation",
     description: "Create a new Google Slides presentation.",
     inputSchema: z.object({
@@ -30,7 +30,8 @@ export const createCreatePresentationTool = (env: Env) =>
       presentation: PresentationSchema,
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SlidesClient({ accessToken: getAccessToken(env) });
       const pres = await client.createPresentation(context.title);
       return {
@@ -45,7 +46,7 @@ export const createCreatePresentationTool = (env: Env) =>
   });
 
 export const createGetPresentationTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_presentation",
     description: "Get presentation details and slide list.",
     inputSchema: z.object({
@@ -55,7 +56,8 @@ export const createGetPresentationTool = (env: Env) =>
       presentation: PresentationSchema,
       slides: z.array(SlideSchema),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SlidesClient({ accessToken: getAccessToken(env) });
       const pres = await client.getPresentation(context.presentationId);
       return {

--- a/google-slides/server/tools/slides.ts
+++ b/google-slides/server/tools/slides.ts
@@ -2,7 +2,7 @@
  * Slide Management Tools
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { SlidesClient, getAccessToken } from "../lib/slides-client.ts";
@@ -23,7 +23,7 @@ const LayoutEnum = z.enum([
 ]);
 
 export const createAddSlideTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "add_slide",
     description: "Add a new slide to the presentation.",
     inputSchema: z.object({
@@ -39,7 +39,8 @@ export const createAddSlideTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SlidesClient({ accessToken: getAccessToken(env) });
       const result = await client.addSlide(
         context.presentationId,
@@ -52,7 +53,7 @@ export const createAddSlideTool = (env: Env) =>
   });
 
 export const createDeleteSlideTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_slide",
     description: "Delete a slide from the presentation.",
     inputSchema: z.object({
@@ -63,7 +64,8 @@ export const createDeleteSlideTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SlidesClient({ accessToken: getAccessToken(env) });
       await client.deleteSlide(context.presentationId, context.slideId);
       return { success: true, message: "Slide deleted" };
@@ -71,7 +73,7 @@ export const createDeleteSlideTool = (env: Env) =>
   });
 
 export const createDuplicateSlideTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "duplicate_slide",
     description: "Create a copy of an existing slide.",
     inputSchema: z.object({
@@ -82,7 +84,8 @@ export const createDuplicateSlideTool = (env: Env) =>
       newSlideId: z.string().optional(),
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SlidesClient({ accessToken: getAccessToken(env) });
       const result = await client.duplicateSlide(
         context.presentationId,
@@ -94,7 +97,7 @@ export const createDuplicateSlideTool = (env: Env) =>
   });
 
 export const createMoveSlideTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "move_slide",
     description: "Move a slide to a different position.",
     inputSchema: z.object({
@@ -106,7 +109,8 @@ export const createMoveSlideTool = (env: Env) =>
       success: z.boolean(),
       message: z.string(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new SlidesClient({ accessToken: getAccessToken(env) });
       await client.moveSlide(
         context.presentationId,

--- a/google-tag-manager/package.json
+++ b/google-tag-manager/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/google-tag-manager/server/tools/accounts.ts
+++ b/google-tag-manager/server/tools/accounts.ts
@@ -4,7 +4,7 @@
  * Tools for listing and getting GTM accounts
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { GTMClient, getAccessToken } from "../lib/gtm-client.ts";
@@ -14,7 +14,7 @@ import { GTMClient, getAccessToken } from "../lib/gtm-client.ts";
 // ============================================================================
 
 export const createListAccountsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_accounts",
     description:
       "List all GTM accounts accessible by the authenticated user. Returns account IDs, names, and metadata.",
@@ -43,7 +43,8 @@ export const createListAccountsTool = (env: Env) =>
       ),
       nextPageToken: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -74,7 +75,7 @@ export const createListAccountsTool = (env: Env) =>
 // ============================================================================
 
 export const createGetAccountTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_account",
     description:
       "Get detailed information about a specific GTM account by its ID.",
@@ -97,7 +98,8 @@ export const createGetAccountTool = (env: Env) =>
           .optional(),
       }),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });

--- a/google-tag-manager/server/tools/containers.ts
+++ b/google-tag-manager/server/tools/containers.ts
@@ -4,7 +4,7 @@
  * Tools for managing GTM containers
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { GTMClient, getAccessToken } from "../lib/gtm-client.ts";
@@ -48,7 +48,7 @@ const ContainerSchema = z.object({
 // ============================================================================
 
 export const createListContainersTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_containers",
     description:
       "List all containers in a GTM account. Returns container IDs, names, and usage contexts.",
@@ -66,7 +66,8 @@ export const createListContainersTool = (env: Env) =>
         .optional()
         .describe("Token for fetching next page"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -100,7 +101,7 @@ export const createListContainersTool = (env: Env) =>
 // ============================================================================
 
 export const createGetContainerTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_container",
     description: "Get detailed information about a specific GTM container.",
     inputSchema: z.object({
@@ -110,7 +111,8 @@ export const createGetContainerTool = (env: Env) =>
     outputSchema: z.object({
       container: ContainerSchema.describe("Container details"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -143,7 +145,7 @@ export const createGetContainerTool = (env: Env) =>
 // ============================================================================
 
 export const createCreateContainerTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_container",
     description: "Create a new GTM container in an account.",
     inputSchema: z.object({
@@ -161,7 +163,8 @@ export const createCreateContainerTool = (env: Env) =>
     outputSchema: z.object({
       container: ContainerSchema.describe("Created container"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -196,7 +199,7 @@ export const createCreateContainerTool = (env: Env) =>
 // ============================================================================
 
 export const createDeleteContainerTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_container",
     description:
       "Delete a GTM container. Warning: This action cannot be undone.",
@@ -208,7 +211,8 @@ export const createDeleteContainerTool = (env: Env) =>
       success: z.boolean().describe("Whether the deletion was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });

--- a/google-tag-manager/server/tools/tags.ts
+++ b/google-tag-manager/server/tools/tags.ts
@@ -4,7 +4,7 @@
  * Tools for managing GTM tags
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { GTMClient, getAccessToken } from "../lib/gtm-client.ts";
@@ -78,7 +78,7 @@ const TagSchema = z.object({
 // ============================================================================
 
 export const createListTagsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_tags",
     description:
       "List all tags in a GTM workspace. Returns tag IDs, names, types, and configurations.",
@@ -98,7 +98,8 @@ export const createListTagsTool = (env: Env) =>
         .optional()
         .describe("Token for fetching next page"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -142,7 +143,7 @@ export const createListTagsTool = (env: Env) =>
 // ============================================================================
 
 export const createGetTagTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_tag",
     description: "Get detailed information about a specific GTM tag.",
     inputSchema: z.object({
@@ -154,7 +155,8 @@ export const createGetTagTool = (env: Env) =>
     outputSchema: z.object({
       tag: TagSchema.describe("Tag details"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -197,7 +199,7 @@ export const createGetTagTool = (env: Env) =>
 // ============================================================================
 
 export const createCreateTagTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_tag",
     description:
       "Create a new tag in a GTM workspace. Tags fire based on triggers and execute tracking code or other functionality.",
@@ -232,7 +234,8 @@ export const createCreateTagTool = (env: Env) =>
     outputSchema: z.object({
       tag: TagSchema.describe("Created tag"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -286,7 +289,7 @@ export const createCreateTagTool = (env: Env) =>
 // ============================================================================
 
 export const createUpdateTagTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "update_tag",
     description:
       "Update an existing GTM tag. All fields from the original tag must be provided.",
@@ -322,7 +325,8 @@ export const createUpdateTagTool = (env: Env) =>
     outputSchema: z.object({
       tag: TagSchema.describe("Updated tag"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -377,7 +381,7 @@ export const createUpdateTagTool = (env: Env) =>
 // ============================================================================
 
 export const createDeleteTagTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_tag",
     description: "Delete a GTM tag. Warning: This action cannot be undone.",
     inputSchema: z.object({
@@ -390,7 +394,8 @@ export const createDeleteTagTool = (env: Env) =>
       success: z.boolean().describe("Whether the deletion was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });

--- a/google-tag-manager/server/tools/triggers.ts
+++ b/google-tag-manager/server/tools/triggers.ts
@@ -4,7 +4,7 @@
  * Tools for managing GTM triggers
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { GTMClient, getAccessToken } from "../lib/gtm-client.ts";
@@ -80,7 +80,7 @@ const TriggerSchema = z.object({
 // ============================================================================
 
 export const createListTriggersTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_triggers",
     description:
       "List all triggers in a GTM workspace. Returns trigger IDs, names, types, and conditions.",
@@ -100,7 +100,8 @@ export const createListTriggersTool = (env: Env) =>
         .optional()
         .describe("Token for fetching next page"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -140,7 +141,7 @@ export const createListTriggersTool = (env: Env) =>
 // ============================================================================
 
 export const createGetTriggerTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_trigger",
     description: "Get detailed information about a specific GTM trigger.",
     inputSchema: z.object({
@@ -152,7 +153,8 @@ export const createGetTriggerTool = (env: Env) =>
     outputSchema: z.object({
       trigger: TriggerSchema.describe("Trigger details"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -191,7 +193,7 @@ export const createGetTriggerTool = (env: Env) =>
 // ============================================================================
 
 export const createCreateTriggerTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_trigger",
     description:
       "Create a new trigger in a GTM workspace. Triggers determine when tags should fire.",
@@ -221,7 +223,8 @@ export const createCreateTriggerTool = (env: Env) =>
     outputSchema: z.object({
       trigger: TriggerSchema.describe("Created trigger"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -271,7 +274,7 @@ export const createCreateTriggerTool = (env: Env) =>
 // ============================================================================
 
 export const createUpdateTriggerTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "update_trigger",
     description:
       "Update an existing GTM trigger. All fields from the original trigger must be provided.",
@@ -300,7 +303,8 @@ export const createUpdateTriggerTool = (env: Env) =>
     outputSchema: z.object({
       trigger: TriggerSchema.describe("Updated trigger"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -351,7 +355,7 @@ export const createUpdateTriggerTool = (env: Env) =>
 // ============================================================================
 
 export const createDeleteTriggerTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_trigger",
     description: "Delete a GTM trigger. Warning: This action cannot be undone.",
     inputSchema: z.object({
@@ -364,7 +368,8 @@ export const createDeleteTriggerTool = (env: Env) =>
       success: z.boolean().describe("Whether the deletion was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });

--- a/google-tag-manager/server/tools/variables.ts
+++ b/google-tag-manager/server/tools/variables.ts
@@ -4,7 +4,7 @@
  * Tools for managing GTM variables
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { GTMClient, getAccessToken } from "../lib/gtm-client.ts";
@@ -74,7 +74,7 @@ const VariableSchema = z.object({
 // ============================================================================
 
 export const createListVariablesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_variables",
     description:
       "List all variables in a GTM workspace. Returns variable IDs, names, types, and configurations.",
@@ -94,7 +94,8 @@ export const createListVariablesTool = (env: Env) =>
         .optional()
         .describe("Token for fetching next page"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -136,7 +137,7 @@ export const createListVariablesTool = (env: Env) =>
 // ============================================================================
 
 export const createGetVariableTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_variable",
     description: "Get detailed information about a specific GTM variable.",
     inputSchema: z.object({
@@ -148,7 +149,8 @@ export const createGetVariableTool = (env: Env) =>
     outputSchema: z.object({
       variable: VariableSchema.describe("Variable details"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -189,7 +191,7 @@ export const createGetVariableTool = (env: Env) =>
 // ============================================================================
 
 export const createCreateVariableTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_variable",
     description:
       "Create a new variable in a GTM workspace. Variables store reusable values.",
@@ -221,7 +223,8 @@ export const createCreateVariableTool = (env: Env) =>
     outputSchema: z.object({
       variable: VariableSchema.describe("Created variable"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -270,7 +273,7 @@ export const createCreateVariableTool = (env: Env) =>
 // ============================================================================
 
 export const createUpdateVariableTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "update_variable",
     description:
       "Update an existing GTM variable. All fields from the original variable must be provided.",
@@ -301,7 +304,8 @@ export const createUpdateVariableTool = (env: Env) =>
     outputSchema: z.object({
       variable: VariableSchema.describe("Updated variable"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -351,7 +355,7 @@ export const createUpdateVariableTool = (env: Env) =>
 // ============================================================================
 
 export const createDeleteVariableTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "delete_variable",
     description:
       "Delete a GTM variable. Warning: This action cannot be undone.",
@@ -365,7 +369,8 @@ export const createDeleteVariableTool = (env: Env) =>
       success: z.boolean().describe("Whether the deletion was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });

--- a/google-tag-manager/server/tools/workspaces.ts
+++ b/google-tag-manager/server/tools/workspaces.ts
@@ -4,7 +4,7 @@
  * Tools for managing GTM workspaces
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { GTMClient, getAccessToken } from "../lib/gtm-client.ts";
@@ -29,7 +29,7 @@ const WorkspaceSchema = z.object({
 // ============================================================================
 
 export const createListWorkspacesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_workspaces",
     description:
       "List all workspaces in a GTM container. Returns workspace IDs, names, and descriptions.",
@@ -48,7 +48,8 @@ export const createListWorkspacesTool = (env: Env) =>
         .optional()
         .describe("Token for fetching next page"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -80,7 +81,7 @@ export const createListWorkspacesTool = (env: Env) =>
 // ============================================================================
 
 export const createGetWorkspaceTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_workspace",
     description: "Get detailed information about a specific GTM workspace.",
     inputSchema: z.object({
@@ -91,7 +92,8 @@ export const createGetWorkspaceTool = (env: Env) =>
     outputSchema: z.object({
       workspace: WorkspaceSchema.describe("Workspace details"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });
@@ -122,7 +124,7 @@ export const createGetWorkspaceTool = (env: Env) =>
 // ============================================================================
 
 export const createCreateWorkspaceTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_workspace",
     description:
       "Create a new workspace in a GTM container. Workspaces allow you to work on container changes without affecting the live version.",
@@ -135,7 +137,8 @@ export const createCreateWorkspaceTool = (env: Env) =>
     outputSchema: z.object({
       workspace: WorkspaceSchema.describe("Created workspace"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = new GTMClient({
         accessToken: getAccessToken(env),
       });

--- a/google-tag-manager/tsconfig.json
+++ b/google-tag-manager/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "ES2024", "DOM", "DOM.Iterable"],

--- a/grain/package.json
+++ b/grain/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@decocms/bindings": "1.0.1-alpha.23",
-    "@decocms/runtime": "1.0.0-alpha.41",
+    "@decocms/runtime": "1.4.0",
     "@supabase/supabase-js": "^2.57.4",
     "zod": "^3.24.3"
   },

--- a/grain/server/tools/get-recording.ts
+++ b/grain/server/tools/get-recording.ts
@@ -1,11 +1,11 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { getGrainApiKey } from "../lib/env.ts";
 import { z } from "zod";
 import { GrainClient, GrainAPIError } from "../lib/grain-client.ts";
 import type { Env } from "../types/env.ts";
 
 export const createGetRecordingTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "GET_RECORDING",
     description:
       "Get detailed information about a specific Grain recording. " +
@@ -70,7 +70,8 @@ export const createGetRecordingTool = (env: Env) =>
         .optional(),
       intelligence_notes_md: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       try {
         const client = new GrainClient({ apiKey: getGrainApiKey(env) });
 

--- a/grain/server/tools/get-summary.ts
+++ b/grain/server/tools/get-summary.ts
@@ -1,11 +1,11 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import { GrainAPIError, GrainClient } from "../lib/grain-client.ts";
 import { getGrainApiKey } from "../lib/env.ts";
 import type { Env } from "../types/env.ts";
 
 export const createGetSummaryTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "GET_SUMMARY",
     description:
       "Get AI-generated intelligence notes for a Grain recording. " +
@@ -28,7 +28,8 @@ export const createGetSummaryTool = (env: Env) =>
         ])
         .optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       try {
         const client = new GrainClient({ apiKey: getGrainApiKey(env) });
         const format = context.format ?? "md";

--- a/grain/server/tools/get-transcript.ts
+++ b/grain/server/tools/get-transcript.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import { GrainAPIError, GrainClient } from "../lib/grain-client.ts";
 import { getGrainApiKey } from "../lib/env.ts";
@@ -7,7 +7,7 @@ import type { Env } from "../types/env.ts";
 const TranscriptFormatSchema = z.enum(["json", "txt", "srt", "vtt"]);
 
 export const createGetTranscriptTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "GET_TRANSCRIPT",
     description:
       "Get transcript content for a Grain recording. " +
@@ -37,7 +37,8 @@ export const createGetTranscriptTool = (env: Env) =>
         ),
       ]),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       try {
         const client = new GrainClient({ apiKey: getGrainApiKey(env) });
         const format = context.format ?? "txt";

--- a/grain/server/tools/list-recordings.ts
+++ b/grain/server/tools/list-recordings.ts
@@ -1,11 +1,11 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { getGrainApiKey } from "../lib/env.ts";
 import { z } from "zod";
 import { GrainClient, GrainAPIError } from "../lib/grain-client.ts";
 import type { Env } from "../types/env.ts";
 
 export const createListRecordingsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "LIST_RECORDINGS",
     description:
       "List and search through your Grain meeting recordings. " +
@@ -60,7 +60,8 @@ export const createListRecordingsTool = (env: Env) =>
       ),
       cursor: z.string().nullable().describe("Next page cursor, null if last"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       try {
         const client = new GrainClient({ apiKey: getGrainApiKey(env) });
         const response = await client.listRecordings({

--- a/grain/server/tools/search-indexed-recordings.ts
+++ b/grain/server/tools/search-indexed-recordings.ts
@@ -1,10 +1,10 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import { searchIndexedRecordings } from "../db/queries.ts";
 import type { Env } from "../types/env.ts";
 
 export const createSearchIndexedRecordingsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "SEARCH_INDEXED_RECORDINGS",
     description:
       "Search recordings indexed in Supabase via webhooks. " +
@@ -65,7 +65,8 @@ export const createSearchIndexedRecordingsTool = (env: Env) =>
       ),
       count: z.number(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       void env;
       const { query, start_date, end_date, tag, owner, limit = 10 } = context;
 

--- a/hyperdx/package.json
+++ b/hyperdx/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@decocms/bindings": "^1.0.8",
-    "@decocms/runtime": "1.1.3",
+    "@decocms/runtime": "1.4.0",
     "@modelcontextprotocol/sdk": "^1.20.0",
     "zod": "^3.24.3"
   },

--- a/hyperdx/tsconfig.json
+++ b/hyperdx/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "ES2024", "DOM", "DOM.Iterable"],

--- a/mcp-studio/package.json
+++ b/mcp-studio/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@decocms/bindings": "^1.1.3",
-    "@decocms/runtime": "1.2.8",
+    "@decocms/runtime": "1.4.0",
     "@jitl/quickjs-singlefile-cjs-release-sync": "^0.31.0",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@types/prettier": "^3.0.0",

--- a/mcp-studio/server/tools/execution.ts
+++ b/mcp-studio/server/tools/execution.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import type { Env } from "../types/env.ts";
 import { z } from "zod";
 import {
@@ -50,7 +50,7 @@ if (!CREATE_BINDING?.inputSchema || !CREATE_BINDING?.outputSchema) {
 }
 
 export const cancelExecutionTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "CANCEL_EXECUTION",
     description:
       "Cancel a running or pending workflow execution. Currently executing steps will complete, but no new steps will start. The execution can be resumed later using RESUME_EXECUTION.",
@@ -60,7 +60,8 @@ export const cancelExecutionTool = (env: Env) =>
     outputSchema: z.object({
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { executionId } = context;
 
       const result = await cancelExecution(env, executionId);
@@ -78,7 +79,7 @@ export const cancelExecutionTool = (env: Env) =>
   });
 
 export const resumeExecutionTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "RESUME_EXECUTION",
     description:
       "Resume a cancelled workflow execution. The execution will be set back to pending and can be re-queued for processing.",
@@ -88,7 +89,8 @@ export const resumeExecutionTool = (env: Env) =>
     outputSchema: z.object({
       success: z.boolean(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { executionId } = context;
 
       const result = await resumeExecution(env, executionId);
@@ -111,7 +113,7 @@ export const resumeExecutionTool = (env: Env) =>
   });
 
 export const createCreateTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: CREATE_BINDING?.name,
     description: "Create a workflow execution and return the execution ID",
     inputSchema: z.object({
@@ -141,7 +143,8 @@ export const createCreateTool = (env: Env) =>
         id: z.string(),
       }),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       try {
         // Fetch the full workflow collection to get steps and input schema
         const workflowCollection = await getWorkflowCollection(
@@ -180,14 +183,15 @@ export const createCreateTool = (env: Env) =>
   });
 
 export const createGetTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_WORKFLOW_EXECUTION_GET",
     description: "Get a single workflow execution by ID with step results.",
     inputSchema: z.object({
       id: z.string().describe("The ID of the workflow execution to get"),
     }),
     outputSchema: createCollectionGetOutputSchema(WorkflowExecutionSchema),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { id } = context;
       const result = await getExecutionFull(env, id);
       if (!result) {
@@ -207,7 +211,7 @@ export const createGetTool = (env: Env) =>
   });
 
 export const createGetExecutionWorkflowTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "WORKFLOW_EXECUTION_GET_WORKFLOW",
     description:
       "Get the immutable workflow associated with a workflow execution",
@@ -224,7 +228,8 @@ export const createGetExecutionWorkflowTool = (env: Env) =>
       id: z.string(),
       workflow_collection_id: z.string().nullish(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { executionId } = context;
       const execution = await getExecution(env, executionId);
       if (!execution) {
@@ -251,7 +256,7 @@ export const createGetExecutionWorkflowTool = (env: Env) =>
   });
 
 export const createGetStepResultTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_WORKFLOW_EXECUTION_GET_STEP_RESULT",
     description: "Get a single step result by execution ID and step ID",
     inputSchema: z.object({
@@ -264,7 +269,8 @@ export const createGetStepResultTool = (env: Env) =>
       output: z.unknown().optional(),
       error: z.string().nullable().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { executionId, stepId } = context;
       const result = await getStepResult(env, executionId, stepId);
       if (!result) {
@@ -284,17 +290,21 @@ export const createGetStepResultTool = (env: Env) =>
   });
 
 export const createListTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_WORKFLOW_EXECUTION_LIST",
     description:
       "List workflow executions with filtering, sorting, and pagination",
     inputSchema: LIST_BINDING.inputSchema,
     outputSchema: LIST_BINDING.outputSchema,
-    execute: async ({
-      context,
-    }: {
-      context: z.infer<typeof LIST_BINDING.inputSchema>;
-    }) => {
+    execute: async (
+      {
+        context,
+      }: {
+        context: z.infer<typeof LIST_BINDING.inputSchema>;
+      },
+      ctx,
+    ) => {
+      ensureAuthenticated(ctx!);
       const { limit = 50, offset = 0 } = context;
 
       const itemsResult = await listExecutions(env, {

--- a/mcp-studio/server/tools/prompt.ts
+++ b/mcp-studio/server/tools/prompt.ts
@@ -17,7 +17,7 @@ import {
   PROMPTS_COLLECTION_BINDING,
   PromptSchema,
 } from "@decocms/bindings/prompt";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import type { ZodType, z } from "zod";
 import { runSQL } from "../db/postgres.ts";
 import {
@@ -95,12 +95,13 @@ function parsePromptRow(
  * COLLECTION_PROMPT_LIST - Query prompts with filtering, sorting, and pagination
  */
 export const createListTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_PROMPT_LIST",
     description: "List prompts with filtering, sorting, and pagination",
     inputSchema: LIST_BINDING.inputSchema,
     outputSchema: LIST_BINDING.outputSchema as ZodType,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { where, orderBy, limit = 50, offset = 0 } = context;
 
       // Build WHERE clause
@@ -148,12 +149,13 @@ export const createListTool = (env: Env) =>
  * COLLECTION_PROMPT_GET - Fetch a single prompt by ID
  */
 export const createGetTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_PROMPT_GET",
     description: "Get a single prompt by ID",
     inputSchema: CollectionGetInputSchema,
     outputSchema: createCollectionGetOutputSchema(PromptSchema),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { id } = context;
 
       const result = await runSQL(
@@ -174,16 +176,20 @@ export const createGetTool = (env: Env) =>
  * COLLECTION_PROMPT_CREATE - Create a new prompt
  */
 export const createInsertTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_PROMPT_CREATE",
     description: "Create a new prompt",
     inputSchema: CREATE_BINDING.inputSchema,
     outputSchema: CREATE_BINDING.outputSchema as ZodType,
-    execute: async ({
-      context,
-    }: {
-      context: z.infer<typeof CREATE_BINDING.inputSchema>;
-    }) => {
+    execute: async (
+      {
+        context,
+      }: {
+        context: z.infer<typeof CREATE_BINDING.inputSchema>;
+      },
+      ctx,
+    ) => {
+      ensureAuthenticated(ctx!);
       const user = env.MESH_REQUEST_CONTEXT?.ensureAuthenticated?.();
       const now = new Date().toISOString();
 
@@ -235,16 +241,20 @@ export const createInsertTool = (env: Env) =>
  * COLLECTION_PROMPT_UPDATE - Update an existing prompt
  */
 export const createUpdateTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_PROMPT_UPDATE",
     description: "Update an existing prompt",
     inputSchema: UPDATE_BINDING.inputSchema,
     outputSchema: UPDATE_BINDING.outputSchema as ZodType,
-    execute: async ({
-      context,
-    }: {
-      context: z.infer<typeof UPDATE_BINDING.inputSchema>;
-    }) => {
+    execute: async (
+      {
+        context,
+      }: {
+        context: z.infer<typeof UPDATE_BINDING.inputSchema>;
+      },
+      ctx,
+    ) => {
+      ensureAuthenticated(ctx!);
       const user = env.MESH_REQUEST_CONTEXT?.ensureAuthenticated?.();
 
       const now = new Date().toISOString();
@@ -306,16 +316,20 @@ export const createUpdateTool = (env: Env) =>
  * COLLECTION_PROMPT_DELETE - Delete a prompt by ID
  */
 export const createDeleteTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_PROMPT_DELETE",
     description: "Delete a prompt by ID",
     inputSchema: DELETE_BINDING.inputSchema,
     outputSchema: DELETE_BINDING.outputSchema as ZodType,
-    execute: async ({
-      context,
-    }: {
-      context: z.infer<typeof DELETE_BINDING.inputSchema>;
-    }) => {
+    execute: async (
+      {
+        context,
+      }: {
+        context: z.infer<typeof DELETE_BINDING.inputSchema>;
+      },
+      ctx,
+    ) => {
+      ensureAuthenticated(ctx!);
       const { id } = context;
 
       // Get the prompt before deleting

--- a/mcp-studio/server/tools/workflow.ts
+++ b/mcp-studio/server/tools/workflow.ts
@@ -6,7 +6,7 @@ import {
   WORKFLOW_BINDING,
   WorkflowSchema,
 } from "@decocms/bindings/workflow";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import { runSQL } from "../db/postgres.ts";
 import type { Env } from "../types/env.ts";
@@ -79,17 +79,21 @@ function transformDbRowToWorkflowCollectionItem(row: unknown): Workflow {
 }
 
 export const createListTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_WORKFLOW_LIST",
     description:
       "List workflows with filtering, sorting, and pagination. This does not include the steps of the workflows, use the GET tool to check the list of steps.",
     inputSchema: LIST_BINDING.inputSchema,
     outputSchema: createCollectionListOutputSchema(WorkflowSchema),
-    execute: async ({
-      context,
-    }: {
-      context: z.infer<typeof LIST_BINDING.inputSchema>;
-    }) => {
+    execute: async (
+      {
+        context,
+      }: {
+        context: z.infer<typeof LIST_BINDING.inputSchema>;
+      },
+      ctx,
+    ) => {
+      ensureAuthenticated(ctx!);
       const { where, orderBy, limit = 50, offset = 0 } = context;
 
       let whereClause = "";
@@ -147,16 +151,20 @@ export async function getWorkflowCollection(
 }
 
 export const createGetTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_WORKFLOW_GET",
     description: "Get a single workflow by ID",
     inputSchema: GET_BINDING.inputSchema,
     outputSchema: GET_BINDING.outputSchema,
-    execute: async ({
-      context,
-    }: {
-      context: z.infer<typeof GET_BINDING.inputSchema>;
-    }) => {
+    execute: async (
+      {
+        context,
+      }: {
+        context: z.infer<typeof GET_BINDING.inputSchema>;
+      },
+      ctx,
+    ) => {
+      ensureAuthenticated(ctx!);
       const { id } = context;
 
       const workflow = await getWorkflowCollection(env, id);
@@ -210,7 +218,7 @@ export async function insertWorkflowCollectionItem(
 }
 
 export const createInsertTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: CREATE_BINDING.name,
     description: `Creates a template/definition for a workflow. This entity is not executable, but can be used to create executions.
     This is ideal for storing and reusing workflows. You may also want to use this tool to iterate on a workflow before creating executions. You may start with an empty array of steps and add steps gradually.
@@ -258,7 +266,8 @@ Example workflow with a step that references the output of another step:
       }),
     }),
     // outputSchema: CREATE_BINDING.outputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       validateConnectionState(env);
       const { data } = context;
       const user = env.MESH_REQUEST_CONTEXT?.ensureAuthenticated();
@@ -381,7 +390,7 @@ async function updateWorkflowCollection(
 }
 
 export const createUpdateTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_WORKFLOW_UPDATE",
     description: "Update an existing workflow",
     inputSchema: z.object({
@@ -395,7 +404,8 @@ export const createUpdateTool = (env: Env) =>
         description: z.string().optional(),
       }),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       try {
         await updateWorkflowCollection(env, context);
         return {
@@ -411,7 +421,7 @@ export const createUpdateTool = (env: Env) =>
   });
 
 export const createAppendStepTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_WORKFLOW_APPEND_STEP",
     description: "Append a new step to an existing workflow",
     inputSchema: z.object({
@@ -425,7 +435,8 @@ export const createAppendStepTool = (env: Env) =>
         .boolean()
         .describe("Whether the step was appended successfully"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { id, step } = context;
 
       const workflow = await getWorkflowCollection(env, id as string);
@@ -455,7 +466,7 @@ export const createAppendStepTool = (env: Env) =>
   });
 
 export const createUpdateStepsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_WORKFLOW_UPDATE_STEPS",
     description: "Update one or more steps of a workflow",
     inputSchema: z.object({
@@ -472,7 +483,8 @@ export const createUpdateStepsTool = (env: Env) =>
         .boolean()
         .describe("Whether the step was updated successfully"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { steps, id } = context;
 
       if (!steps) {
@@ -526,12 +538,13 @@ export const createUpdateStepsTool = (env: Env) =>
   });
 
 export const createDeleteTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_WORKFLOW_DELETE",
     description: "Delete a workflow by ID",
     inputSchema: DELETE_BINDING.inputSchema,
     outputSchema: DELETE_BINDING.outputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { id } = context;
 
       const result = await runSQL<Record<string, unknown>>(

--- a/mcp-studio/tsconfig.json
+++ b/mcp-studio/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": [

--- a/meta-ads/package.json
+++ b/meta-ads/package.json
@@ -13,7 +13,7 @@
     "dev:tunnel": "deco link -p 3003 -- PORT=3003 bun run dev"
   },
   "dependencies": {
-    "@decocms/runtime": "1.1.3",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/meta-ads/server/tools/accounts.ts
+++ b/meta-ads/server/tools/accounts.ts
@@ -7,7 +7,7 @@
  * - META_ADS_GET_ACCOUNT_PAGES: Get pages associated with an account
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { getMetaAccessToken } from "../main.ts";
@@ -18,7 +18,7 @@ import { ACCOUNT_STATUSES } from "../constants.ts";
  * Get all ad accounts accessible by the current user (User Token only)
  */
 export const createGetUserAdAccountsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_GET_USER_AD_ACCOUNTS",
     description:
       "Get all ad accounts accessible by the current authenticated user (requires User Access Token). Returns account ID, name, status, currency, timezone, and amount spent.",
@@ -49,7 +49,8 @@ export const createGetUserAdAccountsTool = (env: Env) =>
       ),
       count: z.number().describe("Number of accounts returned"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -81,7 +82,7 @@ export const createGetUserAdAccountsTool = (env: Env) =>
  * Get all ad accounts associated with the current page (Page Token only)
  */
 export const createGetPageAdAccountsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_GET_PAGE_AD_ACCOUNTS",
     description:
       "Get all ad accounts associated with the current page (requires Page Access Token). Returns account ID, name, status, currency, timezone, and amount spent.",
@@ -107,7 +108,8 @@ export const createGetPageAdAccountsTool = (env: Env) =>
       ),
       count: z.number().describe("Number of accounts returned"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -136,7 +138,7 @@ export const createGetPageAdAccountsTool = (env: Env) =>
  * Get detailed information about a specific ad account
  */
 export const createGetAccountInfoTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_GET_ACCOUNT_INFO",
     description:
       "Get detailed information about a specific Meta Ads account including currency, timezone, spending limits, and balance.",
@@ -159,7 +161,8 @@ export const createGetAccountInfoTool = (env: Env) =>
       balance: z.string().optional(),
       min_daily_budget: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -191,7 +194,7 @@ export const createGetAccountInfoTool = (env: Env) =>
  * Get information about the authenticated user
  */
 export const createGetUserInfoTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_GET_USER_INFO",
     description:
       "Get information about the currently authenticated Meta user including user ID and name. Use this to get the user_id needed for other operations.",
@@ -200,7 +203,8 @@ export const createGetUserInfoTool = (env: Env) =>
       id: z.string().describe("Meta user ID"),
       name: z.string().optional().describe("User's display name"),
     }),
-    execute: async () => {
+    execute: async (_input, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -217,7 +221,7 @@ export const createGetUserInfoTool = (env: Env) =>
  * Get pages associated with the current user (User Token only)
  */
 export const createGetUserAccountPagesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_GET_USER_ACCOUNT_PAGES",
     description:
       "Get Facebook/Instagram pages associated with the current authenticated user (requires User Access Token). Useful for understanding which pages can be used for advertising.",
@@ -239,7 +243,8 @@ export const createGetUserAccountPagesTool = (env: Env) =>
       ),
       count: z.number().describe("Number of pages returned"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -261,7 +266,7 @@ export const createGetUserAccountPagesTool = (env: Env) =>
  * Get information about the current page (Page Token only)
  */
 export const createGetPageInfoTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_GET_PAGE_INFO",
     description:
       "Get information about the currently authenticated page (requires Page Access Token). Returns page ID, name, category, and tasks.",
@@ -275,7 +280,8 @@ export const createGetPageInfoTool = (env: Env) =>
       website: z.string().optional().describe("Page website"),
       phone: z.string().optional().describe("Page phone number"),
     }),
-    execute: async () => {
+    execute: async (_input, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -298,7 +304,7 @@ export const createGetPageInfoTool = (env: Env) =>
  * This is an alias for META_ADS_GET_PAGE_INFO but returns in pages array format for consistency
  */
 export const createGetPageAccountPagesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_GET_PAGE_ACCOUNT_PAGES",
     description:
       "Get information about the currently authenticated page (requires Page Access Token). Returns page details in a consistent format.",
@@ -316,7 +322,8 @@ export const createGetPageAccountPagesTool = (env: Env) =>
         .number()
         .describe("Number of pages returned (always 1 for Page Token)"),
     }),
-    execute: async () => {
+    execute: async (_input, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 

--- a/meta-ads/server/tools/ads.ts
+++ b/meta-ads/server/tools/ads.ts
@@ -11,7 +11,7 @@
  * - META_ADS_CREATE_AD_CREATIVE: Create a new ad creative
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { getMetaAccessToken } from "../main.ts";
@@ -22,7 +22,7 @@ import type { AdStatus, UpdateAdParams } from "../lib/types.ts";
  * Get ads for an ad account
  */
 export const createGetAdsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_GET_ADS",
     description:
       "Get ads for a Meta Ads account. Can filter by campaign ID or ad set ID. Returns ad details including status and creative reference.",
@@ -54,7 +54,8 @@ export const createGetAdsTool = (env: Env) =>
       ),
       count: z.number().describe("Number of ads returned"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -85,7 +86,7 @@ export const createGetAdsTool = (env: Env) =>
  * Get details of a specific ad
  */
 export const createGetAdDetailsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_GET_AD_DETAILS",
     description:
       "Get detailed information about a specific Meta Ads ad including status, creative reference, and tracking configuration.",
@@ -105,7 +106,8 @@ export const createGetAdDetailsTool = (env: Env) =>
       tracking_specs: z.array(z.record(z.string(), z.unknown())).optional(),
       conversion_specs: z.array(z.record(z.string(), z.unknown())).optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -131,7 +133,7 @@ export const createGetAdDetailsTool = (env: Env) =>
  * Get creative details for an ad
  */
 export const createGetAdCreativesTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_GET_AD_CREATIVES",
     description:
       "Get creative details for a specific Meta Ads ad including text, images, videos, and call-to-action configuration.",
@@ -151,7 +153,8 @@ export const createGetAdCreativesTool = (env: Env) =>
       thumbnail_url: z.string().optional(),
       effective_object_story_id: z.string().optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -177,7 +180,7 @@ export const createGetAdCreativesTool = (env: Env) =>
  * Create a new ad
  */
 export const createCreateAdTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_CREATE_AD",
     description:
       "Create a new Meta Ads ad. This is STEP 4 (final step) to create ads. REQUIRES: adset_id from CREATE_ADSET AND creative_id from CREATE_AD_CREATIVE. FLOW: 1) CREATE_CAMPAIGN → 2) CREATE_ADSET → 3) CREATE_AD_CREATIVE → 4) CREATE_AD. If you don't have these IDs, go back and create them first.",
@@ -206,7 +209,8 @@ export const createCreateAdTool = (env: Env) =>
       id: z.string().describe("ID of the created ad"),
       success: z.boolean().describe("Whether the ad was created successfully"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -231,7 +235,7 @@ export const createCreateAdTool = (env: Env) =>
  * Update an existing ad
  */
 export const createUpdateAdTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_UPDATE_AD",
     description:
       "Update an existing Meta Ads ad. Can change name, status, or creative.",
@@ -247,7 +251,8 @@ export const createUpdateAdTool = (env: Env) =>
     outputSchema: z.object({
       success: z.boolean().describe("Whether the update was successful"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -271,7 +276,7 @@ export const createUpdateAdTool = (env: Env) =>
  * Delete an ad
  */
 export const createDeleteAdTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_DELETE_AD",
     description: "Delete a Meta Ads ad. This action cannot be undone.",
     inputSchema: z.object({
@@ -280,7 +285,8 @@ export const createDeleteAdTool = (env: Env) =>
     outputSchema: z.object({
       success: z.boolean().describe("Whether the deletion was successful"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -328,7 +334,7 @@ const callToActionTypeSchema = z.enum([
  * Create an ad creative
  */
 export const createCreateAdCreativeTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_CREATE_AD_CREATIVE",
     description:
       "Create an ad creative with text and CTA. This is STEP 3 in the ad creation flow. REQUIRES: page_id (Facebook Page) and link URL, OR use effective_object_story_id to promote an existing Facebook/Instagram post. FLOW: 1) CREATE_CAMPAIGN → 2) CREATE_ADSET → 3) CREATE_AD_CREATIVE → 4) CREATE_AD. Returns creative_id to use in CREATE_AD.",
@@ -398,7 +404,8 @@ export const createCreateAdCreativeTool = (env: Env) =>
         .boolean()
         .describe("Whether the creative was created successfully"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 

--- a/meta-ads/server/tools/adsets.ts
+++ b/meta-ads/server/tools/adsets.ts
@@ -177,6 +177,7 @@ export const createGetAdSetDetailsTool = (env: Env) =>
         .optional(),
       promoted_object: z.record(z.string(), z.unknown()).optional(),
     }),
+    // @ts-expect-error: ctx is always passed by runtime
     execute: async ({ context }, ctx) => {
       ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);

--- a/meta-ads/server/tools/adsets.ts
+++ b/meta-ads/server/tools/adsets.ts
@@ -9,7 +9,7 @@
  * - META_ADS_DELETE_ADSET: Delete an ad set
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { getMetaAccessToken } from "../main.ts";
@@ -30,7 +30,7 @@ const targetingSummarySchema = z.object({
  * Get ad sets for an ad account
  */
 export const createGetAdSetsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_GET_ADSETS",
     description:
       "Get ad sets for a Meta Ads account. Can filter by campaign ID. Returns ad set details including targeting, budget, and optimization settings.",
@@ -68,7 +68,8 @@ export const createGetAdSetsTool = (env: Env) =>
       ),
       count: z.number().describe("Number of ad sets returned"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -113,7 +114,7 @@ export const createGetAdSetsTool = (env: Env) =>
  * Get details of a specific ad set
  */
 export const createGetAdSetDetailsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_GET_ADSET_DETAILS",
     description:
       "Get detailed information about a specific Meta Ads ad set including full targeting details, budget, schedule, and optimization settings.",
@@ -176,7 +177,8 @@ export const createGetAdSetDetailsTool = (env: Env) =>
         .optional(),
       promoted_object: z.record(z.string(), z.unknown()).optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -269,7 +271,7 @@ const targetingInputSchema = z.object({
  * Create a new ad set
  */
 export const createCreateAdSetTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_CREATE_ADSET",
     description:
       "Create a new Meta Ads ad set. This is STEP 2 of 5 to create ads. REQUIRES: A campaign_id from CREATE_CAMPAIGN. FLOW: 1) CREATE_CAMPAIGN → 2) CREATE_ADSET → 3) UPLOAD_AD_IMAGE (optional) → 4) CREATE_AD_CREATIVE → 5) CREATE_AD. Define targeting, budget, optimization goal, and billing settings.",
@@ -392,7 +394,8 @@ export const createCreateAdSetTool = (env: Env) =>
         .boolean()
         .describe("Whether the ad set was created successfully"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -424,7 +427,7 @@ export const createCreateAdSetTool = (env: Env) =>
  * Update an existing ad set
  */
 export const createUpdateAdSetTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_UPDATE_ADSET",
     description:
       "Update an existing Meta Ads ad set. Can change targeting, budget, status, or optimization settings.",
@@ -493,7 +496,8 @@ export const createUpdateAdSetTool = (env: Env) =>
     outputSchema: z.object({
       success: z.boolean().describe("Whether the update was successful"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -521,7 +525,7 @@ export const createUpdateAdSetTool = (env: Env) =>
  * Delete an ad set
  */
 export const createDeleteAdSetTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_DELETE_ADSET",
     description:
       "Delete a Meta Ads ad set. This action cannot be undone. All ads in the ad set will also be deleted.",
@@ -531,7 +535,8 @@ export const createDeleteAdSetTool = (env: Env) =>
     outputSchema: z.object({
       success: z.boolean().describe("Whether the deletion was successful"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 

--- a/meta-ads/server/tools/campaigns.ts
+++ b/meta-ads/server/tools/campaigns.ts
@@ -9,7 +9,7 @@
  * - META_ADS_DELETE_CAMPAIGN: Delete a campaign
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { getMetaAccessToken } from "../main.ts";
@@ -19,7 +19,7 @@ import { createMetaAdsClient } from "../lib/meta-client.ts";
  * Get campaigns for an ad account
  */
 export const createGetCampaignsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_GET_CAMPAIGNS",
     description:
       "Get campaigns for a Meta Ads account. Can filter by status (ACTIVE, PAUSED, etc). Returns campaign details including objective, budget, and status.",
@@ -58,7 +58,8 @@ export const createGetCampaignsTool = (env: Env) =>
       ),
       count: z.number().describe("Number of campaigns returned"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -91,7 +92,7 @@ export const createGetCampaignsTool = (env: Env) =>
  * Get details of a specific campaign
  */
 export const createGetCampaignDetailsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_GET_CAMPAIGN_DETAILS",
     description:
       "Get detailed information about a specific Meta Ads campaign including objective, budget, schedule, and status.",
@@ -114,7 +115,8 @@ export const createGetCampaignDetailsTool = (env: Env) =>
       buying_type: z.string().optional(),
       special_ad_categories: z.array(z.string()).optional(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -143,7 +145,7 @@ export const createGetCampaignDetailsTool = (env: Env) =>
  * Create a new campaign
  */
 export const createCreateCampaignTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_CREATE_CAMPAIGN",
     description:
       "Create a new Meta Ads campaign. This is STEP 1 of 5 to create ads. FLOW: 1) CREATE_CAMPAIGN → 2) CREATE_ADSET → 3) UPLOAD_AD_IMAGE (optional) → 4) CREATE_AD_CREATIVE → 5) CREATE_AD. Requires account ID, name, and objective. Budget can be set at campaign or ad set level.",
@@ -226,7 +228,8 @@ export const createCreateCampaignTool = (env: Env) =>
         .boolean()
         .describe("Whether the campaign was created successfully"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -254,7 +257,7 @@ export const createCreateCampaignTool = (env: Env) =>
  * Update an existing campaign
  */
 export const createUpdateCampaignTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_UPDATE_CAMPAIGN",
     description:
       "Update an existing Meta Ads campaign. Can change name, status, budget, or schedule. Use this to pause/activate campaigns.",
@@ -292,7 +295,8 @@ export const createUpdateCampaignTool = (env: Env) =>
     outputSchema: z.object({
       success: z.boolean().describe("Whether the update was successful"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 
@@ -316,7 +320,7 @@ export const createUpdateCampaignTool = (env: Env) =>
  * Delete a campaign
  */
 export const createDeleteCampaignTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_DELETE_CAMPAIGN",
     description:
       "Delete a Meta Ads campaign. This action cannot be undone. The campaign and all its ad sets and ads will be deleted.",
@@ -326,7 +330,8 @@ export const createDeleteCampaignTool = (env: Env) =>
     outputSchema: z.object({
       success: z.boolean().describe("Whether the deletion was successful"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 

--- a/meta-ads/server/tools/insights.ts
+++ b/meta-ads/server/tools/insights.ts
@@ -5,7 +5,7 @@
  * - META_ADS_GET_INSIGHTS: Get performance metrics for any object (account, campaign, adset, ad)
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { getMetaAccessToken } from "../main.ts";
@@ -24,7 +24,7 @@ const actionMetricSchema = z.array(
  * Get performance insights for any object
  */
 export const createGetInsightsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "META_ADS_GET_INSIGHTS",
     description: `Get performance insights for a Meta Ads object (account, campaign, ad set, or ad). 
 Returns metrics like impressions, reach, clicks, CTR, CPC, CPM, spend, and conversions.
@@ -131,7 +131,8 @@ Use date_preset for common time ranges (last_7d, last_30d, etc) or time_range fo
         }),
       }),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const accessToken = await getMetaAccessToken(env);
       const client = createMetaAdsClient({ accessToken });
 

--- a/meta-ads/tsconfig.json
+++ b/meta-ads/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],

--- a/multi-channel-inbox/package.json
+++ b/multi-channel-inbox/package.json
@@ -21,7 +21,7 @@
 	},
 	"dependencies": {
 		"@base-ui/react": "^1.2.0",
-		"@decocms/runtime": "^1.2.10",
+		"@decocms/runtime": "1.4.0",
 		"@hookform/resolvers": "^5.2.2",
 		"@modelcontextprotocol/ext-apps": "^1.1.2",
 		"@modelcontextprotocol/sdk": "^1.26.0",

--- a/multi-channel-inbox/tsconfig.json
+++ b/multi-channel-inbox/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+    "ignoreDeprecations": "6.0",
 		"target": "ESNext",
 		"module": "ESNext",
 		"moduleResolution": "bundler",

--- a/nanobanana/package.json
+++ b/nanobanana/package.json
@@ -11,7 +11,7 @@
     "build": "bun run build:server"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/nanobanana/server/tools/gemini.ts
+++ b/nanobanana/server/tools/gemini.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import {
   AspectRatioSchema,
   GenerateImageOutputSchema,
@@ -115,12 +115,13 @@ function createStorageAdapter(objectStorage: ObjectStorageBinding) {
 }
 
 const createGenerateImageTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "GENERATE_IMAGE",
     description: "Generate images using Gemini models via OpenRouter",
     inputSchema: GenerateImageInputSchema,
     outputSchema: GenerateImageOutputSchema,
-    execute: async ({ context }: { context: GenerateImageInput }) => {
+    execute: async ({ context }: { context: GenerateImageInput }, ctx) => {
+      ensureAuthenticated(ctx!);
       const doExecute = async () => {
         console.log("[GENERATE_IMAGE] 🚀 INÍCIO da execução");
         console.log("[GENERATE_IMAGE] 📥 Context recebido:", {

--- a/nanobanana/server/tools/get-image-result.ts
+++ b/nanobanana/server/tools/get-image-result.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import type { Env } from "server/main.ts";
 import { getTask } from "./utils/task-store.ts";
 
 const createGetImageResultTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_image_result",
     description:
       "Check the status of an image generation request. Returns the current status and, when ready, the image URL. Poll this tool until status is 'Ready'. Stop polling if status is 'Error' or 'Task not found' — these are terminal failures.",
@@ -30,7 +30,8 @@ const createGetImageResultTool = (_env: Env) =>
         .optional()
         .describe("Error message (only present when status is Error)"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const task = getTask(context.request_id);
 
       if (!task) {

--- a/nanobanana/server/tools/submit-image.ts
+++ b/nanobanana/server/tools/submit-image.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { AspectRatioSchema } from "@decocms/mcps-shared/image-generators";
 import type { Env } from "server/main.ts";
 import { createGeminiClient, models, type Model } from "./utils/gemini.ts";
@@ -147,7 +147,7 @@ async function generateAndUpload(
 }
 
 const createSubmitImageTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "submit_image",
     description:
       "Submit an image generation request using Gemini models via OpenRouter. Returns a request_id immediately — use get_image_result to poll for the result.",
@@ -160,7 +160,8 @@ const createSubmitImageTool = (env: Env) =>
         ),
       model: z.string().describe("The model used for generation"),
     }),
-    execute: async ({ context }: { context: SubmitImageInput }) => {
+    execute: async ({ context }: { context: SubmitImageInput }, ctx) => {
+      ensureAuthenticated(ctx!);
       const taskId = createTask();
       const modelToUse = context.model ?? "gemini-3.1-flash-image-preview";
 

--- a/nanobanana/tsconfig.json
+++ b/nanobanana/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": [

--- a/object-storage/package.json
+++ b/object-storage/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.716.0",
     "@aws-sdk/s3-request-presigner": "^3.716.0",
-    "@decocms/runtime": "1.1.3",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/object-storage/server/tools/storage.ts
+++ b/object-storage/server/tools/storage.ts
@@ -16,7 +16,7 @@ import {
   PutObjectCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { createS3Client, getPresignedUrlExpiration } from "../lib/s3-client.ts";
@@ -25,7 +25,7 @@ import { createS3Client, getPresignedUrlExpiration } from "../lib/s3-client.ts";
  * LIST_OBJECTS - List objects in the bucket with pagination support
  */
 export const createListObjectsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "LIST_OBJECTS",
     description:
       "List objects in the S3 bucket. Supports prefix filtering and pagination for large buckets.",
@@ -75,7 +75,8 @@ export const createListObjectsTool = (env: Env) =>
           "Common prefixes (folders) when delimiter is specified (e.g., ['folder-a/', 'folder-b/'])",
         ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { prefix, maxKeys, continuationToken, delimiter } = context;
       const s3Client = createS3Client(env);
       const state = env.MESH_REQUEST_CONTEXT.state;
@@ -110,7 +111,7 @@ export const createListObjectsTool = (env: Env) =>
  * GET_OBJECT_METADATA - Get object metadata using HEAD operation
  */
 export const createGetObjectMetadataTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "GET_OBJECT_METADATA",
     description:
       "Get metadata for an object without downloading it (HEAD operation)",
@@ -127,7 +128,8 @@ export const createGetObjectMetadataTool = (env: Env) =>
         .optional()
         .describe("Custom metadata key-value pairs"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { key } = context;
       const s3Client = createS3Client(env);
       const state = env.MESH_REQUEST_CONTEXT.state;
@@ -153,7 +155,7 @@ export const createGetObjectMetadataTool = (env: Env) =>
  * GET_PRESIGNED_URL - Generate a presigned URL for downloading an object
  */
 export const createGetPresignedUrlTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "GET_PRESIGNED_URL",
     description:
       "Generate a presigned URL for downloading an object. The URL allows temporary access without credentials.",
@@ -172,7 +174,8 @@ export const createGetPresignedUrlTool = (env: Env) =>
         .number()
         .describe("Expiration time in seconds that was used"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { key, expiresIn } = context;
       const s3Client = createS3Client(env);
       const state = env.MESH_REQUEST_CONTEXT.state;
@@ -198,7 +201,7 @@ export const createGetPresignedUrlTool = (env: Env) =>
  * PUT_PRESIGNED_URL - Generate a presigned URL for uploading an object
  */
 export const createPutPresignedUrlTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "PUT_PRESIGNED_URL",
     description:
       "Generate a presigned URL for uploading an object. The URL allows temporary upload access without credentials.",
@@ -221,7 +224,8 @@ export const createPutPresignedUrlTool = (env: Env) =>
         .number()
         .describe("Expiration time in seconds that was used"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { key, expiresIn, contentType } = context;
       const s3Client = createS3Client(env);
       const state = env.MESH_REQUEST_CONTEXT.state;
@@ -248,7 +252,7 @@ export const createPutPresignedUrlTool = (env: Env) =>
  * DELETE_OBJECT - Delete a single object
  */
 export const createDeleteObjectTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DELETE_OBJECT",
     description: "Delete a single object from the bucket",
     inputSchema: z.object({
@@ -258,7 +262,8 @@ export const createDeleteObjectTool = (env: Env) =>
       success: z.boolean().describe("Whether the deletion was successful"),
       key: z.string().describe("The key that was deleted"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { key } = context;
       const s3Client = createS3Client(env);
       const state = env.MESH_REQUEST_CONTEXT.state;
@@ -281,7 +286,7 @@ export const createDeleteObjectTool = (env: Env) =>
  * DELETE_OBJECTS - Delete multiple objects in batch
  */
 export const createDeleteObjectsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "DELETE_OBJECTS",
     description:
       "Delete multiple objects in a single batch operation (max 1000 objects)",
@@ -304,7 +309,8 @@ export const createDeleteObjectsTool = (env: Env) =>
         )
         .describe("Array of errors for failed deletions"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { keys } = context;
       const s3Client = createS3Client(env);
       const state = env.MESH_REQUEST_CONTEXT.state;

--- a/object-storage/tsconfig.json
+++ b/object-storage/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": [

--- a/openrouter/package.json
+++ b/openrouter/package.json
@@ -20,7 +20,7 @@
     "@ai-sdk/provider": "^3.0.2",
     "@ai-sdk/provider-utils": "^4.0.4",
     "@decocms/bindings": "^1.3.1",
-    "@decocms/runtime": "1.2.8",
+    "@decocms/runtime": "1.4.0",
     "@openrouter/ai-sdk-provider": "^1.5.4",
     "@openrouter/sdk": "^0.3.11",
     "ai": "^6.0.3",

--- a/openrouter/server/tools/embeddings/generate.ts
+++ b/openrouter/server/tools/embeddings/generate.ts
@@ -3,14 +3,14 @@
  * Submit an embedding request to the OpenRouter embeddings router
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { getOpenRouterApiKey } from "server/lib/env.ts";
 import { z } from "zod";
 import type { Env } from "../../main.ts";
 import { OpenRouter } from "@openrouter/sdk";
 
 export const createGenerateEmbeddingsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "GENERATE_EMBEDDINGS",
     description:
       "Generate vector embeddings for text input using OpenRouter's embeddings API. " +
@@ -46,7 +46,8 @@ export const createGenerateEmbeddingsTool = (env: Env) =>
     outputSchema: z.object({
       data: z.unknown(),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { input, model, encoding_format, dimensions } = context;
       const sdk = new OpenRouter({ apiKey: getOpenRouterApiKey(env) });
 

--- a/openrouter/server/tools/embeddings/list-models.ts
+++ b/openrouter/server/tools/embeddings/list-models.ts
@@ -3,7 +3,7 @@
  * Returns all available embeddings models and their properties
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { getOpenRouterApiKey } from "server/lib/env.ts";
 import { z } from "zod";
 import type { Env } from "../../main.ts";
@@ -36,7 +36,7 @@ if (!LIST_BINDING?.inputSchema || !LIST_BINDING?.outputSchema) {
 }
 
 export const createListEmbeddingModelsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_EMBEDDING_MODELS_LIST",
     description:
       "List all available embeddings models on OpenRouter with their properties. " +
@@ -47,7 +47,8 @@ export const createListEmbeddingModelsTool = (env: Env) =>
     outputSchema: z.object({
       items: z.unknown(),
     }),
-    execute: async () => {
+    execute: async (_input, ctx) => {
+      ensureAuthenticated(ctx!);
       const sdk = new OpenRouter({ apiKey: getOpenRouterApiKey(env) });
       const models = (await sdk.embeddings.listModels()).data;
 

--- a/openrouter/server/tools/llm-binding.ts
+++ b/openrouter/server/tools/llm-binding.ts
@@ -15,10 +15,7 @@ import {
   type ModelCollectionEntitySchema,
 } from "@decocms/bindings/llm";
 import { streamToResponse } from "@decocms/runtime/bindings";
-import {
-  createPrivateTool,
-  createStreamableTool,
-} from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { getOpenRouterApiKey } from "../lib/env.ts";
 import { logger } from "../lib/logger.ts";
@@ -399,14 +396,15 @@ function sortModelsByWellKnown(models: ListedModel[]): ListedModel[] {
  * COLLECTION_LLM_LIST - Lists all available models with filtering and pagination
  */
 export const createListLLMTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_LLM_LIST",
     description:
       "List all available models from OpenRouter with filtering and pagination support. " +
       "Returns comprehensive information about each model including capabilities, pricing, and limits.",
     inputSchema: LIST_BINDING.inputSchema,
     outputSchema: LIST_BINDING.outputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { where, orderBy, limit = 50, offset = 0 } = context;
       const client = new OpenRouterClient({
         apiKey: getOpenRouterApiKey(env),
@@ -451,14 +449,15 @@ export const createListLLMTool = (env: Env) =>
  * COLLECTION_LLM_GET - Retrieves a single model by its ID
  */
 export const createGetLLMTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_LLM_GET",
     description:
       "Get detailed information about a specific OpenRouter model including " +
       "pricing, capabilities, context length, and provider information.",
     inputSchema: GET_BINDING.inputSchema,
     outputSchema: GET_BINDING.outputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { id } = context;
       const client = new OpenRouterClient({
         apiKey: getOpenRouterApiKey(env),
@@ -484,14 +483,15 @@ export const createGetLLMTool = (env: Env) =>
  * LLM_METADATA - Returns metadata about a specific model's capabilities
  */
 export const createLLMMetadataTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "LLM_METADATA",
     description:
       "Get metadata about a specific model's capabilities including supported URL patterns " +
       "for different media types (images, files, etc.).",
     inputSchema: METADATA_BINDING.inputSchema,
     outputSchema: METADATA_BINDING.outputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { modelId } = context;
       const client = new OpenRouterClient({
         apiKey: getOpenRouterApiKey(env),
@@ -578,13 +578,14 @@ const findApiCallError = (error: unknown, depth = 0): APICallError | null => {
  * LLM_DO_STREAM - Streams a language model response in real-time
  */
 export const createLLMStreamTool = (usageHooks?: UsageHooks) => (env: Env) =>
-  createStreamableTool({
+  createTool({
     id: "LLM_DO_STREAM",
     description:
       "Stream a language model response in real-time using OpenRouter. " +
       "Returns a streaming response for interactive chat experiences.",
     inputSchema: STREAM_BINDING.inputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const {
         modelId,
         callOptions: { abortSignal: _abortSignal, ...callOptions },
@@ -792,14 +793,15 @@ function transformGenerateResult(result: unknown): Record<string, unknown> {
  * LLM_DO_GENERATE - Generates a complete response in a single call (non-streaming)
  */
 export const createLLMGenerateTool = (usageHooks?: UsageHooks) => (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "LLM_DO_GENERATE",
     description:
       "Generate a complete language model response using OpenRouter (non-streaming). " +
       "Returns the full response with usage statistics and cost information.",
     inputSchema: GENERATE_BINDING.inputSchema,
     outputSchema: GENERATE_BINDING.outputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const {
         modelId,
         callOptions: { abortSignal: _abortSignal, ...callOptions },

--- a/openrouter/server/tools/models/compare.ts
+++ b/openrouter/server/tools/models/compare.ts
@@ -3,7 +3,7 @@
  * Compare multiple models side-by-side to help choose the best one
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { getOpenRouterApiKey } from "../../lib/env.ts";
 import { z } from "zod";
 import { OpenRouterClient } from "../../lib/openrouter-client.ts";
@@ -11,7 +11,7 @@ import type { Env } from "../../main.ts";
 import { compareModels } from "./utils.ts";
 
 export const createCompareModelsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COMPARE_MODELS",
     description:
       "Compare multiple OpenRouter models side-by-side to help choose the best model for a specific use case. " +
@@ -48,7 +48,8 @@ export const createCompareModelsTool = (env: Env) =>
         .optional()
         .describe("Automated recommendation based on comparison"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { modelIds, criteria } = context;
       const client = new OpenRouterClient({
         apiKey: getOpenRouterApiKey(env),

--- a/openrouter/server/tools/models/recommend.ts
+++ b/openrouter/server/tools/models/recommend.ts
@@ -3,7 +3,7 @@
  * Get AI model recommendations based on task requirements
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { getOpenRouterApiKey } from "../../lib/env.ts";
 import { z } from "zod";
 import { OpenRouterClient } from "../../lib/openrouter-client.ts";
@@ -11,7 +11,7 @@ import type { Env } from "../../main.ts";
 import { recommendModelsForTask } from "./utils.ts";
 
 export const createRecommendModelTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "RECOMMEND_MODEL",
     description:
       "Get intelligent model recommendations based on your task description and requirements. " +
@@ -88,7 +88,8 @@ export const createRecommendModelTool = (env: Env) =>
         )
         .describe("Top recommended models ordered by score"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { taskDescription, requirements = {} } = context;
       const client = new OpenRouterClient({
         apiKey: getOpenRouterApiKey(env),

--- a/openrouter/tsconfig.json
+++ b/openrouter/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "ES2024", "DOM", "DOM.Iterable"],

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "whisper"
   ],
   "dependencies": {
-    "@decocms/runtime": "1.3.1",
+    "@decocms/runtime": "1.4.0",
     "@types/node": "^24.10.0",
     "zod": "^3.24.3"
   }

--- a/perplexity/package.json
+++ b/perplexity/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "undici": "^7.0.0",
     "zod": "^4.0.0"
   },

--- a/perplexity/server/tools/perplexity.ts
+++ b/perplexity/server/tools/perplexity.ts
@@ -8,7 +8,7 @@
  * - perplexity_search    → /search endpoint (raw web results)
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { getPerplexityApiKey } from "../lib/env.ts";
@@ -74,7 +74,7 @@ const reasoningEffortField = z
 // ============================================================================
 
 export const createAskTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "perplexity_ask",
     description:
       "Answer a question using web-grounded AI (Sonar Pro model). " +
@@ -96,7 +96,8 @@ export const createAskTool = (env: Env) =>
           "AI-generated text response with numbered citation references",
         ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const apiKey = getPerplexityApiKey(env);
       const options: ChatOptions = {
         ...(context.search_recency_filter && {
@@ -125,7 +126,7 @@ export const createAskTool = (env: Env) =>
 // ============================================================================
 
 export const createResearchTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "perplexity_research",
     description:
       "Conduct deep, multi-source research on a topic (Sonar Deep Research model). " +
@@ -146,7 +147,8 @@ export const createResearchTool = (env: Env) =>
           "AI-generated text response with numbered citation references",
         ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const apiKey = getPerplexityApiKey(env);
       const stripThinking = context.strip_thinking === true;
       const options: ChatOptions = {
@@ -170,7 +172,7 @@ export const createResearchTool = (env: Env) =>
 // ============================================================================
 
 export const createReasonTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "perplexity_reason",
     description:
       "Analyze a question using step-by-step reasoning with web grounding (Sonar Reasoning Pro model). " +
@@ -193,7 +195,8 @@ export const createReasonTool = (env: Env) =>
           "AI-generated text response with numbered citation references",
         ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const apiKey = getPerplexityApiKey(env);
       const stripThinking = context.strip_thinking === true;
       const options: ChatOptions = {
@@ -223,7 +226,7 @@ export const createReasonTool = (env: Env) =>
 // ============================================================================
 
 export const createSearchTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "perplexity_search",
     description:
       "Search the web and return a ranked list of results with titles, URLs, snippets, and dates. " +
@@ -260,7 +263,8 @@ export const createSearchTool = (env: Env) =>
           "Formatted search results, each with title, URL, snippet, and date",
         ),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const apiKey = getPerplexityApiKey(env);
       const results = await performSearch(
         apiKey,

--- a/perplexity/tsconfig.json
+++ b/perplexity/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "ES2024", "DOM", "DOM.Iterable"],

--- a/pinecone/package.json
+++ b/pinecone/package.json
@@ -13,7 +13,7 @@
     "build": "bun --bun vite build"
   },
   "dependencies": {
-    "@decocms/runtime": "0.25.1",
+    "@decocms/runtime": "1.4.0",
     "zod": "^3.24.3"
   },
   "devDependencies": {

--- a/pinecone/tsconfig.json
+++ b/pinecone/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],

--- a/readonly-sql/package.json
+++ b/readonly-sql/package.json
@@ -13,7 +13,7 @@
     "build": "bun --bun vite build"
   },
   "dependencies": {
-    "@decocms/runtime": "0.25.1",
+    "@decocms/runtime": "1.4.0",
     "postgres": "^3.4.5",
     "zod": "^3.24.3"
   },

--- a/readonly-sql/server/tools/sql.ts
+++ b/readonly-sql/server/tools/sql.ts
@@ -4,7 +4,7 @@
  * Tools for executing read-only SQL queries against configured databases.
  */
 
-import { createPrivateTool } from "@decocms/runtime/mastra";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import { createDatabaseClient, type DatabaseClient } from "../lib/db-client.ts";
@@ -14,7 +14,7 @@ import { validateReadOnlyQuery } from "../lib/sql-validator.ts";
  * QUERY_SQL - Execute a read-only SQL query
  */
 export const createQuerySqlTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "QUERY_SQL",
     description:
       "Execute a read-only SQL query against the configured database. Only SELECT and other read operations are allowed. Supports standard SQL syntax including JOINs, WHERE clauses, aggregations, and CTEs.",
@@ -62,7 +62,8 @@ export const createQuerySqlTool = (env: Env) =>
         .boolean()
         .describe("Whether the results were truncated due to the limit"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { query, params = [], limit } = context;
       const state = env.DECO_CHAT_REQUEST_CONTEXT.state;
 

--- a/readonly-sql/tsconfig.json
+++ b/readonly-sql/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],

--- a/reddit/package.json
+++ b/reddit/package.json
@@ -13,7 +13,7 @@
     "build": "bun --bun vite build"
   },
   "dependencies": {
-    "@decocms/runtime": "0.25.1",
+    "@decocms/runtime": "1.4.0",
     "zod": "^3.24.3"
   },
   "devDependencies": {

--- a/reddit/server/tools/reddit.ts
+++ b/reddit/server/tools/reddit.ts
@@ -7,7 +7,7 @@
  */
 import type { Env } from "../main.ts";
 import { createRedditClient } from "./utils/reddit.ts";
-import { createPrivateTool } from "@decocms/runtime/mastra";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import {
   getSubredditPostsInputSchema,
   getSubredditPostsOutputSchema,
@@ -19,13 +19,14 @@ import {
  * GET_SUBREDDIT_POSTS - Fetch posts from a specific subreddit
  */
 export const createGetSubredditPostsTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "GET_SUBREDDIT_POSTS",
     description:
       "Fetch posts from a Reddit subreddit. You can specify the subreddit name (e.g., 'mcp', 'programming', 'news'), how to sort the posts (hot, new, top, rising), and how many posts to return. Use this to browse and discover content from specific Reddit communities.",
     inputSchema: getSubredditPostsInputSchema,
     outputSchema: getSubredditPostsOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { subreddit, sort, time, limit, after } = context;
 
       const client = createRedditClient();
@@ -51,13 +52,14 @@ export const createGetSubredditPostsTool = (_env: Env) =>
  * SEARCH_REDDIT - Search for posts across Reddit or within a specific subreddit
  */
 export const createSearchRedditTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "SEARCH_REDDIT",
     description:
       "Search Reddit for posts matching a query. You can search all of Reddit or limit the search to a specific subreddit. Results can be sorted by relevance, hot, top, new, or number of comments. Use this to find discussions and posts about specific topics.",
     inputSchema: searchRedditInputSchema,
     outputSchema: searchRedditOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { query, subreddit, sort, time, limit, after } = context;
 
       const client = createRedditClient();

--- a/reddit/tsconfig.json
+++ b/reddit/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],

--- a/registry/package.json
+++ b/registry/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@decocms/bindings": "^1.0.4",
-    "@decocms/runtime": "1.1.3",
+    "@decocms/runtime": "1.4.0",
     "@supabase/supabase-js": "^2.89.0",
     "zod": "^4.0.0"
   },

--- a/registry/server/tools/registry-binding.ts
+++ b/registry/server/tools/registry-binding.ts
@@ -6,7 +6,7 @@
  * Uses Supabase as the single source of truth for all MCP server data
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import {
   createSupabaseClient,
@@ -260,17 +260,21 @@ function parseServerId(id: string): { name: string; version?: string } {
  * COLLECTION_REGISTRY_LIST - Lists all servers from Supabase
  */
 export const createListRegistryTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_REGISTRY_APP_LIST",
     description:
       "Lists MCP servers available in the registry with support for pagination, search, and filters (tags, categories, verified, hasRemote). Always returns the latest version of each server.",
     inputSchema: ListInputSchema,
     outputSchema: ListOutputSchema,
-    execute: async ({
-      context,
-    }: {
-      context: z.infer<typeof ListInputSchema>;
-    }) => {
+    execute: async (
+      {
+        context,
+      }: {
+        context: z.infer<typeof ListInputSchema>;
+      },
+      ctx,
+    ) => {
+      ensureAuthenticated(ctx!);
       const { limit = 30, cursor, where, tags, categories, verified } = context;
       try {
         // Get configuration from environment
@@ -337,17 +341,21 @@ export const createListRegistryTool = (_env: Env) =>
  * To get all versions of a server, use COLLECTION_REGISTRY_APP_VERSIONS.
  */
 export const createGetRegistryTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_REGISTRY_APP_GET",
     description:
       "Gets the latest version of a specific MCP server from the registry by name (accepts 'name' or 'name@version', but always returns latest)",
     inputSchema: GetInputSchema,
     outputSchema: GetOutputSchema,
-    execute: async ({
-      context,
-    }: {
-      context: z.infer<typeof GetInputSchema>;
-    }) => {
+    execute: async (
+      {
+        context,
+      }: {
+        context: z.infer<typeof GetInputSchema>;
+      },
+      ctx,
+    ) => {
+      ensureAuthenticated(ctx!);
       const { id } = context;
       try {
         // Parse ID
@@ -387,7 +395,7 @@ export const createGetRegistryTool = (_env: Env) =>
  * COLLECTION_REGISTRY_APP_VERSIONS - Lists all versions of a specific server
  */
 export const createVersionsRegistryTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_REGISTRY_APP_VERSIONS",
     description:
       "Lists all available versions of a specific MCP server from the registry",
@@ -398,11 +406,15 @@ export const createVersionsRegistryTool = (_env: Env) =>
         .describe("Array of all available versions for the server"),
       count: z.number().describe("Total number of versions available"),
     }),
-    execute: async ({
-      context,
-    }: {
-      context: z.infer<typeof VersionsInputSchema>;
-    }) => {
+    execute: async (
+      {
+        context,
+      }: {
+        context: z.infer<typeof VersionsInputSchema>;
+      },
+      ctx,
+    ) => {
+      ensureAuthenticated(ctx!);
       const { name } = context;
       try {
         // Get configuration from environment
@@ -451,7 +463,7 @@ export const createVersionsRegistryTool = (_env: Env) =>
  * COLLECTION_REGISTRY_APP_FILTERS - Get available filter options
  */
 export const createFiltersRegistryTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "COLLECTION_REGISTRY_APP_FILTERS",
     description:
       "Gets all available tags and categories that can be used to filter MCP servers, with counts showing how many servers use each filter value",
@@ -474,7 +486,8 @@ export const createFiltersRegistryTool = (_env: Env) =>
         )
         .describe("Available categories sorted by usage count (descending)"),
     }),
-    execute: async () => {
+    execute: async (_input, ctx) => {
+      ensureAuthenticated(ctx!);
       try {
         // Get configuration from environment
         const supabaseUrl = process.env.SUPABASE_URL;

--- a/registry/tsconfig.json
+++ b/registry/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],

--- a/replicate/package.json
+++ b/replicate/package.json
@@ -13,7 +13,7 @@
     "build": "bun --bun vite build"
   },
   "dependencies": {
-    "@decocms/runtime": "0.25.1",
+    "@decocms/runtime": "1.4.0",
     "replicate": "^1.4.0",
     "zod": "^3.24.3"
   },

--- a/replicate/server/tools/cancel-prediction.ts
+++ b/replicate/server/tools/cancel-prediction.ts
@@ -3,7 +3,7 @@
  * Cancel a running prediction
  */
 
-import { createPrivateTool } from "@decocms/runtime/mastra";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import type { Env } from "../main";
 import { createReplicateClient } from "../lib/replicate";
 import {
@@ -12,7 +12,7 @@ import {
 } from "../lib/types";
 
 export const createCancelPredictionTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "CANCEL_PREDICTION",
     description:
       "Cancel a prediction that is currently starting or processing. " +
@@ -20,7 +20,8 @@ export const createCancelPredictionTool = (env: Env) =>
       "Returns the updated prediction status.",
     inputSchema: CancelPredictionInputSchema,
     outputSchema: CancelPredictionOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { predictionId } = context;
 
       const client = createReplicateClient(env);

--- a/replicate/server/tools/get-model.ts
+++ b/replicate/server/tools/get-model.ts
@@ -3,13 +3,13 @@
  * Get detailed information about a specific Replicate model
  */
 
-import { createPrivateTool } from "@decocms/runtime/mastra";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import type { Env } from "../main";
 import { createReplicateClient } from "../lib/replicate";
 import { GetModelInputSchema, CompleteModelDetailsSchema } from "../lib/types";
 
 export const createGetModelTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "GET_MODEL",
     description:
       "Get detailed information about a specific Replicate model. " +
@@ -17,7 +17,8 @@ export const createGetModelTool = (env: Env) =>
       "example inputs/outputs, latest version details, and schema information.",
     inputSchema: GetModelInputSchema,
     outputSchema: CompleteModelDetailsSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { model } = context;
 
       // Parse owner/name from model string

--- a/replicate/server/tools/get-prediction.ts
+++ b/replicate/server/tools/get-prediction.ts
@@ -3,7 +3,7 @@
  * Retrieve the status and results of a prediction by ID
  */
 
-import { createPrivateTool } from "@decocms/runtime/mastra";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main";
 import { createReplicateClient } from "../lib/replicate";
@@ -13,7 +13,7 @@ import {
 } from "../lib/types";
 
 export const createGetPredictionTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "GET_PREDICTION",
     description:
       "Get the current status and results of a prediction by its ID. " +
@@ -21,7 +21,8 @@ export const createGetPredictionTool = (env: Env) =>
       "or to retrieve results after receiving a webhook notification.",
     inputSchema: GetPredictionInputSchema,
     outputSchema: z.object(CompletePredictionOutputSchema),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { predictionId } = context;
 
       const client = createReplicateClient(env);

--- a/replicate/server/tools/list-models.ts
+++ b/replicate/server/tools/list-models.ts
@@ -3,7 +3,7 @@
  * List available models from a Replicate user/organization
  */
 
-import { createPrivateTool } from "@decocms/runtime/mastra";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import {
   assertEnvKey,
   makeApiRequest,
@@ -13,7 +13,7 @@ import { ListModelsInputSchema, ListModelsOutputSchema } from "../lib/types";
 import { REPLICATE_API_URL } from "../constants";
 
 export const createListModelsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "LIST_MODELS",
     description:
       "List available models from Replicate. " +
@@ -22,7 +22,8 @@ export const createListModelsTool = (env: Env) =>
       "Use the next_cursor from the response to paginate through results.",
     inputSchema: ListModelsInputSchema,
     outputSchema: ListModelsOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { owner, cursor } = context;
 
       // Use the search API to list models by owner

--- a/replicate/server/tools/run-model.ts
+++ b/replicate/server/tools/run-model.ts
@@ -3,7 +3,7 @@
  * Create and execute a prediction using a Replicate model
  */
 
-import { createPrivateTool } from "@decocms/runtime/mastra";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Prediction } from "replicate";
 import type { Env } from "../main";
@@ -25,7 +25,7 @@ function isValidModelIdentifier(
 }
 
 export const createRunModelTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "RUN_MODEL",
     description:
       "Execute a prediction using a Replicate model. " +
@@ -37,7 +37,8 @@ export const createRunModelTool = (env: Env) =>
       ...BasePredictionOutputSchema,
       status: PredictionStatusSchema,
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const { model, input, wait = true, webhook } = context;
 
       const client = createReplicateClient(env);

--- a/replicate/tsconfig.json
+++ b/replicate/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],

--- a/shared/audio-transcribers/base.ts
+++ b/shared/audio-transcribers/base.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/mastra";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import {
   applyMiddlewares,
   Contract,
@@ -48,14 +48,15 @@ export function createAudioTranscriberTools<TEnv extends AudioTranscriberEnv>(
   options: CreateAudioTranscriberOptions<TEnv>,
 ) {
   const transcribeAudio = (env: TEnv) =>
-    createPrivateTool({
+    createTool({
       id: "TRANSCRIBE_AUDIO",
       description:
         options.metadata.description ||
         `Transcribe audio using ${options.metadata.provider}`,
       inputSchema: TranscribeAudioInputSchema,
       outputSchema: TranscribeAudioOutputSchema,
-      execute: async ({ context }: { context: TranscribeAudioInput }) => {
+      execute: async ({ context }: { context: TranscribeAudioInput }, ctx) => {
+        ensureAuthenticated(ctx!);
         const doExecute = async () => {
           const contract = options.getContract(env);
 

--- a/shared/image-analyzers/base.ts
+++ b/shared/image-analyzers/base.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/mastra";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import {
   applyMiddlewares,
   withLogging,
@@ -34,14 +34,15 @@ export function createImageAnalyzerTools<
    * ANALYZE_IMAGE tool
    */
   const analyzeImage = (env: TEnv) =>
-    createPrivateTool({
+    createTool({
       id: "ANALYZE_IMAGE",
       description:
         options.metadata.description ||
         `Analyzes images using ${options.metadata.provider}. Can describe content, identify objects, answer questions about the image.`,
       inputSchema: AnalyzeImageInputSchema,
       outputSchema: AnalyzeImageOutputSchema,
-      execute: async ({ context }: { context: AnalyzeImageInput }) => {
+      execute: async ({ context }: { context: AnalyzeImageInput }, ctx) => {
+        ensureAuthenticated(ctx!);
         const doExecute = async () => {
           const contractConfig = options.analyzeTool.getContract?.(env);
 
@@ -106,12 +107,16 @@ export function createImageAnalyzerTools<
    */
   const compareImages = options.compareTool
     ? (env: TEnv) =>
-        createPrivateTool({
+        createTool({
           id: "COMPARE_IMAGES",
           description: `Compares multiple images using ${options.metadata.provider}. Useful for identifying differences, similarities, or analyzing changes.`,
           inputSchema: CompareImagesInputSchema,
           outputSchema: CompareImagesOutputSchema,
-          execute: async ({ context }: { context: CompareImagesInput }) => {
+          execute: async (
+            { context }: { context: CompareImagesInput },
+            ctx,
+          ) => {
+            ensureAuthenticated(ctx!);
             const doExecute = async () => {
               const contractConfig = options.compareTool!.getContract?.(env);
 
@@ -177,12 +182,13 @@ export function createImageAnalyzerTools<
    */
   const extractTextFromImage = options.extractTextTool
     ? (env: TEnv) =>
-        createPrivateTool({
+        createTool({
           id: "EXTRACT_TEXT_FROM_IMAGE",
           description: `Extracts all visible text from an image using OCR from ${options.metadata.provider}. Useful for reading documents, signs, screenshots, etc.`,
           inputSchema: ExtractTextInputSchema,
           outputSchema: ExtractTextOutputSchema,
-          execute: async ({ context }: { context: ExtractTextInput }) => {
+          execute: async ({ context }: { context: ExtractTextInput }, ctx) => {
+            ensureAuthenticated(ctx!);
             const doExecute = async () => {
               const contractConfig =
                 options.extractTextTool!.getContract?.(env);

--- a/shared/image-generators/base.ts
+++ b/shared/image-generators/base.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { saveImage } from "./storage";
 import { ObjectStorage } from "../storage";
 import {
@@ -131,14 +131,15 @@ export function createImageGeneratorTools<
   type Input = z.infer<typeof inputSchema>;
 
   const generateImage = (env: TEnv) =>
-    createPrivateTool({
+    createTool({
       id: "GENERATE_IMAGE",
       description:
         options.metadata.description ||
         `Generate images using ${options.metadata.provider}`,
       inputSchema,
       outputSchema: GenerateImageOutputSchema,
-      execute: async ({ context }: { context: Input }) => {
+      execute: async ({ context }: { context: Input }, ctx) => {
+        ensureAuthenticated(ctx!);
         const doExecute = async () => {
           const contract = options.getContract(env);
 

--- a/shared/package.json
+++ b/shared/package.json
@@ -26,7 +26,7 @@
     },
     "devDependencies": {
         "@decocms/bindings": "1.0.7",
-        "@decocms/runtime": "1.1.3",
+        "@decocms/runtime": "1.4.0",
         "@types/bun": "^1.2.14",
         "vite": "7.2.0",
         "zod": "^4.0.0"

--- a/shared/search-ai/base.ts
+++ b/shared/search-ai/base.ts
@@ -5,7 +5,7 @@
  * search AI providers like Perplexity, ChatGPT Search, Google Gemini, etc.
  */
 
-import { createPrivateTool } from "@decocms/runtime/mastra";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import {
   AskInputSchema,
   ChatInputSchema,
@@ -130,14 +130,15 @@ export function createSearchAITools<
   const ask = (env: TEnv) => {
     type AskInputType = z.infer<typeof askInputSchema>;
 
-    return createPrivateTool({
+    return createTool({
       id: "ASK",
       description:
         options.metadata.description ||
         `Ask a question to ${options.metadata.provider} and get web-backed answers`,
       inputSchema: askInputSchema,
       outputSchema: SearchAIOutputSchema,
-      execute: async ({ context }: { context: AskInputType }) => {
+      execute: async ({ context }: { context: AskInputType }, ctx) => {
+        ensureAuthenticated(ctx!);
         const doExecute = async (): Promise<SearchAIOutput> => {
           // Handle contract if provided
           let transactionId: string | undefined;
@@ -217,14 +218,15 @@ export function createSearchAITools<
   const chat = (env: TEnv) => {
     type ChatInputType = z.infer<typeof chatInputSchema>;
 
-    return createPrivateTool({
+    return createTool({
       id: "CHAT",
       description:
         `Have a multi-turn conversation with ${options.metadata.provider}. ` +
         `This allows you to provide message history for more contextual responses.`,
       inputSchema: chatInputSchema,
       outputSchema: SearchAIOutputSchema,
-      execute: async ({ context }: { context: ChatInputType }) => {
+      execute: async ({ context }: { context: ChatInputType }, ctx) => {
+        ensureAuthenticated(ctx!);
         const doExecute = async (): Promise<SearchAIOutput> => {
           // Handle contract if provided
           let transactionId: string | undefined;

--- a/shared/tools/file-management.ts
+++ b/shared/tools/file-management.ts
@@ -18,7 +18,7 @@
  *     description: "Uploads a file",
  *     inputSchema: fileUploadInputSchema,
  *     execute: async ({ input }, ctx) => {
-      ensureAuthenticated(ctx!);
+ *       ensureAuthenticated(ctx!);
  *       const file = await createFileFromInput(input);
  *       // ... use file
  *     },

--- a/shared/tools/file-management.ts
+++ b/shared/tools/file-management.ts
@@ -13,11 +13,12 @@
  * import { createFileFromInput, fileUploadInputSchema } from '@decocms/mcps-shared/tools/file-management';
  *
  * export const createUploadFileTool = (env: Env) =>
- *   createPrivateTool({
+ *   createTool({
  *     id: "upload_file",
  *     description: "Uploads a file",
  *     inputSchema: fileUploadInputSchema,
- *     execute: async ({ input }) => {
+ *     execute: async ({ input }, ctx) => {
+      ensureAuthenticated(ctx!);
  *       const file = await createFileFromInput(input);
  *       // ... use file
  *     },

--- a/shared/tools/file-management/base.ts
+++ b/shared/tools/file-management/base.ts
@@ -6,7 +6,7 @@
  * It standardizes the creation of file upload, list, get, delete, and search tools.
  */
 
-import { createPrivateTool } from "@decocms/runtime/mastra";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import {
   fileUploadInputSchema,
   fileUploadOutputSchema,
@@ -230,14 +230,15 @@ export function createFileManagementTools<
   TClient extends FileManagementClient,
 >(options: CreateFileManagementOptions<TEnv, TClient>) {
   const uploadFile = (env: TEnv) =>
-    createPrivateTool({
+    createTool({
       id: "upload_file",
       description:
         options.metadata.description ||
         `Uploads a file to ${options.metadata.provider}. You can provide either a file URL or file content. The file will be processed and made available for context retrieval.`,
       inputSchema: fileUploadInputSchema,
       outputSchema: fileUploadOutputSchema,
-      execute: async ({ context }: { context: FileUploadInput }) => {
+      execute: async ({ context }: { context: FileUploadInput }, ctx) => {
+        ensureAuthenticated(ctx!);
         return await withFileOperationErrorHandling(async () => {
           const contractConfig = options.uploadTool.getContract?.(env);
           let transactionId: string | undefined;
@@ -302,12 +303,13 @@ export function createFileManagementTools<
     });
 
   const listFiles = (env: TEnv) =>
-    createPrivateTool({
+    createTool({
       id: "list_files",
       description: `Lists all files in ${options.metadata.provider}`,
       inputSchema: fileListInputSchema,
       outputSchema: fileListOutputSchema,
-      execute: async ({ context }: { context: FileListInput }) => {
+      execute: async ({ context }: { context: FileListInput }, ctx) => {
+        ensureAuthenticated(ctx!);
         try {
           const client = options.getClient(env);
           const result = await options.listTool.execute({
@@ -330,12 +332,13 @@ export function createFileManagementTools<
     });
 
   const getFile = (env: TEnv) =>
-    createPrivateTool({
+    createTool({
       id: "get_file",
       description: `Gets details of a specific file from ${options.metadata.provider}`,
       inputSchema: fileGetInputSchema,
       outputSchema: fileGetOutputSchema,
-      execute: async ({ context }: { context: FileGetInput }) => {
+      execute: async ({ context }: { context: FileGetInput }, ctx) => {
+        ensureAuthenticated(ctx!);
         return await withFileOperationErrorHandling(async () => {
           const contractConfig = options.getTool.getContract?.(env);
           let transactionId: string | undefined;
@@ -398,12 +401,13 @@ export function createFileManagementTools<
     });
 
   const deleteFile = (env: TEnv) =>
-    createPrivateTool({
+    createTool({
       id: "delete_file",
       description: `Deletes a file from ${options.metadata.provider}`,
       inputSchema: fileDeleteInputSchema,
       outputSchema: fileDeleteOutputSchema,
-      execute: async ({ context }: { context: FileDeleteInput }) => {
+      execute: async ({ context }: { context: FileDeleteInput }, ctx) => {
+        ensureAuthenticated(ctx!);
         return await withFileOperationErrorHandling(async () => {
           const contractConfig = options.deleteTool.getContract?.(env);
           let transactionId: string | undefined;
@@ -453,14 +457,15 @@ export function createFileManagementTools<
   const searchContext = options.searchTool
     ? (env: TEnv) => {
         const searchToolConfig = options.searchTool!;
-        return createPrivateTool({
+        return createTool({
           id: "search_context",
           description:
             searchToolConfig.description ||
             `Retrieves relevant document snippets from ${options.metadata.provider}'s knowledge base.`,
           inputSchema: searchToolConfig.inputSchema,
           outputSchema: searchToolConfig.outputSchema,
-          execute: async ({ context }: { context: any }) => {
+          execute: async ({ context }: { context: any }, ctx) => {
+            ensureAuthenticated(ctx!);
             const contractConfig = searchToolConfig.getContract?.(env);
             let transactionId: string | undefined;
 

--- a/shared/tools/user.ts
+++ b/shared/tools/user.ts
@@ -5,7 +5,7 @@
  * - Getting current user information
  * - User authentication checks
  */
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 
 /**
@@ -38,7 +38,7 @@ export interface UserToolsEnv {
  * to get the user object.
  */
 export const createGetUserTool = <TEnv extends UserToolsEnv>(env: TEnv) =>
-  createPrivateTool({
+  createTool({
     id: "GET_USER",
     description: "Get the current logged in user",
     inputSchema: z.object({}),
@@ -48,7 +48,8 @@ export const createGetUserTool = <TEnv extends UserToolsEnv>(env: TEnv) =>
       avatar: z.string().nullable(),
       email: z.string(),
     }),
-    execute: async () => {
+    execute: async (_input, ctx) => {
+      ensureAuthenticated(ctx!);
       const user = env.DECO_CHAT_REQUEST_CONTEXT.ensureAuthenticated();
 
       if (!user) {

--- a/shared/video-generators/base.ts
+++ b/shared/video-generators/base.ts
@@ -1,4 +1,4 @@
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { saveVideo } from "./storage";
 import { ObjectStorage } from "../storage";
 import {
@@ -202,14 +202,15 @@ export function createVideoGeneratorTools<
     : ExtendVideoInputSchema;
 
   const generateVideo = (env: TEnv) =>
-    createPrivateTool({
+    createTool({
       id: "GENERATE_VIDEO",
       description:
         options.metadata.description ||
         `Generate videos using ${options.metadata.provider}`,
       inputSchema: generateVideoInputSchema,
       outputSchema: GenerateVideoOutputSchema,
-      execute: async ({ context }) => {
+      execute: async ({ context }, ctx) => {
+        ensureAuthenticated(ctx!);
         const doExecute = async () => {
           const contractConfig = options.generateTool.getContract?.(env);
 
@@ -293,12 +294,13 @@ export function createVideoGeneratorTools<
 
   const listVideos = options.listTool
     ? (env: TEnv) =>
-        createPrivateTool({
+        createTool({
           id: "LIST_VIDEOS",
           description: `List videos generated with ${options.metadata.provider}. Supports pagination to navigate through all videos.`,
           inputSchema: ListVideosInputSchema,
           outputSchema: ListVideosOutputSchema,
-          execute: async ({ context }: { context: ListVideosInput }) => {
+          execute: async ({ context }: { context: ListVideosInput }, ctx) => {
+            ensureAuthenticated(ctx!);
             const client = options.getClient?.(env) as TClient;
             return options.listTool!.execute({ env, input: context, client });
           },
@@ -307,12 +309,13 @@ export function createVideoGeneratorTools<
 
   const extendVideo = options.extendTool
     ? (env: TEnv) =>
-        createPrivateTool({
+        createTool({
           id: "EXTEND_VIDEO",
           description: `Extend or remix an existing video using ${options.metadata.provider}. Creates a new video based on an existing one with a new prompt.`,
           inputSchema: extendVideoInputSchema,
           outputSchema: ExtendVideoOutputSchema,
-          execute: async ({ context }) => {
+          execute: async ({ context }, ctx) => {
+            ensureAuthenticated(ctx!);
             const doExecute = async () => {
               const contractConfig = options.extendTool!.getContract?.(env);
 

--- a/slack-mcp/package.json
+++ b/slack-mcp/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@decocms/bindings": "^1.0.8",
-    "@decocms/runtime": "1.3.0",
+    "@decocms/runtime": "1.4.0",
     "@slack/web-api": "^7.8.0",
     "@supabase/supabase-js": "^2.47.10",
     "hono": "^4.7.4",

--- a/slack-mcp/server/tools/setup.ts
+++ b/slack-mcp/server/tools/setup.ts
@@ -4,7 +4,7 @@
  * Tools for bot status and thread management.
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import z from "zod";
 import type { Env } from "../types/env.ts";
 import { getBotInfo, ensureSlackClient } from "../lib/slack-client.ts";
@@ -18,7 +18,7 @@ import {
  * Get bot status
  */
 export const createGetBotStatusTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "SLACK_GET_BOT_STATUS",
     description: "Get the current status of the Slack bot",
     annotations: { readOnlyHint: true },
@@ -36,7 +36,8 @@ export const createGetBotStatusTool = (env: Env) =>
         error: z.string().optional(),
       })
       .strict(),
-    execute: async () => {
+    execute: async (_input, ctx) => {
+      ensureAuthenticated(ctx!);
       try {
         const botToken =
           env.MESH_REQUEST_CONTEXT?.state?.SLACK_CREDENTIALS?.BOT_TOKEN;
@@ -83,7 +84,7 @@ export const createGetBotStatusTool = (env: Env) =>
  * Get thread info
  */
 export const createGetThreadInfoTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "SLACK_GET_THREAD_INFO",
     description:
       "Get information about a logical conversation thread (used for context management)",
@@ -110,7 +111,8 @@ export const createGetThreadInfoTool = (_env: Env) =>
         error: z.string().optional(),
       })
       .strict(),
-    execute: async ({ context }: { context: unknown }) => {
+    execute: async ({ context }: { context: unknown }, ctx) => {
+      ensureAuthenticated(ctx!);
       const input = context as {
         channel: string;
         thread_identifier: string;
@@ -151,7 +153,7 @@ export const createGetThreadInfoTool = (_env: Env) =>
  * Reset thread context
  */
 export const createResetThreadTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "SLACK_RESET_THREAD",
     description:
       "Reset a conversation thread context (clears message history for the thread)",
@@ -169,7 +171,8 @@ export const createResetThreadTool = (_env: Env) =>
         error: z.string().optional(),
       })
       .strict(),
-    execute: async ({ context }: { context: unknown }) => {
+    execute: async ({ context }: { context: unknown }, ctx) => {
+      ensureAuthenticated(ctx!);
       const input = context as {
         channel: string;
         thread_identifier: string;
@@ -195,7 +198,7 @@ export const createResetThreadTool = (_env: Env) =>
  * Get thread conversation history
  */
 export const createGetThreadHistoryTool = (_env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "SLACK_GET_THREAD_HISTORY",
     description:
       "Get the conversation history for a logical thread (internal context, not Slack messages)",
@@ -225,7 +228,8 @@ export const createGetThreadHistoryTool = (_env: Env) =>
         error: z.string().optional(),
       })
       .strict(),
-    execute: async ({ context }: { context: unknown }) => {
+    execute: async ({ context }: { context: unknown }, ctx) => {
+      ensureAuthenticated(ctx!);
       const input = context as {
         channel: string;
         thread_identifier: string;

--- a/slack-mcp/tsconfig.json
+++ b/slack-mcp/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": [

--- a/sora/package.json
+++ b/sora/package.json
@@ -13,7 +13,7 @@
     "build": "bun --bun vite build"
   },
   "dependencies": {
-    "@decocms/runtime": "0.25.1",
+    "@decocms/runtime": "1.4.0",
     "zod": "^3.24.3"
   },
   "devDependencies": {

--- a/sora/tsconfig.json
+++ b/sora/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],

--- a/strapi/package.json
+++ b/strapi/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@decocms/runtime": "^1.2.7",
+    "@decocms/runtime": "1.4.0",
     "qs": "^6.14.0",
     "zod": "^4.0.0"
   },

--- a/strapi/tsconfig.json
+++ b/strapi/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/template-minimal/package.json
+++ b/template-minimal/package.json
@@ -11,7 +11,7 @@
     "build": "bun run build:server"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/template-minimal/server/tools/index.ts
+++ b/template-minimal/server/tools/index.ts
@@ -26,7 +26,7 @@ export const tools = [
 // import { z } from "zod";
 //
 // export const myToolFactory = (env: Env) =>
-//   createPrivateTool({
+//   createTool({
 //     id: "my_tool",
 //     description: "Does something useful",
 //     inputSchema: z.object({
@@ -35,7 +35,8 @@ export const tools = [
 //     outputSchema: z.object({
 //       result: z.string().describe("Output result"),
 //     }),
-//     execute: async ({ input }) => {
+//     execute: async ({ input }, ctx) => {
+ensureAuthenticated(ctx!);
 //       // Your implementation here
 //       return { result: `Processed: ${input.param}` };
 //     },

--- a/template-minimal/server/tools/index.ts
+++ b/template-minimal/server/tools/index.ts
@@ -35,8 +35,8 @@ export const tools = [
 //     outputSchema: z.object({
 //       result: z.string().describe("Output result"),
 //     }),
-//     execute: async ({ input }, ctx) => {
-ensureAuthenticated(ctx!);
+// //     execute: async ({ input }, ctx) => {
+//       ensureAuthenticated(ctx!);
 //       // Your implementation here
 //       return { result: `Processed: ${input.param}` };
 //     },

--- a/template-minimal/tsconfig.json
+++ b/template-minimal/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "ES2024"],

--- a/tiktok-ads/package.json
+++ b/tiktok-ads/package.json
@@ -12,7 +12,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@decocms/runtime": "1.1.3",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/tiktok-ads/server/tools/adgroups.ts
+++ b/tiktok-ads/server/tools/adgroups.ts
@@ -4,7 +4,7 @@
  * Tools for listing, creating, and updating ad groups
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import {
@@ -84,7 +84,7 @@ const PageInfoSchema = z.object({
 // ============================================================================
 
 export const createListAdGroupsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_adgroups",
     description:
       "List all ad groups for an advertiser with optional filters for campaign, name, and status.",
@@ -123,7 +123,8 @@ export const createListAdGroupsTool = (env: Env) =>
       adgroups: z.array(AdGroupSchema).describe("List of ad groups"),
       page_info: PageInfoSchema.describe("Pagination info"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const advertiserId = context.advertiser_id || getDefaultAdvertiserId(env);
       if (!advertiserId) {
         throw new Error(
@@ -158,7 +159,7 @@ export const createListAdGroupsTool = (env: Env) =>
 // ============================================================================
 
 export const createGetAdGroupTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_adgroup",
     description:
       "Get detailed information about a specific ad group by its ID.",
@@ -172,7 +173,8 @@ export const createGetAdGroupTool = (env: Env) =>
     outputSchema: z.object({
       adgroup: AdGroupSchema.nullable().describe("Ad Group details"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const advertiserId = context.advertiser_id || getDefaultAdvertiserId(env);
       if (!advertiserId) {
         throw new Error(
@@ -200,7 +202,7 @@ export const createGetAdGroupTool = (env: Env) =>
 // ============================================================================
 
 export const createCreateAdGroupTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_adgroup",
     description:
       "Create a new ad group within a campaign. Requires advertiser ID, campaign ID, name, and optimization goal.",
@@ -257,7 +259,8 @@ export const createCreateAdGroupTool = (env: Env) =>
       success: z.boolean().describe("Whether creation was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const advertiserId = context.advertiser_id || getDefaultAdvertiserId(env);
       if (!advertiserId) {
         throw new Error(
@@ -302,7 +305,7 @@ export const createCreateAdGroupTool = (env: Env) =>
 // ============================================================================
 
 export const createUpdateAdGroupTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "update_adgroup",
     description:
       "Update an existing ad group. Only provided fields will be updated. At least one field to update must be provided.",
@@ -349,7 +352,8 @@ export const createUpdateAdGroupTool = (env: Env) =>
       success: z.boolean().describe("Whether update was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const advertiserId = context.advertiser_id || getDefaultAdvertiserId(env);
       if (!advertiserId) {
         throw new Error(

--- a/tiktok-ads/server/tools/ads.ts
+++ b/tiktok-ads/server/tools/ads.ts
@@ -4,7 +4,7 @@
  * Tools for listing, creating, and updating ads
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import {
@@ -58,7 +58,7 @@ const PageInfoSchema = z.object({
 // ============================================================================
 
 export const createListAdsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_ads",
     description:
       "List all ads for an advertiser with optional filters for campaign, ad group, name, and status.",
@@ -101,7 +101,8 @@ export const createListAdsTool = (env: Env) =>
       ads: z.array(AdSchema).describe("List of ads"),
       page_info: PageInfoSchema.describe("Pagination info"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const advertiserId = context.advertiser_id || getDefaultAdvertiserId(env);
       if (!advertiserId) {
         throw new Error(
@@ -137,7 +138,7 @@ export const createListAdsTool = (env: Env) =>
 // ============================================================================
 
 export const createGetAdTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_ad",
     description: "Get detailed information about a specific ad by its ID.",
     inputSchema: z.object({
@@ -150,7 +151,8 @@ export const createGetAdTool = (env: Env) =>
     outputSchema: z.object({
       ad: AdSchema.nullable().describe("Ad details"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const advertiserId = context.advertiser_id || getDefaultAdvertiserId(env);
       if (!advertiserId) {
         throw new Error(
@@ -178,7 +180,7 @@ export const createGetAdTool = (env: Env) =>
 // ============================================================================
 
 export const createCreateAdTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_ad",
     description:
       "Create a new ad within an ad group. Requires advertiser ID, ad group ID, name, and ad format.",
@@ -236,7 +238,8 @@ export const createCreateAdTool = (env: Env) =>
       success: z.boolean().describe("Whether creation was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const advertiserId = context.advertiser_id || getDefaultAdvertiserId(env);
       if (!advertiserId) {
         throw new Error(
@@ -277,7 +280,7 @@ export const createCreateAdTool = (env: Env) =>
 // ============================================================================
 
 export const createUpdateAdTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "update_ad",
     description:
       "Update an existing ad. Only provided fields will be updated. At least one field to update must be provided.",
@@ -317,7 +320,8 @@ export const createUpdateAdTool = (env: Env) =>
       success: z.boolean().describe("Whether update was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const advertiserId = context.advertiser_id || getDefaultAdvertiserId(env);
       if (!advertiserId) {
         throw new Error(

--- a/tiktok-ads/server/tools/campaigns.ts
+++ b/tiktok-ads/server/tools/campaigns.ts
@@ -4,7 +4,7 @@
  * Tools for listing, creating, and updating campaigns
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import {
@@ -61,7 +61,7 @@ const PageInfoSchema = z.object({
 // ============================================================================
 
 export const createListCampaignsTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "list_campaigns",
     description:
       "List all campaigns for an advertiser with optional filters for name, objective, and status.",
@@ -99,7 +99,8 @@ export const createListCampaignsTool = (env: Env) =>
       campaigns: z.array(CampaignSchema).describe("List of campaigns"),
       page_info: PageInfoSchema.describe("Pagination info"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const advertiserId = context.advertiser_id || getDefaultAdvertiserId(env);
       if (!advertiserId) {
         throw new Error(
@@ -134,7 +135,7 @@ export const createListCampaignsTool = (env: Env) =>
 // ============================================================================
 
 export const createGetCampaignTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_campaign",
     description:
       "Get detailed information about a specific campaign by its ID.",
@@ -148,7 +149,8 @@ export const createGetCampaignTool = (env: Env) =>
     outputSchema: z.object({
       campaign: CampaignSchema.nullable().describe("Campaign details"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const advertiserId = context.advertiser_id || getDefaultAdvertiserId(env);
       if (!advertiserId) {
         throw new Error(
@@ -176,7 +178,7 @@ export const createGetCampaignTool = (env: Env) =>
 // ============================================================================
 
 export const createCreateCampaignTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "create_campaign",
     description:
       "Create a new advertising campaign. Requires advertiser ID, name, and objective type.",
@@ -206,7 +208,8 @@ export const createCreateCampaignTool = (env: Env) =>
       success: z.boolean().describe("Whether creation was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const advertiserId = context.advertiser_id || getDefaultAdvertiserId(env);
       if (!advertiserId) {
         throw new Error(
@@ -240,7 +243,7 @@ export const createCreateCampaignTool = (env: Env) =>
 // ============================================================================
 
 export const createUpdateCampaignTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "update_campaign",
     description:
       "Update an existing campaign. Only provided fields will be updated. At least one field to update must be provided.",
@@ -278,7 +281,8 @@ export const createUpdateCampaignTool = (env: Env) =>
       success: z.boolean().describe("Whether update was successful"),
       message: z.string().describe("Result message"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const advertiserId = context.advertiser_id || getDefaultAdvertiserId(env);
       if (!advertiserId) {
         throw new Error(

--- a/tiktok-ads/server/tools/reports.ts
+++ b/tiktok-ads/server/tools/reports.ts
@@ -4,7 +4,7 @@
  * Tools for getting performance reports at different levels
  */
 
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../main.ts";
 import {
@@ -78,7 +78,7 @@ const PageInfoSchema = z.object({
 // ============================================================================
 
 export const createGetReportTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_report",
     description:
       "Get performance report data for campaigns, ad groups, or ads. Supports custom date ranges, dimensions, and metrics.",
@@ -133,7 +133,8 @@ export const createGetReportTool = (env: Env) =>
       rows: z.array(ReportRowSchema).describe("Report data rows"),
       page_info: PageInfoSchema.describe("Pagination info"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const advertiserId = context.advertiser_id || getDefaultAdvertiserId(env);
       if (!advertiserId) {
         throw new Error(
@@ -205,7 +206,7 @@ export const createGetReportTool = (env: Env) =>
 // ============================================================================
 
 export const createGetCampaignReportTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_campaign_report",
     description:
       "Get performance report for campaigns. Returns spend, impressions, clicks, conversions and other metrics by day.",
@@ -240,7 +241,8 @@ export const createGetCampaignReportTool = (env: Env) =>
       rows: z.array(ReportRowSchema).describe("Campaign report data"),
       page_info: PageInfoSchema.describe("Pagination info"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const advertiserId = context.advertiser_id || getDefaultAdvertiserId(env);
       if (!advertiserId) {
         throw new Error(
@@ -288,7 +290,7 @@ export const createGetCampaignReportTool = (env: Env) =>
 // ============================================================================
 
 export const createGetAdGroupReportTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_adgroup_report",
     description:
       "Get performance report for ad groups. Returns spend, impressions, clicks, conversions and other metrics by day.",
@@ -327,7 +329,8 @@ export const createGetAdGroupReportTool = (env: Env) =>
       rows: z.array(ReportRowSchema).describe("Ad group report data"),
       page_info: PageInfoSchema.describe("Pagination info"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const advertiserId = context.advertiser_id || getDefaultAdvertiserId(env);
       if (!advertiserId) {
         throw new Error(
@@ -376,7 +379,7 @@ export const createGetAdGroupReportTool = (env: Env) =>
 // ============================================================================
 
 export const createGetAdReportTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_ad_report",
     description:
       "Get performance report for individual ads. Returns spend, impressions, clicks, conversions and other metrics by day.",
@@ -419,7 +422,8 @@ export const createGetAdReportTool = (env: Env) =>
       rows: z.array(ReportRowSchema).describe("Ad report data"),
       page_info: PageInfoSchema.describe("Pagination info"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const advertiserId = context.advertiser_id || getDefaultAdvertiserId(env);
       if (!advertiserId) {
         throw new Error(
@@ -475,7 +479,7 @@ export const createGetAdReportTool = (env: Env) =>
 // ============================================================================
 
 export const createGetAdvertiserInfoTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "get_advertiser_info",
     description:
       "Get information about one or more advertisers, including name, status, balance, and timezone.",
@@ -503,7 +507,8 @@ export const createGetAdvertiserInfoTool = (env: Env) =>
         )
         .describe("List of advertiser information"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       let advertiserIds = context.advertiser_ids;
       if (!advertiserIds || advertiserIds.length === 0) {
         const defaultId = getDefaultAdvertiserId(env);

--- a/tiktok-ads/tsconfig.json
+++ b/tiktok-ads/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",

--- a/veo/package.json
+++ b/veo/package.json
@@ -11,7 +11,7 @@
     "build": "bun run build:server"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/veo/server/tools/veo.ts
+++ b/veo/server/tools/veo.ts
@@ -1,6 +1,6 @@
 import type { Env } from "server/main.ts";
 import { createVeoClient, VeoModels, type VeoModel } from "./utils/veo.ts";
-import { createPrivateTool } from "@decocms/runtime/tools";
+import { createTool, ensureAuthenticated } from "@decocms/runtime/tools";
 import {
   saveVideo,
   createGenerateVideoInputSchema,
@@ -127,13 +127,14 @@ const ExtendVideoOutputSchema = z.object({
 // Tool factories
 
 const createGenerateVideoTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "GENERATE_VIDEO",
     description:
       "Start generating a video using Google Veo. Returns an operation name immediately. Use GET_GENERATED_VIDEO with the operation name to check status and retrieve the video once ready.",
     inputSchema: generateVideoInputSchema,
     outputSchema: GenerateVideoOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = createVeoClient(env);
 
       const modelToUse = context.model ?? "veo-3.1-generate-preview";
@@ -166,13 +167,14 @@ const createGenerateVideoTool = (env: Env) =>
   });
 
 const createGetGeneratedVideoTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "GET_GENERATED_VIDEO",
     description:
       "Check the status of a video generation operation and retrieve the video URL when completed. Use the operationName returned by GENERATE_VIDEO or EXTEND_VIDEO.",
     inputSchema: GetGeneratedVideoInputSchema,
     outputSchema: GetGeneratedVideoOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = createVeoClient(env);
       const { operationName } = context;
 
@@ -236,13 +238,14 @@ const createGetGeneratedVideoTool = (env: Env) =>
   });
 
 const createExtendVideoTool = (env: Env) =>
-  createPrivateTool({
+  createTool({
     id: "EXTEND_VIDEO",
     description:
       "Start extending or remixing an existing video using Google Veo. Returns an operation name immediately. Use GET_GENERATED_VIDEO with the operation name to check status and retrieve the video once ready.",
     inputSchema: extendVideoInputSchema,
     outputSchema: ExtendVideoOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context }, ctx) => {
+      ensureAuthenticated(ctx!);
       const client = createVeoClient(env);
 
       const modelToUse = context.model ?? "veo-3.1-generate-preview";

--- a/veo/tsconfig.json
+++ b/veo/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": [

--- a/virtual-try-on/package.json
+++ b/virtual-try-on/package.json
@@ -14,7 +14,7 @@
     "build": "bun run build:server"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/virtual-try-on/tsconfig.json
+++ b/virtual-try-on/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": [

--- a/vtex-docs/package.json
+++ b/vtex-docs/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^1.3.22",
     "@ai-sdk/openai-compatible": "^0.2.14",
-    "@decocms/runtime": "1.1.3",
+    "@decocms/runtime": "1.4.0",
     "@supabase/supabase-js": "^2.49.1",
     "ai": "^4.3.16",
     "zod": "^4.0.0"

--- a/vtex/package.json
+++ b/vtex/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@decocms/bindings": "^1.3.1",
-    "@decocms/runtime": "1.3.1",
+    "@decocms/runtime": "1.4.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/whatsapp-management/package.json
+++ b/whatsapp-management/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@decocms/bindings": "^1.1.3",
-    "@decocms/runtime": "1.1.3",
+    "@decocms/runtime": "1.4.0",
     "hono": "^4.11.3",
     "zod": "^4.0.0"
   },

--- a/whatsapp-management/tsconfig.json
+++ b/whatsapp-management/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "ES2024", "DOM", "DOM.Iterable"],

--- a/whatsapp/package.json
+++ b/whatsapp/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@decocms/bindings": "^1.1.3",
-    "@decocms/runtime": "1.1.3",
+    "@decocms/runtime": "1.4.0",
     "@upstash/redis": "^1.36.1",
     "ai": "^6.0.50",
     "hono": "^4.11.3",

--- a/whatsapp/tsconfig.json
+++ b/whatsapp/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "ES2024", "DOM", "DOM.Iterable"],

--- a/whisper/package.json
+++ b/whisper/package.json
@@ -13,7 +13,7 @@
     "build": "bun --bun vite build"
   },
   "dependencies": {
-    "@decocms/runtime": "0.24.0",
+    "@decocms/runtime": "1.4.0",
     "zod": "^3.24.3"
   },
   "devDependencies": {

--- a/whisper/tsconfig.json
+++ b/whisper/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],


### PR DESCRIPTION
## Summary

- Bumps `@decocms/runtime` from various versions to `1.4.0` across all 54 workspace packages
- Replaces deprecated `createPrivateTool` with `createTool` + `ensureAuthenticated(ctx!)` in 135 tool files
- Fixes `@decocms/runtime/mastra` imports → `@decocms/runtime/tools` (subpath removed in 1.4.0)
- Replaces removed `createStreamableTool` with `createTool` in LLM binding tools
- Factory wrappers `(env) =>` are preserved (deprecated but functional) for a follow-up cleanup

## Test plan

- [ ] `bun install` succeeds
- [ ] `bun run check` passes (44 pre-existing errors, no new ones)
- [ ] Tools still register and execute correctly with the deprecated factory pattern
- [ ] `ensureAuthenticated(ctx!)` properly gates private tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `@decocms/runtime` to `1.4.0` across the monorepo and migrates tools to `createTool` with `ensureAuthenticated(ctx!)`, resolving API changes and CI failures. TS configs now ignore the TS 7 `baseUrl` deprecation to keep builds passing.

- **Migration**
  - Replace `createPrivateTool`/`createStreamableTool` with `createTool` and call `ensureAuthenticated(ctx!)` inside `execute`.
  - Update imports from `@decocms/runtime/mastra` to `@decocms/runtime/tools`.
  - Add `"ignoreDeprecations": "6.0"` to `tsconfig.json` where `baseUrl` is used.
  - Keep factory wrappers `(env) =>` for now.

- **Bug Fixes**
  - Remove unused `@ts-expect-error` in `deco-llm/server/main.ts`.
  - Add `@ts-expect-error` for `meta-ads` `adsets.ts` execute signature mismatch.
  - Fix corrupted commented code in `template-minimal` and `shared/tools/file-management.ts`.

<sup>Written for commit 10812efcba235e5fd5c40377099bf8c5cd44abc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

