### PR TITLE
Fix @decocms/runtime version in package.json

### DIFF
--- a/slack-mcp/package.json
+++ b/slack-mcp/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@decocms/bindings": "^1.0.8",
-    "@decocms/runtime": "^1.2.6",
+    "@decocms/runtime": "1.2.6",
     "@slack/web-api": "^7.8.0",
     "@supabase/supabase-js": "^2.47.10",
     "hono": "^4.7.4",


### PR DESCRIPTION
Updated the version of @decocms/runtime to 1.2.6.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned `@decocms/runtime` to version 1.2.6 to ensure reproducible builds. Removes the caret to prevent unintended minor/patch upgrades.

<sup>Written for commit 25df3f65a6ed1f8ee94878d2c9bf9eb02edecea3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

