### PR TITLE
fix(github): improve callTool response handling

### DIFF
--- a/github/server/lib/mcp-proxy.ts
+++ b/github/server/lib/mcp-proxy.ts
@@ -168,11 +168,6 @@ export function buildUpstreamTools(
             name: toolDef.name,
             arguments: context as Record<string, unknown>,
           });
-          console.log(
-            `[mcp-proxy] callTool ${toolDef.name} result:`,
-            JSON.stringify(result),
-          );
-
           const contents = result.content as
             | Array<{ type: string; text?: string }>
             | undefined;

--- a/github/server/lib/mcp-proxy.ts
+++ b/github/server/lib/mcp-proxy.ts
@@ -15,6 +15,15 @@ import { z } from "zod";
 import type { Env } from "../types/env.ts";
 import { getAppInstallationToken } from "./github-app-auth.ts";
 
+function safeJsonParse(text: string | undefined): unknown | null {
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
 const DEFAULT_UPSTREAM_URL = "https://api.githubcopilot.com/mcp/";
 
 /**
@@ -164,25 +173,27 @@ export function buildUpstreamTools(
             JSON.stringify(result),
           );
 
-          // The MCP SDK callTool returns { content: [{ type, text }] }.
-          // The deco runtime wraps execute's return in JSON.stringify,
-          // so we need to extract and parse the text to avoid double encoding.
           const contents = result.content as
             | Array<{ type: string; text?: string }>
             | undefined;
-          const textContent = contents?.find(
+          const msg = contents?.find(
             (c): c is { type: "text"; text: string } =>
               c.type === "text" && typeof c.text === "string",
-          );
-          if (textContent?.text) {
-            try {
-              return JSON.parse(textContent.text);
-            } catch {
-              return textContent.text;
-            }
+          )?.text;
+
+          if (result.isError) {
+            throw new Error(msg || "Something went wrong");
           }
 
-          return result;
+          if (result.structuredContent) {
+            return result.structuredContent;
+          }
+
+          const parsed = safeJsonParse(msg);
+          if (!parsed) {
+            throw new Error(`Failed to parse: ${msg}`);
+          }
+          return parsed;
         } finally {
           client.close().catch(() => {});
         }


### PR DESCRIPTION
## Summary
- Handle `result.isError` by throwing with the text message or a fallback
- Return `result.structuredContent` directly when available
- Parse text content as JSON with explicit error on parse failure
- Add `safeJsonParse` helper for safe JSON parsing

## Test plan
- [ ] Verify error responses from upstream MCP are properly thrown
- [ ] Verify structured content responses are returned directly
- [ ] Verify JSON text responses are parsed and returned
- [ ] Verify non-JSON text responses throw a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves callTool response handling in the GitHub MCP proxy. Throws on upstream errors, prefers `structuredContent`, and parses text responses as JSON with clear failures.

- **Bug Fixes**
  - Throw with the tool’s text message (or fallback) when `result.isError` is true.
  - Return `result.structuredContent` directly when available.
  - Parse text content as JSON; if parsing fails, throw `Failed to parse: <msg>`.
  - Add `safeJsonParse` helper and remove response logs.

<sup>Written for commit 67a5913efd4f7b921736191af4edc6c2b4c6d1d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

