### PR TITLE
fix(slack): direct HTTP fallback for missing org context

### DIFF
--- a/slack-mcp/server/llm.ts
+++ b/slack-mcp/server/llm.ts
@@ -100,6 +100,112 @@ async function getFallbackAgent(
 }
 
 /**
+ * Direct HTTP fallback when createDecopilotClient fails due to missing
+ * organization context in the runtime. Calls the Mesh Decopilot API
+ * directly and converts the SSE response into the AgentClient async iterable.
+ */
+async function getDirectHttpAgent(
+  connectionId: string,
+): Promise<AgentClient | null> {
+  const config = await getCachedConnectionConfig(connectionId);
+  const token = config?.meshApiKey || config?.meshToken;
+  if (
+    !token ||
+    !config?.organizationId ||
+    !config?.meshUrl ||
+    !config?.agentId
+  ) {
+    return null;
+  }
+
+  const { meshUrl, organizationId, agentId } = config;
+
+  return {
+    STREAM: async (params) => {
+      const url = `${meshUrl}/api/${organizationId}/decopilot/stream`;
+      console.log(`[LLM] Direct HTTP call to ${url}`);
+
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          messages: params.messages,
+          agent: { id: agentId },
+          stream: true,
+          toolApprovalLevel: params.toolApprovalLevel ?? "auto",
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(
+          `Direct HTTP decopilot call failed (${response.status}): ${errorText}`,
+        );
+      }
+
+      return sseResponseToAsyncIterable(response);
+    },
+  };
+}
+
+/**
+ * Convert an SSE Response into an async iterable of message objects
+ * compatible with the AgentClient STREAM interface.
+ */
+async function* sseResponseToAsyncIterable(
+  response: Response,
+): AsyncGenerator<{ parts: Array<{ type: string; text?: string }> }> {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let textContent = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || !trimmed.startsWith("data:")) continue;
+        const data = trimmed.slice("data:".length).trim();
+        if (!data || data === "[DONE]") continue;
+
+        try {
+          const event = JSON.parse(data);
+          if (event.type === "text-delta" && event.delta) {
+            textContent += event.delta;
+          } else if (event.type === "text" && event.text) {
+            textContent += event.text;
+          } else if (
+            event.type === "tool-call" ||
+            event.type === "tool-input-start"
+          ) {
+            textContent = "";
+          } else if (event.type === "finish") {
+            break;
+          }
+        } catch {
+          // ignore parse errors
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  yield { parts: [{ type: "text", text: textContent }] };
+}
+
+/**
  * Check if the agent binding is available and configured.
  */
 export function isAgentAvailable(connectionId: string): boolean {
@@ -167,7 +273,25 @@ export async function streamAgentResponse(
   console.log(`[LLM] Using fallback client for ${connectionId}`);
   const fallback = await getFallbackAgent(connectionId);
   if (fallback) {
-    return fallback.STREAM(streamParams);
+    try {
+      return await fallback.STREAM(streamParams);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.log(
+        `[LLM] Fallback client failed for ${connectionId}: ${msg}, trying direct HTTP`,
+      );
+
+      // Workaround: runtime's createDecopilotClient may fail with
+      // "Organization context is required" — bypass it with a direct HTTP call
+      if (msg.includes("Organization context is required")) {
+        const directAgent = await getDirectHttpAgent(connectionId);
+        if (directAgent) {
+          return await directAgent.STREAM(streamParams);
+        }
+      }
+
+      throw err;
+    }
   }
 
   throw new Error(


### PR DESCRIPTION
## Summary

When the runtime's `createDecopilotClient` fails with "Organization context is required" (the runtime's `streamAgent` depends on a global org context that doesn't exist during webhook handling), this adds a direct HTTP fallback that calls the Mesh Decopilot API (`POST /api/{orgId}/decopilot/stream`) directly via `fetch`, bypassing the runtime entirely. The fallback only activates when the specific org context error is caught, preserving the existing flow for all other cases.

## Test plan
- [ ] Deploy to the slack-mcp pod and verify the bot responds instead of showing "Sorry, an error occurred..."
- [ ] Check logs for `[LLM] Direct HTTP call to` confirming the new codepath is hit
- [ ] Verify streaming responses still work correctly end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a direct HTTP fallback to Mesh Decopilot when the runtime lacks org context, preventing Slack webhook requests from failing. Streaming still works by converting SSE into the `AgentClient` stream format.

- **Bug Fixes**
  - On "Organization context is required", bypass the runtime and call `POST /api/{orgId}/decopilot/stream` via `fetch`.
  - Added an SSE-to-async-iterable adapter that feeds text parts to `STREAM`; logs `[LLM] Direct HTTP call to ...` for tracing.
  - Fallback only runs for that specific error and when token/org/agent are present; otherwise the original path is unchanged.

<sup>Written for commit f18b1741ebfa9997de05f8b5ba79ffeacd6a4435. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

