### PR TITLE
fix encoding

### DIFF
--- a/github/server/lib/github-app-auth.ts
+++ b/github/server/lib/github-app-auth.ts
@@ -9,7 +9,10 @@
 import crypto from "node:crypto";
 
 const GITHUB_APP_ID = process.env.GITHUB_APP_ID || "";
-const GITHUB_PRIVATE_KEY = process.env.GITHUB_PRIVATE_KEY || "";
+const GITHUB_PRIVATE_KEY = (process.env.GITHUB_PRIVATE_KEY || "").replace(
+  /\\n/g,
+  "\n",
+);
 
 function base64url(data: Buffer | string): string {
   const buf = typeof data === "string" ? Buffer.from(data) : data;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes PEM parsing for the GitHub App private key by converting escaped `\n` to real newlines when reading `GITHUB_PRIVATE_KEY`. This prevents auth failures during JWT signing when the key is provided as a single-line env variable.

<sup>Written for commit c64557cf247235311cabcfe981579c770903ee28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

