### PR TITLE
fix(slack): fix Accept header for API key generation

### DIFF
--- a/slack-mcp/server/main.ts
+++ b/slack-mcp/server/main.ts
@@ -60,7 +60,7 @@ async function generateMeshApiKey(
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${sessionToken}`,
-      Accept: "application/json",
+      Accept: "application/json, text/event-stream",
     },
     body: JSON.stringify({
       jsonrpc: "2.0",


### PR DESCRIPTION
## Summary

The Mesh `/mcp/self` endpoint requires `Accept: application/json, text/event-stream`. The old header (`application/json` only) caused a silent 406 rejection, so `generateMeshApiKey` always returned null. Without a persistent API key, the fallback agent had no valid token after the 5-minute session token expired, causing all LLM calls to fail with "Organization context is required".

## Test plan
- [x] Validated via curl: old header → 406, new header → 200 with API key
- [ ] Deploy, trigger onChange, verify `mesh_api_key` is populated in Supabase
- [ ] Verify bot responds after session token expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Accept header for Mesh `/mcp/self` API key generation by sending `Accept: application/json, text/event-stream`. This resolves 406 responses, persists the API key, and keeps the Slack bot working after the 5-minute session token expires.

<sup>Written for commit ee7b14b6a81c98e8ed94d48467e13123c753c52d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

