### PR TITLE
fix(github): fix double-encoded tool results and bump runtime to 1.4.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -225,7 +225,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@decocms/bindings": "^1.4.0",
-        "@decocms/runtime": "^1.3.0",
+        "@decocms/runtime": "1.4.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "zod": "^4.0.0",
       },
@@ -774,7 +774,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@decocms/bindings": "^1.0.8",
-        "@decocms/runtime": "^1.2.6",
+        "@decocms/runtime": "1.3.0",
         "@slack/web-api": "^7.8.0",
         "@supabase/supabase-js": "^2.47.10",
         "hono": "^4.7.4",
@@ -3968,7 +3968,7 @@
 
     "github/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
-    "github/@decocms/runtime": ["@decocms/runtime@1.3.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-xRFTV9gqrdsUCAkJ3xoBOeDGXps6moZeZB/NNL+XZ7LNa4qzfmL3BGWG42n8xbFyEpprfEfOtOD+tVgWhkPDxQ=="],
+    "github/@decocms/runtime": ["@decocms/runtime@1.4.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-tWRsfJ8YxGPyVkrTWwQ9BNakThE7WCd1eWnPBAxzAeJn1ldMDzIrJMyi9bOkGqUB2mvswrDoVXNqFLPxbNEIPg=="],
 
     "github/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 

--- a/github-repo-reports/tsconfig.json
+++ b/github-repo-reports/tsconfig.json
@@ -20,13 +20,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
-
-    /* Path Aliases */
-    "baseUrl": ".",
-    "paths": {
-      "server/*": ["./server/*"]
-    }
+    "noUncheckedSideEffectImports": true
   },
   "include": ["server"]
 }

--- a/github/package.json
+++ b/github/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@decocms/bindings": "^1.4.0",
-    "@decocms/runtime": "^1.3.0",
+    "@decocms/runtime": "1.4.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "zod": "^4.0.0"
   },

--- a/github/server/lib/mcp-proxy.ts
+++ b/github/server/lib/mcp-proxy.ts
@@ -207,6 +207,24 @@ export function createUpstreamToolsProvider(): (
               arguments: context as Record<string, unknown>,
             });
 
+            // The MCP SDK callTool returns { content: [{ type, text }] }.
+            // The deco runtime wraps execute's return in JSON.stringify,
+            // so we need to extract and parse the text to avoid double encoding.
+            const contents = result.content as
+              | Array<{ type: string; text?: string }>
+              | undefined;
+            const textContent = contents?.find(
+              (c): c is { type: "text"; text: string } =>
+                c.type === "text" && typeof c.text === "string",
+            );
+            if (textContent?.text) {
+              try {
+                return JSON.parse(textContent.text);
+              } catch {
+                return textContent.text;
+              }
+            }
+
             return result;
           },
         }),

--- a/github/tsconfig.json
+++ b/github/tsconfig.json
@@ -21,13 +21,6 @@
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    /* Path Aliases */
-    "baseUrl": ".",
-    "paths": {
-      "server/*": [
-        "./server/*"
-      ]
-    },
     /* Types */
     "types": [
       "@types/node"


### PR DESCRIPTION
## Summary
- Bumps `@decocms/runtime` to `1.4.0` (pinned) in the GitHub MCP
- Fixes double-encoded tool results: the MCP SDK's `callTool` returns `{ content: [{ type: "text", text: "..." }] }`, and the deco runtime wraps `execute`'s return with `JSON.stringify`, causing the response to be double-encoded. Now extracts and parses the text content before returning.

## Test plan
- [ ] Call a GitHub MCP tool (e.g. search repos) and verify the response contains parsed JSON, not a double-encoded string

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix double-encoded MCP tool responses in the GitHub MCP and pin `@decocms/runtime` to 1.4.0 for compatibility. Also removes deprecated tsconfig path options to resolve TS5101 errors.

- **Bug Fixes**
  - Parse `callTool` text content to return JSON objects (or raw text) and avoid double encoding with the deco runtime.
  - Remove `baseUrl`/`paths` from `github` and `github-repo-reports` tsconfigs; the `server/*` alias was unused and triggered TS5101 on newer TypeScript.

- **Dependencies**
  - Pin `@decocms/runtime` to `1.4.0`.

<sup>Written for commit db0685b4f83af663ff1272f763b44d2bf9c547f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

