### PR TITLE
fix: resolve all oxlint warnings across the monorepo

### DIFF
--- a/content-scraper/server/lib/db-client.ts
+++ b/content-scraper/server/lib/db-client.ts
@@ -47,8 +47,10 @@ export function escapeSqlValue(value: SqlValue): string {
   // String escaping
   const escaped = value
     // Remove null bytes (can cause truncation attacks)
+    // oxlint-disable-next-line no-control-regex
     .replace(/\0/g, "")
     // Remove other control characters (except newlines and tabs)
+    // oxlint-disable-next-line no-control-regex
     .replace(/[\x01-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "")
     // Escape backslashes first
     .replace(/\\/g, "\\\\")

--- a/content-scraper/tsconfig.json
+++ b/content-scraper/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "5.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023"],

--- a/discord-read/server/lib/config-cache.ts
+++ b/discord-read/server/lib/config-cache.ts
@@ -9,7 +9,6 @@ import {
   loadConnectionConfig,
   saveConnectionConfig,
   deleteConnectionConfig,
-  type DiscordConnectionRow,
 } from "./supabase-client.ts";
 
 /**

--- a/discord-read/server/lib/logger.ts
+++ b/discord-read/server/lib/logger.ts
@@ -184,62 +184,57 @@ export class HyperDXLogger {
    */
   private async sendToHyperDX(logEntry: Record<string, unknown>) {
     console.log(`[HyperDX] 📤 Sending log to ${this.hyperDxEndpoint}...`);
-    try {
-      const response = await fetch(this.hyperDxEndpoint, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: this.apiKey!,
-        },
-        body: JSON.stringify({
-          resourceLogs: [
-            {
-              resource: {
-                attributes: [
-                  {
-                    key: "service.name",
-                    value: { stringValue: this.service },
-                  },
-                ],
-              },
-              scopeLogs: [
+    const response = await fetch(this.hyperDxEndpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: this.apiKey!,
+      },
+      body: JSON.stringify({
+        resourceLogs: [
+          {
+            resource: {
+              attributes: [
                 {
-                  scope: { name: this.service },
-                  logRecords: [
-                    {
-                      timeUnixNano: `${Date.now() * 1000000}`,
-                      severityText: String(
-                        logEntry.level || "info",
-                      ).toUpperCase(),
-                      body: { stringValue: String(logEntry.body) },
-                      attributes: Object.entries(logEntry)
-                        .filter(([key]) => key !== "body" && key !== "level")
-                        .map(([key, value]) => ({
-                          key,
-                          value: { stringValue: String(value) },
-                        })),
-                    },
-                  ],
+                  key: "service.name",
+                  value: { stringValue: this.service },
                 },
               ],
             },
-          ],
-        }),
-      });
+            scopeLogs: [
+              {
+                scope: { name: this.service },
+                logRecords: [
+                  {
+                    timeUnixNano: `${Date.now() * 1000000}`,
+                    severityText: String(
+                      logEntry.level || "info",
+                    ).toUpperCase(),
+                    body: { stringValue: String(logEntry.body) },
+                    attributes: Object.entries(logEntry)
+                      .filter(([key]) => key !== "body" && key !== "level")
+                      .map(([key, value]) => ({
+                        key,
+                        value: { stringValue: String(value) },
+                      })),
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    });
 
-      const body = await response.text();
-      if (!response.ok) {
-        throw new Error(
-          `HyperDX API returned ${response.status}: ${response.statusText} - ${body}`,
-        );
-      }
-      console.log(
-        `[HyperDX] ✅ Log sent successfully (${response.status}) - Response: ${body || "(empty)"}`,
+    const body = await response.text();
+    if (!response.ok) {
+      throw new Error(
+        `HyperDX API returned ${response.status}: ${response.statusText} - ${body}`,
       );
-    } catch (error) {
-      // Re-throw to be caught by caller
-      throw error;
     }
+    console.log(
+      `[HyperDX] ✅ Log sent successfully (${response.status}) - Response: ${body || "(empty)"}`,
+    );
   }
 }
 

--- a/discord-read/server/main.ts
+++ b/discord-read/server/main.ts
@@ -148,7 +148,7 @@ const runtime = withRuntime<Env, typeof StateSchema, Registry>({
         }
 
         const configToSave: DiscordConfig = {
-          ...(existingConfig || {}),
+          ...existingConfig,
           connectionId: mergedConnectionId,
           organizationId: mergedOrgId,
           meshUrl: mergedMeshUrl,

--- a/discord-read/server/tools/config.ts
+++ b/discord-read/server/tools/config.ts
@@ -20,7 +20,7 @@ import { isSupabaseConfigured } from "../lib/supabase-client.ts";
 /**
  * Save Discord bot configuration
  */
-export const createSaveConfigTool = (env: Env) =>
+export const createSaveConfigTool = (_env: Env) =>
   createPrivateTool({
     id: "DISCORD_SAVE_CONFIG",
     description:
@@ -159,7 +159,7 @@ export const createSaveConfigTool = (env: Env) =>
 /**
  * Update Discord bot configuration (partial update)
  */
-export const createUpdateConfigTool = (env: Env) =>
+export const createUpdateConfigTool = (_env: Env) =>
   createPrivateTool({
     id: "DISCORD_UPDATE_CONFIG",
     description:
@@ -281,7 +281,7 @@ export const createUpdateConfigTool = (env: Env) =>
 /**
  * Load Discord bot configuration
  */
-export const createLoadConfigTool = (env: Env) =>
+export const createLoadConfigTool = (_env: Env) =>
   createPrivateTool({
     id: "DISCORD_LOAD_CONFIG",
     description:
@@ -364,7 +364,7 @@ export const createLoadConfigTool = (env: Env) =>
 /**
  * Delete Discord bot configuration
  */
-export const createDeleteConfigTool = (env: Env) =>
+export const createDeleteConfigTool = (_env: Env) =>
   createPrivateTool({
     id: "DISCORD_DELETE_CONFIG",
     description:
@@ -408,7 +408,7 @@ export const createDeleteConfigTool = (env: Env) =>
 /**
  * Get cache statistics
  */
-export const createCacheStatsTool = (env: Env) =>
+export const createCacheStatsTool = (_env: Env) =>
   createPrivateTool({
     id: "DISCORD_CONFIG_CACHE_STATS",
     description: "Get Discord configuration cache statistics",
@@ -430,7 +430,7 @@ export const createCacheStatsTool = (env: Env) =>
 /**
  * Clear configuration cache
  */
-export const createClearCacheTool = (env: Env) =>
+export const createClearCacheTool = (_env: Env) =>
   createPrivateTool({
     id: "DISCORD_CONFIG_CLEAR_CACHE",
     description:

--- a/discord-read/server/tools/database.ts
+++ b/discord-read/server/tools/database.ts
@@ -15,7 +15,7 @@ import { invalidateAutoRespondCache } from "../discord/client.ts";
 /**
  * Query Discord messages (read-only, scoped to connection)
  */
-export const createQueryMessagesTool = (env: Env) =>
+export const createQueryMessagesTool = (_env: Env) =>
   createPrivateTool({
     id: "DISCORD_QUERY_MESSAGES",
     description:
@@ -159,7 +159,7 @@ export const createQueryMessagesTool = (env: Env) =>
 /**
  * Query Discord guilds (read-only)
  */
-export const createQueryGuildsTool = (env: Env) =>
+export const createQueryGuildsTool = (_env: Env) =>
   createPrivateTool({
     id: "DISCORD_QUERY_GUILDS",
     description: "Query Discord guilds (servers) from the database.",
@@ -228,7 +228,7 @@ export const createQueryGuildsTool = (env: Env) =>
 /**
  * Query message statistics
  */
-export const createMessageStatsTool = (env: Env) =>
+export const createMessageStatsTool = (_env: Env) =>
   createPrivateTool({
     id: "DISCORD_MESSAGE_STATS",
     description:
@@ -333,7 +333,7 @@ export const createMessageStatsTool = (env: Env) =>
 /**
  * Query channel contexts (custom prompts per channel)
  */
-export const createQueryChannelContextsTool = (env: Env) =>
+export const createQueryChannelContextsTool = (_env: Env) =>
   createPrivateTool({
     id: "DISCORD_QUERY_CHANNEL_CONTEXTS",
     description:

--- a/discord-read/server/tools/discord/messages.ts
+++ b/discord-read/server/tools/discord/messages.ts
@@ -593,7 +593,7 @@ export const createPurgeChannelMessagesTool = (env: Env) =>
               console.log(
                 `🧹 [Purge] Bulk deleted ${chunk.length} recent messages`,
               );
-            } catch (error) {
+            } catch {
               console.log(
                 `⚠️ [Purge] Bulk delete failed, falling back to individual delete`,
               );

--- a/discord-read/shared/db.ts
+++ b/discord-read/shared/db.ts
@@ -32,8 +32,8 @@ export function getDatabaseEnv(): Env | null {
  * For now, we'll use direct table operations instead
  */
 export async function runSQL<T = unknown>(
-  sql: string,
-  params: unknown[] = [],
+  _sql: string,
+  _params: unknown[] = [],
 ): Promise<T[]> {
   const client = getSupabaseClient();
   if (!client) {

--- a/hyperdx/server/tools/alerts.ts
+++ b/hyperdx/server/tools/alerts.ts
@@ -55,7 +55,7 @@ const AlertChannelSchema = z.discriminatedUnion("type", [
   }),
 ]);
 
-const AlertResponseSchema = z.object({
+const _AlertResponseSchema = z.object({
   id: z.string(),
   interval: AlertIntervalSchema,
   threshold: z.number(),

--- a/hyperdx/tsconfig.json
+++ b/hyperdx/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "5.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "ES2024", "DOM", "DOM.Iterable"],

--- a/multi-channel-inbox/api/tools/conversations.ts
+++ b/multi-channel-inbox/api/tools/conversations.ts
@@ -268,7 +268,7 @@ export const statsTool = (env: Env) =>
       total_conversations: z.number(),
     }),
     annotations: { readOnlyHint: true },
-    execute: async ({}) => {
+    execute: async () => {
       const byStatus = await runSQL<{
         status: string;
         count: number;

--- a/multi-channel-inbox/api/tools/sources.ts
+++ b/multi-channel-inbox/api/tools/sources.ts
@@ -108,7 +108,7 @@ export const listSourcesTool = (env: Env) =>
       ),
     }),
     annotations: { readOnlyHint: true },
-    execute: async ({}) => {
+    execute: async () => {
       const sources = await runSQL<{
         id: string;
         source_type: string;

--- a/multi-channel-inbox/tsconfig.json
+++ b/multi-channel-inbox/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"ignoreDeprecations": "5.0",
 		"target": "ESNext",
 		"module": "ESNext",
 		"moduleResolution": "bundler",

--- a/multi-channel-inbox/web/components/ui/combobox.tsx
+++ b/multi-channel-inbox/web/components/ui/combobox.tsx
@@ -273,7 +273,7 @@ function ComboboxChip({
 
 function ComboboxChipsInput({
   className,
-  children,
+  children: _children,
   ...props
 }: ComboboxPrimitive.Input.Props) {
   return (

--- a/registry/scripts/enrich-with-ai.ts
+++ b/registry/scripts/enrich-with-ai.ts
@@ -131,9 +131,6 @@ async function enrichMcpWithAI(
   const name = server.name;
   const description = server.description || server.short_description || "";
   const repoUrl = server.repository?.url || "";
-  const hasRemote = (server.remotes?.length ?? 0) > 0;
-  const isNpm = server.remotes?.some((r) => r.type === "npm") ?? false;
-  const isVerified = server.verified;
 
   // Serialize remotes for the prompt
   const remotesInfo =

--- a/registry/scripts/publish-verified.ts
+++ b/registry/scripts/publish-verified.ts
@@ -117,7 +117,7 @@ async function main() {
     // ── Apply icon overrides ──────────────────────────────────
     console.log("\n── ICON OVERRIDES ──");
     let iconCount = 0;
-    for (const server of [...(current || [])]) {
+    for (const server of current || []) {
       const override = VERIFIED_SERVER_OVERRIDES[server.name];
       if (!override?.icons) continue;
 

--- a/registry/tsconfig.json
+++ b/registry/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "5.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],

--- a/scripts/filter-deployable-mcps.ts
+++ b/scripts/filter-deployable-mcps.ts
@@ -26,7 +26,7 @@ if (!mcpsJson) {
 let mcps: string[];
 try {
   mcps = JSON.parse(mcpsJson);
-} catch (error) {
+} catch {
   console.error("❌ Error: Invalid JSON array provided");
   process.exit(1);
 }

--- a/slack-mcp/server/health.ts
+++ b/slack-mcp/server/health.ts
@@ -130,7 +130,10 @@ export async function getHealthStatus(): Promise<HealthStatus> {
 
   return {
     status: cachedDeepResult.status,
-    summary: buildSummary(cachedDeepResult.status, cachedDeepResult.connections),
+    summary: buildSummary(
+      cachedDeepResult.status,
+      cachedDeepResult.connections,
+    ),
     timestamp: now.toISOString(),
     deepCheckAt: cachedDeepResult.timestamp,
     uptime: process.uptime(),
@@ -233,7 +236,7 @@ async function runDeepCheck(): Promise<ConnectionHealth[]> {
       } else {
         const { WebClient } = await import("@slack/web-api");
         const tempClient = new WebClient(config.botToken);
-        const authResult = await tempClient.auth.test();
+        await tempClient.auth.test();
         layers.push({
           layer: "slack_api",
           status: "ok",
@@ -309,7 +312,6 @@ async function runDeepCheck(): Promise<ConnectionHealth[]> {
           const reader = resp.body!.getReader();
           const decoder = new TextDecoder();
           let gotText = false;
-          let responsePreview = "";
 
           try {
             let buffer = "";
@@ -332,7 +334,6 @@ async function runDeepCheck(): Promise<ConnectionHealth[]> {
                     (event.type === "text" && event.text)
                   ) {
                     gotText = true;
-                    responsePreview += event.delta || event.text || "";
                   }
                 } catch {
                   // ignore parse errors
@@ -382,7 +383,7 @@ async function runDeepCheck(): Promise<ConnectionHealth[]> {
           });
           callbackReachable = resp.status < 500;
           callbackDetail = `callback=${resp.status}, triggers=${triggerState.activeTriggerTypes.length}`;
-        } catch (fetchErr) {
+        } catch {
           callbackDetail = `callback unreachable, triggers=${triggerState.activeTriggerTypes.length}`;
         }
 
@@ -464,7 +465,9 @@ async function runDeepCheck(): Promise<ConnectionHealth[]> {
 
     results.push({
       connectionId: config.connectionId.slice(0, 8) + "…",
-      teamName: config.teamName ? config.teamName.slice(0, 1) + "***" : undefined,
+      teamName: config.teamName
+        ? config.teamName.slice(0, 1) + "***"
+        : undefined,
       connectionName: config.connectionName,
       mode,
       overall,

--- a/slack-mcp/server/lib/logger.ts
+++ b/slack-mcp/server/lib/logger.ts
@@ -180,71 +180,66 @@ export class HyperDXLogger {
    */
   private async sendToHyperDX(logEntry: Record<string, unknown>) {
     console.log(`[HyperDX] 📤 Sending log to ${this.hyperDxEndpoint}...`);
-    try {
-      const response = await fetch(this.hyperDxEndpoint, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: this.apiKey!,
-        },
-        body: JSON.stringify({
-          resourceLogs: [
-            {
-              resource: {
-                attributes: [
-                  {
-                    key: "service.name",
-                    value: { stringValue: this.service },
-                  },
-                ],
-              },
-              scopeLogs: [
+    const response = await fetch(this.hyperDxEndpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: this.apiKey!,
+      },
+      body: JSON.stringify({
+        resourceLogs: [
+          {
+            resource: {
+              attributes: [
                 {
-                  scope: { name: this.service },
-                  logRecords: [
-                    {
-                      timeUnixNano: `${Date.now() * 1000000}`,
-                      severityNumber:
-                        (
-                          {
-                            debug: 5,
-                            info: 9,
-                            warn: 13,
-                            error: 17,
-                          } as Record<string, number>
-                        )[String(logEntry.level || "info")] ?? 9,
-                      severityText: String(
-                        logEntry.level || "info",
-                      ).toUpperCase(),
-                      body: { stringValue: String(logEntry.body) },
-                      attributes: Object.entries(logEntry)
-                        .filter(([key]) => key !== "body" && key !== "level")
-                        .map(([key, value]) => ({
-                          key,
-                          value: { stringValue: String(value) },
-                        })),
-                    },
-                  ],
+                  key: "service.name",
+                  value: { stringValue: this.service },
                 },
               ],
             },
-          ],
-        }),
-      });
+            scopeLogs: [
+              {
+                scope: { name: this.service },
+                logRecords: [
+                  {
+                    timeUnixNano: `${Date.now() * 1000000}`,
+                    severityNumber:
+                      (
+                        {
+                          debug: 5,
+                          info: 9,
+                          warn: 13,
+                          error: 17,
+                        } as Record<string, number>
+                      )[String(logEntry.level || "info")] ?? 9,
+                    severityText: String(
+                      logEntry.level || "info",
+                    ).toUpperCase(),
+                    body: { stringValue: String(logEntry.body) },
+                    attributes: Object.entries(logEntry)
+                      .filter(([key]) => key !== "body" && key !== "level")
+                      .map(([key, value]) => ({
+                        key,
+                        value: { stringValue: String(value) },
+                      })),
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    });
 
-      const body = await response.text();
-      if (!response.ok) {
-        throw new Error(
-          `HyperDX API returned ${response.status}: ${response.statusText} - ${body}`,
-        );
-      }
-      console.log(
-        `[HyperDX] ✅ Log sent successfully (${response.status}) - Response: ${body || "(empty)"}`,
+    const body = await response.text();
+    if (!response.ok) {
+      throw new Error(
+        `HyperDX API returned ${response.status}: ${response.statusText} - ${body}`,
       );
-    } catch (error) {
-      // Re-throw to be caught by caller
-      throw error;
     }
+    console.log(
+      `[HyperDX] ✅ Log sent successfully (${response.status}) - Response: ${body || "(empty)"}`,
+    );
   }
 }
 

--- a/slack-mcp/server/router.ts
+++ b/slack-mcp/server/router.ts
@@ -262,7 +262,7 @@ app.post("/slack/interactive", async (c) => {
 async function processConnectionEventAsync(
   payload: SlackWebhookPayload,
   connectionConfig: SlackConnectionConfig,
-  traceId: string,
+  _traceId: string,
 ): Promise<void> {
   if (!payload.event) {
     return;

--- a/slack-mcp/server/slack/handlers/eventHandler.ts
+++ b/slack-mcp/server/slack/handlers/eventHandler.ts
@@ -16,7 +16,6 @@ import { appendAssistantMessage } from "../../lib/thread.ts";
 import {
   sendMessage,
   replyInThread,
-  getBotInfo,
   getThreadReplies,
   sendThinkingMessage,
   processSlackFiles,
@@ -26,7 +25,6 @@ import {
   getUserInfo,
 } from "../../lib/slack-client.ts";
 import type {
-  SlackEvent,
   SlackAppMentionEvent,
   SlackMessageEvent,
 } from "../../lib/types.ts";

--- a/slack-mcp/server/tools/index.ts
+++ b/slack-mcp/server/tools/index.ts
@@ -16,7 +16,6 @@ import { syncCacheTool } from "./sync-cache.ts";
 import { triggers } from "../lib/trigger-store.ts";
 
 type ToolFactory<E> = (env: E) => unknown;
-type ToolCollection<E> = ToolFactory<E>[];
 
 /**
  * Wrap tool factory to ensure Slack client is initialized

--- a/virtual-try-on/server/dev-server.ts
+++ b/virtual-try-on/server/dev-server.ts
@@ -26,7 +26,7 @@ const PORT = Number.parseInt(Bun.env.PORT ?? "8000");
 // - SSE connections stay open until explicitly closed
 // - The client (Cursor/MCP) may have its own timeout
 
-const server = Bun.serve({
+Bun.serve({
   port: PORT,
   fetch: runtime.fetch,
   development: true,

--- a/virtual-try-on/tsconfig.json
+++ b/virtual-try-on/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "5.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "lib": [

--- a/vtex/server/generated/b2b-buyer-data/zod.gen.ts
+++ b/vtex/server/generated/b2b-buyer-data/zod.gen.ts
@@ -49,7 +49,7 @@ export const zBuyerSchemaResponse = z.object({
                         })),
                         cardNumber: z.optional(z.object({
                             type: z.optional(z.string()),
-                            pattern: z.optional(z.string().regex(/^[\*]{12}[0-9]{4}$/))
+                            pattern: z.optional(z.string().regex(/^[*]{12}[0-9]{4}$/))
                         })),
                         bin: z.optional(z.object({
                             type: z.optional(z.string())

--- a/vtex/server/tools/index.ts
+++ b/vtex/server/tools/index.ts
@@ -4,7 +4,6 @@
  * Registry tools are auto-generated from OpenAPI specs via hey-api.
  * Custom tools handle complex multi-step operations.
  */
-import type { Env } from "../types/env.ts";
 import {
   brandTools,
   categoryTools,


### PR DESCRIPTION
## Summary

- Fixed all 38 oxlint warnings across 23 files in the monorepo (unused variables/imports/parameters, useless try/catch wrappers, unnecessary spreads, empty destructuring patterns, useless escapes)
- Prefixed intentionally unused parameters with `_`, removed truly unused declarations, unwrapped no-op try/catch blocks, and added inline suppression for intentional control-character regexes in `content-scraper`
- Lint now passes cleanly with 0 warnings and 0 errors

## Test plan
- [x] `bun run lint` passes with 0 warnings and 0 errors
- [x] `bun run fmt` passes (pre-commit hook verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears all `oxlint` warnings across the monorepo and silences TypeScript 5.9 `baseUrl` deprecation to unblock CI. No functional changes intended; lint and TS checks now pass cleanly.

- **Refactors**
  - Prefixed intentionally unused params with `_`; removed unused imports/types/vars.
  - Simplified error handling and removed defensive/no-op code in loggers and tools across `discord-read`, `slack-mcp`, `multi-channel-inbox`, `registry`, `vtex`, and `virtual-try-on`.
  - Added targeted `oxlint-disable-next-line no-control-regex` in `content-scraper` sanitization; fixed VTEX masked-card regex.

- **Bug Fixes**
  - Added `"ignoreDeprecations": "5.0"` to `tsconfig.json` in `content-scraper`, `hyperdx`, `multi-channel-inbox`, `registry`, and `virtual-try-on` to silence TS5101 (`baseUrl`) in TS 5.9 and pass CI.

<sup>Written for commit 36bf7bef01ad898e62bcf48365850899df2020a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

