### PR TITLE
fix(github): accept more app key formats

### DIFF
--- a/github/README.md
+++ b/github/README.md
@@ -42,10 +42,14 @@ This MCP requires a **GitHub App** (not a plain OAuth App) because webhook routi
 ### Environment Variables
 
 ```bash
+GITHUB_APP_ID=<github-app-id>
+GITHUB_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
 GITHUB_CLIENT_ID=<github-app-client-id>
 GITHUB_CLIENT_SECRET=<github-app-client-secret>
 GITHUB_WEBHOOK_SECRET=<webhook-secret>  # Required for webhook signature verification
 ```
+
+`GITHUB_PRIVATE_KEY` accepts raw PEM, a single-line env value with `\n` escapes, or base64-encoded PEM.
 
 ### Running locally
 

--- a/github/server/.env.example
+++ b/github/server/.env.example
@@ -1,5 +1,6 @@
 # GitHub App credentials (required)
 GITHUB_APP_ID=
+# Raw PEM, single-line PEM with \n escapes, or base64-encoded PEM
 GITHUB_PRIVATE_KEY=
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=

--- a/github/server/lib/github-app-auth.ts
+++ b/github/server/lib/github-app-auth.ts
@@ -9,9 +9,53 @@
 import crypto from "node:crypto";
 
 const GITHUB_APP_ID = process.env.GITHUB_APP_ID || "";
-const GITHUB_PRIVATE_KEY = (process.env.GITHUB_PRIVATE_KEY || "").replace(
-  /\\n/g,
-  "\n",
+
+function normalizePrivateKey(rawKey: string): string {
+  let key = rawKey.trim();
+
+  if (!key) return "";
+
+  // Support values copied from env files, secret managers, or JSON strings.
+  if (
+    (key.startsWith('"') && key.endsWith('"')) ||
+    (key.startsWith("'") && key.endsWith("'"))
+  ) {
+    key = key.slice(1, -1);
+  }
+
+  key = key.replace(/\\r/g, "\r").replace(/\\n/g, "\n").trim();
+
+  if (!key.includes("-----BEGIN") && key.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(key) as {
+        privateKey?: string;
+        private_key?: string;
+      };
+      const nestedKey = parsed.privateKey || parsed.private_key;
+      if (nestedKey) {
+        key = normalizePrivateKey(nestedKey);
+      }
+    } catch {
+      // Ignore invalid JSON and continue with other heuristics.
+    }
+  }
+
+  if (!key.includes("-----BEGIN")) {
+    try {
+      const decoded = Buffer.from(key, "base64").toString("utf8").trim();
+      if (decoded.includes("-----BEGIN")) {
+        key = normalizePrivateKey(decoded);
+      }
+    } catch {
+      // Ignore invalid base64 and let validation fail below.
+    }
+  }
+
+  return key;
+}
+
+const GITHUB_PRIVATE_KEY = normalizePrivateKey(
+  process.env.GITHUB_PRIVATE_KEY || "",
 );
 
 function base64url(data: Buffer | string): string {
@@ -42,10 +86,24 @@ function createAppJWT(): string {
   );
 
   const signingInput = `${header}.${payload}`;
-  const signature = crypto
-    .createSign("RSA-SHA256")
-    .update(signingInput)
-    .sign(GITHUB_PRIVATE_KEY, "base64url");
+  let signature: string;
+
+  try {
+    const signingKey = crypto.createPrivateKey({
+      key: GITHUB_PRIVATE_KEY,
+      format: "pem",
+    });
+    signature = crypto
+      .createSign("RSA-SHA256")
+      .update(signingInput)
+      .sign(signingKey, "base64url");
+  } catch (error) {
+    throw new Error(
+      "Invalid GITHUB_PRIVATE_KEY. Expected a GitHub App PEM private key, " +
+        "either as raw PEM, a single-line value with \\n escapes, or base64-encoded PEM.",
+      { cause: error },
+    );
+  }
 
   return `${signingInput}.${signature}`;
 }


### PR DESCRIPTION
This updates the GitHub MCP auth helper to normalize GitHub App private keys before signing JWTs. It now accepts raw PEM values, single-line values with escaped newlines, base64-encoded PEM, and JSON-shaped secrets that contain a nested private key. The change also validates the PEM earlier so startup failures surface as a clear configuration error instead of an OpenSSL NO_START_LINE crash. README and .env example docs now include GITHUB_APP_ID and the supported GITHUB_PRIVATE_KEY formats.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts more GitHub App private key formats and validates them early to prevent startup crashes when signing JWTs. Docs now list `GITHUB_APP_ID` and explain supported `GITHUB_PRIVATE_KEY` formats.

- **Bug Fixes**
  - Normalize `GITHUB_PRIVATE_KEY`: trims quotes, unescapes `\n`, reads JSON `{privateKey|private_key}`, and base64-decodes when needed.
  - Validate the PEM with `crypto.createPrivateKey` and surface a clear "Invalid GITHUB_PRIVATE_KEY" config error instead of an OpenSSL NO_START_LINE failure.
  - Update README and `.env.example` with `GITHUB_APP_ID` and key format guidance.

<sup>Written for commit 082f08063c613ba1f39c469ffdf6ba8f4d634668. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

