### PR TITLE
fix(slack): use org slug for decopilot API path

### DIFF
--- a/slack-mcp/server/llm.ts
+++ b/slack-mcp/server/llm.ts
@@ -109,20 +109,16 @@ async function getDirectHttpAgent(
 ): Promise<AgentClient | null> {
   const config = await getCachedConnectionConfig(connectionId);
   const token = config?.meshApiKey || config?.meshToken;
-  if (
-    !token ||
-    !config?.organizationId ||
-    !config?.meshUrl ||
-    !config?.agentId
-  ) {
+  const orgPath = config?.organizationSlug || config?.organizationId;
+  if (!token || !orgPath || !config?.meshUrl || !config?.agentId) {
     return null;
   }
 
-  const { meshUrl, organizationId, agentId } = config;
+  const { meshUrl, agentId } = config;
 
   return {
     STREAM: async (params) => {
-      const url = `${meshUrl}/api/${organizationId}/decopilot/stream`;
+      const url = `${meshUrl}/api/${orgPath}/decopilot/stream`;
       console.log(`[LLM] Direct HTTP call to ${url}`);
 
       const response = await fetch(url, {


### PR DESCRIPTION
## Summary

The direct HTTP fallback for the decopilot API was using `organizationId` in the URL path, but the Mesh API expects the `organizationSlug`. Validated via curl: slug returns 200 with SSE stream, ID returns 500 "Organization mismatch".

## Test plan
- [x] Validated with curl against production Mesh API
- [ ] Deploy and verify bot responds in Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix direct HTTP fallback in `slack-mcp` to use `organizationSlug` in the Mesh API path for Decopilot streaming. Prevents 500 "Organization mismatch" errors and restores streaming responses in Slack.

<sup>Written for commit 4f15174cf40e42b51490440713a08e2588723ded. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

