### PR TITLE
feat(github): log upstream MCP callTool responses

### DIFF
--- a/github/server/lib/mcp-proxy.ts
+++ b/github/server/lib/mcp-proxy.ts
@@ -159,6 +159,10 @@ export function buildUpstreamTools(
             name: toolDef.name,
             arguments: context as Record<string, unknown>,
           });
+          console.log(
+            `[mcp-proxy] callTool ${toolDef.name} result:`,
+            JSON.stringify(result),
+          );
 
           // The MCP SDK callTool returns { content: [{ type, text }] }.
           // The deco runtime wraps execute's return in JSON.stringify,


### PR DESCRIPTION
## Summary
- Adds `console.log` to the GitHub MCP proxy to log raw upstream callTool responses before parsing/transformation, aiding debugging of response handling.

## Test plan
- [ ] Deploy and invoke a GitHub tool, verify the upstream response appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log raw upstream MCP `callTool` results in the GitHub MCP proxy via a `console.log` (prefixed with “[mcp-proxy]”) before any parsing to make debugging response handling easier.

<sup>Written for commit e78d6c382b063a68df9d839ed90d737328b8de92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

