### PR TITLE
fix(github): migrate to createTool() API, remove per-user caching

### DIFF
--- a/github/server/.env.example
+++ b/github/server/.env.example
@@ -1,4 +1,6 @@
-# GitHub OAuth credentials (required)
+# GitHub App credentials (required)
+GITHUB_APP_ID=
+GITHUB_PRIVATE_KEY=
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 

--- a/github/server/lib/github-app-auth.ts
+++ b/github/server/lib/github-app-auth.ts
@@ -1,0 +1,110 @@
+/**
+ * GitHub App Authentication
+ *
+ * Generates a JWT from GITHUB_APP_ID + GITHUB_PRIVATE_KEY,
+ * then exchanges it for an installation access token.
+ * Used at startup to discover upstream MCP tools.
+ */
+
+import crypto from "node:crypto";
+
+const GITHUB_APP_ID = process.env.GITHUB_APP_ID || "";
+const GITHUB_PRIVATE_KEY = process.env.GITHUB_PRIVATE_KEY || "";
+
+function base64url(data: Buffer | string): string {
+  const buf = typeof data === "string" ? Buffer.from(data) : data;
+  return buf.toString("base64url");
+}
+
+/**
+ * Create a JWT signed with the GitHub App's private key (RS256).
+ * Valid for 10 minutes (GitHub's maximum).
+ */
+function createAppJWT(): string {
+  if (!GITHUB_APP_ID || !GITHUB_PRIVATE_KEY) {
+    throw new Error(
+      "GitHub App credentials not configured. " +
+        "Set GITHUB_APP_ID and GITHUB_PRIVATE_KEY environment variables.",
+    );
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const payload = base64url(
+    JSON.stringify({
+      iat: now - 60, // 60s clock skew allowance
+      exp: now + 600, // 10 minutes
+      iss: GITHUB_APP_ID,
+    }),
+  );
+
+  const signingInput = `${header}.${payload}`;
+  const signature = crypto
+    .createSign("RSA-SHA256")
+    .update(signingInput)
+    .sign(GITHUB_PRIVATE_KEY, "base64url");
+
+  return `${signingInput}.${signature}`;
+}
+
+/**
+ * Get an installation access token for the GitHub App.
+ * Picks the first available installation.
+ */
+export async function getAppInstallationToken(): Promise<string> {
+  const jwt = createAppJWT();
+
+  // List installations
+  const installationsRes = await fetch(
+    "https://api.github.com/app/installations?per_page=1",
+    {
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+
+  if (!installationsRes.ok) {
+    const text = await installationsRes.text();
+    throw new Error(
+      `Failed to list GitHub App installations: ${installationsRes.status} — ${text}`,
+    );
+  }
+
+  const installations = (await installationsRes.json()) as Array<{
+    id: number;
+  }>;
+
+  if (installations.length === 0) {
+    throw new Error(
+      "GitHub App has no installations. Install the app on at least one account.",
+    );
+  }
+
+  const installationId = installations[0].id;
+
+  // Create installation access token
+  const tokenRes = await fetch(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+
+  if (!tokenRes.ok) {
+    const text = await tokenRes.text();
+    throw new Error(
+      `Failed to create installation token: ${tokenRes.status} — ${text}`,
+    );
+  }
+
+  const data = (await tokenRes.json()) as { token: string };
+  return data.token;
+}

--- a/github/server/lib/mcp-proxy.ts
+++ b/github/server/lib/mcp-proxy.ts
@@ -3,86 +3,44 @@
  *
  * Uses the official MCP TypeScript SDK Client to connect to an upstream
  * MCP server and proxy tools and resources through our OAuth flow.
+ *
+ * Tool definitions are fetched once at startup using a GitHub App installation
+ * token. Tool execution uses the per-request user token from ctx.
  */
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type { CreatedTool } from "@decocms/runtime/tools";
+import { createTool, type AppContext } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../types/env.ts";
-
-/** Cached client per upstream URL + token combo */
-let cachedClient: Client | null = null;
-let cachedClientKey = "";
-let cachedClientConnected = false;
+import { getAppInstallationToken } from "./github-app-auth.ts";
 
 const DEFAULT_UPSTREAM_URL = "https://api.githubcopilot.com/mcp/";
 
 /**
- * Get or create an MCP client connected to the upstream server.
- * Caches the client to avoid reconnecting on every request.
+ * Create a fresh MCP client connected to the upstream server.
  */
-async function getUpstreamClient(
-  upstreamUrl: string,
-  token: string,
-): Promise<Client> {
-  const key = `${upstreamUrl}::${token}`;
-
-  if (cachedClient && cachedClientKey === key && cachedClientConnected) {
-    return cachedClient;
-  }
-
-  // Close previous client if exists
-  if (cachedClient) {
-    try {
-      await cachedClient.close();
-    } catch {
-      // Ignore close errors
-    }
-  }
-
-  console.log(`[MCP Proxy] Connecting to upstream: ${upstreamUrl}`);
-
+function connectUpstreamClient(token: string): Promise<Client> {
   const client = new Client({ name: "github-mcp-proxy", version: "1.0.0" });
 
-  const transport = new StreamableHTTPClientTransport(new URL(upstreamUrl), {
-    requestInit: {
-      headers: {
-        Authorization: `Bearer ${token}`,
+  const transport = new StreamableHTTPClientTransport(
+    new URL(DEFAULT_UPSTREAM_URL),
+    {
+      requestInit: {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
       },
     },
-  });
+  );
 
-  await client.connect(transport);
-
-  cachedClient = client;
-  cachedClientKey = key;
-  cachedClientConnected = true;
-
-  console.log("[MCP Proxy] Connected to upstream server");
-
-  return client;
+  return client.connect(transport).then(() => client);
 }
 
-/** Cached upstream tool definitions, keyed by token */
-type ToolsDef = Awaited<ReturnType<Client["listTools"]>>["tools"];
-const toolsCache = new Map<string, { tools: ToolsDef; timestamp: number }>();
-const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-const MAX_CACHE_ENTRIES = 50;
+// ============================================================================
+// JSON Schema → Zod conversion
+// ============================================================================
 
-/** Evict expired entries from the tools cache */
-function evictExpiredToolsCache(): void {
-  const now = Date.now();
-  for (const [key, entry] of toolsCache) {
-    if (now - entry.timestamp > CACHE_TTL_MS) {
-      toolsCache.delete(key);
-    }
-  }
-}
-
-/**
- * Convert a JSON Schema property to a Zod schema.
- */
 function jsonSchemaPropertyToZod(
   prop: { type?: string; description?: string; [key: string]: unknown },
   required: boolean,
@@ -121,9 +79,6 @@ function jsonSchemaPropertyToZod(
   return schema;
 }
 
-/**
- * Convert a JSON Schema object to a Zod z.object() schema.
- */
 function jsonSchemaToZod(inputSchema?: {
   properties?: Record<string, any>;
   required?: string[];
@@ -143,112 +98,98 @@ function jsonSchemaToZod(inputSchema?: {
   return z.object(shape);
 }
 
-/**
- * Create a tool provider that fetches upstream tools via the SDK Client
- * and wraps them as CreatedTool[] for the Deco runtime.
- */
-export function createUpstreamToolsProvider(): (
-  env: Env,
-) => Promise<CreatedTool[]> {
-  return async (env: Env): Promise<CreatedTool[]> => {
-    const token = env.MESH_REQUEST_CONTEXT?.authorization;
-    const upstreamUrl = DEFAULT_UPSTREAM_URL;
+// ============================================================================
+// Startup tool discovery
+// ============================================================================
 
-    if (!token) {
-      console.log(
-        "[MCP Proxy] No auth token available, skipping upstream tools",
-      );
-      return [];
-    }
-
-    try {
-      const client = await getUpstreamClient(upstreamUrl, token);
-
-      // Check cache (keyed by token to avoid leaking between users)
-      const now = Date.now();
-      const cached = toolsCache.get(token);
-      let tools: ToolsDef;
-      if (cached && now - cached.timestamp < CACHE_TTL_MS) {
-        tools = cached.tools;
-      } else {
-        // Evict expired entries; if still at cap, drop oldest
-        evictExpiredToolsCache();
-        if (toolsCache.size >= MAX_CACHE_ENTRIES) {
-          const oldest = [...toolsCache.entries()].sort(
-            (a, b) => a[1].timestamp - b[1].timestamp,
-          )[0];
-          if (oldest) toolsCache.delete(oldest[0]);
-        }
-        const result = await client.listTools();
-        tools = result.tools;
-        toolsCache.set(token, { tools, timestamp: now });
-        console.log(`[MCP Proxy] Found ${tools.length} upstream tools`);
-      }
-
-      return tools.map(
-        (toolDef): CreatedTool => ({
-          id: toolDef.name,
-          description: toolDef.description || `GitHub tool: ${toolDef.name}`,
-          inputSchema: jsonSchemaToZod(toolDef.inputSchema as any),
-          execute: async ({ context }) => {
-            const currentToken = env.MESH_REQUEST_CONTEXT?.authorization;
-            if (!currentToken) {
-              throw new Error("GitHub authorization token not found");
-            }
-
-            const currentUrl = DEFAULT_UPSTREAM_URL;
-
-            const upstreamClient = await getUpstreamClient(
-              currentUrl,
-              currentToken,
-            );
-            const result = await upstreamClient.callTool({
-              name: toolDef.name,
-              arguments: context as Record<string, unknown>,
-            });
-
-            // The MCP SDK callTool returns { content: [{ type, text }] }.
-            // The deco runtime wraps execute's return in JSON.stringify,
-            // so we need to extract and parse the text to avoid double encoding.
-            const contents = result.content as
-              | Array<{ type: string; text?: string }>
-              | undefined;
-            const textContent = contents?.find(
-              (c): c is { type: "text"; text: string } =>
-                c.type === "text" && typeof c.text === "string",
-            );
-            if (textContent?.text) {
-              try {
-                return JSON.parse(textContent.text);
-              } catch {
-                return textContent.text;
-              }
-            }
-
-            return result;
-          },
-        }),
-      );
-    } catch (error) {
-      console.error("[MCP Proxy] Failed to fetch upstream tools:", error);
-      return [];
-    }
-  };
-}
+type ToolsDef = Awaited<ReturnType<Client["listTools"]>>["tools"];
 
 /**
- * Invalidate the upstream tools cache and disconnect client.
+ * Discover upstream tool definitions at startup using a GitHub App
+ * installation token. Throws on failure — the server should not boot
+ * if tool discovery fails.
  */
-export function invalidateUpstreamCache(): void {
-  toolsCache.clear();
-
-  if (cachedClient) {
-    cachedClient.close().catch(() => {});
-    cachedClient = null;
-    cachedClientKey = "";
-    cachedClientConnected = false;
+async function discoverUpstreamToolDefs(): Promise<ToolsDef> {
+  console.log("[MCP Proxy] Discovering upstream tools at startup...");
+  const token = await getAppInstallationToken();
+  const client = await connectUpstreamClient(token);
+  try {
+    const result = await client.listTools();
+    console.log(`[MCP Proxy] Discovered ${result.tools.length} upstream tools`);
+    return result.tools;
+  } finally {
+    client.close().catch(() => {});
   }
 }
+
+/**
+ * Top-level promise that resolves to the upstream tool definitions.
+ * Awaited in tools/index.ts before the server starts accepting requests.
+ * If this fails, the server process crashes — by design.
+ */
+export const upstreamToolDefsReady: Promise<ToolsDef> =
+  discoverUpstreamToolDefs();
+
+// ============================================================================
+// Upstream tool creation
+// ============================================================================
+
+/**
+ * Build createTool() instances from pre-discovered tool definitions.
+ * Execution uses the per-request user token from ctx.
+ */
+export function buildUpstreamTools(
+  toolDefs: ToolsDef,
+): ReturnType<typeof createTool>[] {
+  return toolDefs.map((toolDef) =>
+    createTool({
+      id: toolDef.name,
+      description: toolDef.description || `GitHub tool: ${toolDef.name}`,
+      inputSchema: jsonSchemaToZod(toolDef.inputSchema as any),
+      execute: async ({ context }, ctx) => {
+        const currentToken = (ctx as AppContext<Env>).env.MESH_REQUEST_CONTEXT
+          ?.authorization;
+        if (!currentToken) {
+          throw new Error("GitHub authorization token not found");
+        }
+
+        const client = await connectUpstreamClient(currentToken);
+        try {
+          const result = await client.callTool({
+            name: toolDef.name,
+            arguments: context as Record<string, unknown>,
+          });
+
+          // The MCP SDK callTool returns { content: [{ type, text }] }.
+          // The deco runtime wraps execute's return in JSON.stringify,
+          // so we need to extract and parse the text to avoid double encoding.
+          const contents = result.content as
+            | Array<{ type: string; text?: string }>
+            | undefined;
+          const textContent = contents?.find(
+            (c): c is { type: "text"; text: string } =>
+              c.type === "text" && typeof c.text === "string",
+          );
+          if (textContent?.text) {
+            try {
+              return JSON.parse(textContent.text);
+            } catch {
+              return textContent.text;
+            }
+          }
+
+          return result;
+        } finally {
+          client.close().catch(() => {});
+        }
+      },
+    }),
+  );
+}
+
+// ============================================================================
+// Resource proxying (pass-through to upstream)
+// ============================================================================
 
 /** Methods that should be forwarded to the upstream server */
 const PROXY_METHODS = new Set([
@@ -287,8 +228,8 @@ export async function handleProxiedRequest(
 
   console.log(`[MCP Proxy] Forwarding ${body.method} to upstream`);
 
+  const client = await connectUpstreamClient(token);
   try {
-    const client = await getUpstreamClient(upstreamUrl, token);
     let result: unknown;
 
     switch (body.method) {
@@ -328,5 +269,7 @@ export async function handleProxiedRequest(
       },
       { headers: { "Content-Type": "application/json" } },
     );
+  } finally {
+    client.close().catch(() => {});
   }
 }

--- a/github/server/main.ts
+++ b/github/server/main.ts
@@ -10,10 +10,7 @@ import { serve } from "@decocms/mcps-shared/serve";
 import { withRuntime } from "@decocms/runtime";
 import { exchangeCodeForToken } from "./lib/github-client.ts";
 import { captureInstallationMappings } from "./lib/installation-map.ts";
-import {
-  handleProxiedRequest,
-  invalidateUpstreamCache,
-} from "./lib/mcp-proxy.ts";
+import { handleProxiedRequest } from "./lib/mcp-proxy.ts";
 import { tools } from "./tools/index.ts";
 import { type Env, StateSchema } from "./types/env.ts";
 import { handleGitHubWebhook } from "./webhook.ts";
@@ -70,8 +67,6 @@ const runtime = withRuntime<Env, typeof StateSchema, Registry>({
 
   configuration: {
     onChange: async (env) => {
-      invalidateUpstreamCache();
-
       const token = env.MESH_REQUEST_CONTEXT?.authorization;
       const connectionId = env.MESH_REQUEST_CONTEXT?.connectionId;
       if (token && connectionId) {
@@ -126,6 +121,8 @@ console.log(`
 🚀 Server listening on http://localhost:${port}/mcp
 
 📋 Environment Variables:
-   GITHUB_CLIENT_ID      - GitHub App Client ID
-   GITHUB_CLIENT_SECRET  - GitHub App Client Secret
+   GITHUB_APP_ID         - GitHub App ID
+   GITHUB_PRIVATE_KEY    - GitHub App private key (PEM)
+   GITHUB_CLIENT_ID      - GitHub App Client ID (OAuth)
+   GITHUB_CLIENT_SECRET  - GitHub App Client Secret (OAuth)
 `);

--- a/github/server/tools/index.ts
+++ b/github/server/tools/index.ts
@@ -1,11 +1,14 @@
 /**
  * GitHub MCP Tools
  *
- * All tools come from the upstream MCP server via the proxy,
- * plus trigger tools from the @decocms/runtime triggers SDK.
+ * Upstream tools are discovered at startup via GitHub App auth.
+ * Trigger tools come from the @decocms/runtime triggers SDK.
+ * Both are resolved before the server starts accepting requests.
  */
 
-import { createUpstreamToolsProvider } from "../lib/mcp-proxy.ts";
+import { upstreamToolDefsReady, buildUpstreamTools } from "../lib/mcp-proxy.ts";
 import { triggers } from "../lib/trigger-store.ts";
 
-export const tools = [createUpstreamToolsProvider(), () => triggers.tools()];
+const toolDefs = await upstreamToolDefsReady;
+
+export const tools = [...buildUpstreamTools(toolDefs), ...triggers.tools()];

--- a/slack-mcp/server/health.ts
+++ b/slack-mcp/server/health.ts
@@ -130,7 +130,10 @@ export async function getHealthStatus(): Promise<HealthStatus> {
 
   return {
     status: cachedDeepResult.status,
-    summary: buildSummary(cachedDeepResult.status, cachedDeepResult.connections),
+    summary: buildSummary(
+      cachedDeepResult.status,
+      cachedDeepResult.connections,
+    ),
     timestamp: now.toISOString(),
     deepCheckAt: cachedDeepResult.timestamp,
     uptime: process.uptime(),
@@ -464,7 +467,9 @@ async function runDeepCheck(): Promise<ConnectionHealth[]> {
 
     results.push({
       connectionId: config.connectionId.slice(0, 8) + "…",
-      teamName: config.teamName ? config.teamName.slice(0, 1) + "***" : undefined,
+      teamName: config.teamName
+        ? config.teamName.slice(0, 1) + "***"
+        : undefined,
       connectionName: config.connectionName,
       mode,
       overall,


### PR DESCRIPTION
## Summary

- Replaces deprecated factory functions and `createPrivateTool` with `createTool()` instances that read `env` from the per-request `ctx` (2nd arg), per `@decocms/runtime@1.4.0` API
- Discovers upstream GitHub MCP tool definitions at startup using a GitHub App installation token (`GITHUB_APP_ID` + `GITHUB_PRIVATE_KEY`), so the server fails fast if discovery fails
- Removes all per-user token caching (`cachedClient`, `toolsCache`) — tool execution creates fresh connections with the per-request user token from `ctx`
- `tools` is now a static `CreatedTool[]` array passed directly to `withRuntime`, eliminating the deprecated factory function warning

## Test plan

- [ ] Verify `GITHUB_APP_ID` and `GITHUB_PRIVATE_KEY` env vars are set in deployment
- [ ] Confirm server crashes on startup if env vars are missing or GitHub App has no installations
- [ ] Confirm tool discovery logs the correct number of upstream tools at boot
- [ ] Verify per-user tool execution works (OAuth flow → tool call uses user's token, not app token)
- [ ] Verify webhook routing still works (installation map unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the GitHub MCP server to `createTool()` and removes per-user caching. Upstream tools are discovered at startup using a GitHub App installation token; each tool run uses the per-request user token.

- **Refactors**
  - Replace deprecated factories and `createPrivateTool` with `createTool()` reading env from per-request `ctx` per `@decocms/runtime@1.4.0`.
  - Discover upstream MCP tools at boot via a GitHub App token (`upstreamToolDefsReady`); server fails fast if discovery fails.
  - Export a static `tools` array (upstream + triggers); drop provider factories and cache invalidation; remove cached clients and tools cache; each call opens/closes a client.
  - Keep resource proxying behavior the same; ensure clients close cleanly.
  - Format-only changes in `slack-mcp` health.

- **Migration**
  - Set `GITHUB_APP_ID` and `GITHUB_PRIVATE_KEY` in the environment; `.env.example` and startup logs updated.
  - Ensure the GitHub App has at least one installation.
  - OAuth remains required; tool runs use the user token from `MESH_REQUEST_CONTEXT`.

<sup>Written for commit f4194b109c445081ac3dec77f7a4a3e453fd69bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

