### PR TITLE
fix(slack): fix HyperDX auth header and simplify API key source

### DIFF
--- a/slack-mcp/server/lib/config-cache.ts
+++ b/slack-mcp/server/lib/config-cache.ts
@@ -45,7 +45,6 @@ export interface ConnectionConfig {
   teamName?: string;
   botUserId?: string;
   connectionName?: string;
-  hyperDxApiKey?: string;
   responseConfig?: {
     showOnlyFinalResponse?: boolean;
     enableStreaming?: boolean;

--- a/slack-mcp/server/lib/logger.ts
+++ b/slack-mcp/server/lib/logger.ts
@@ -185,7 +185,7 @@ export class HyperDXLogger {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: this.apiKey!,
+          Authorization: `Bearer ${this.apiKey}`,
         },
         body: JSON.stringify({
           resourceLogs: [

--- a/slack-mcp/server/main.ts
+++ b/slack-mcp/server/main.ts
@@ -267,7 +267,6 @@ const onChangeHandler = async (env: Env, config: any) => {
       systemPrompt,
       botToken,
       signingSecret,
-      hyperDxApiKey: state?.HYPERDX_API_KEY,
       responseConfig: {
         showOnlyFinalResponse,
         enableStreaming,
@@ -304,15 +303,7 @@ const onChangeHandler = async (env: Env, config: any) => {
       };
       await cacheConnectionConfig(updatedConfig);
 
-      // Configure HyperDX logger with API key if provided
-      const hyperDxKey = state?.HYPERDX_API_KEY;
-      console.log(
-        `[HyperDX] API Key from state: ${hyperDxKey ? "present (" + hyperDxKey.substring(0, 8) + "...)" : "NOT SET"}`,
-      );
-      if (hyperDxKey) {
-        logger.setApiKey(hyperDxKey);
-        console.log("[HyperDX] Logger configured with API key");
-      }
+      // HyperDX API key is read from process.env.HYPERDX_API_KEY in logger constructor
     } catch (error) {
       // Config is already saved, just log the error
       await logger.error("Failed to get Slack info", {

--- a/slack-mcp/server/router.ts
+++ b/slack-mcp/server/router.ts
@@ -181,11 +181,6 @@ app.post("/slack/events/:connectionId", async (c) => {
     );
   }
 
-  // 4. Configure HyperDX logger if API key is in cached config (survives server restarts)
-  if (connectionConfig.hyperDxApiKey) {
-    logger.setApiKey(connectionConfig.hyperDxApiKey);
-  }
-
   // Verify the request with connection's signing secret
   const { verified, payload } = await logger.measure(
     () =>

--- a/slack-mcp/server/types/env.ts
+++ b/slack-mcp/server/types/env.ts
@@ -146,14 +146,6 @@ export const StateSchema = z.object({
     .describe(
       "Friendly name for this connection (e.g., 'Cliente Acme - Produção'). Used in logs for easy identification.",
     ),
-
-  // HyperDX Configuration
-  HYPERDX_API_KEY: z
-    .string()
-    .optional()
-    .describe(
-      "HyperDX API key for advanced logging and observability. If not provided, logs will only go to stdout.",
-    ),
 });
 
 export type Env = DefaultEnv<typeof StateSchema, Registry>;


### PR DESCRIPTION
## Summary
- Fix `Authorization` header in HyperDX logger — was sending raw API key instead of `Bearer <key>`, causing 401 on every log send
- Remove `HYPERDX_API_KEY` from Mesh StateSchema and ConnectionConfig — the logger now reads it solely from `process.env.HYPERDX_API_KEY` (K8s env var)
- Clean up redundant `setApiKey` calls in `main.ts` and `router.ts`

## Test plan
- [ ] Deploy to K8s and verify HyperDX receives logs from `slack-mcp` service
- [ ] Confirm `HYPERDX_API_KEY` no longer appears in Mesh UI connection settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HyperDX auth and simplifies API key handling. Adds the missing Bearer prefix and reads `HYPERDX_API_KEY` only from `process.env` to stop 401s and remove the key from Mesh UI.

- **Bug Fixes**
  - Use `Authorization: Bearer <key>` when sending logs to HyperDX.

- **Refactors**
  - Remove `HYPERDX_API_KEY` from `StateSchema` and `ConnectionConfig`; logger now reads from `process.env.HYPERDX_API_KEY`.
  - Delete redundant `setApiKey` calls in `main.ts` and `router.ts`.

<sup>Written for commit 3d5caeb5160e0fdc537e03fa424310d8909b8a70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

