### PR TITLE
fix(github): handle non-JSON upstream tool responses

### DIFF
--- a/github/server/lib/mcp-proxy.ts
+++ b/github/server/lib/mcp-proxy.ts
@@ -168,7 +168,10 @@ export function buildUpstreamTools(
             name: toolDef.name,
             arguments: context as Record<string, unknown>,
           });
-          console.log(`[mcp-proxy] callTool result for ${toolDef.name}:`, JSON.stringify(result, null, 2));
+          console.log(
+            `[mcp-proxy] callTool result for ${toolDef.name}:`,
+            JSON.stringify(result, null, 2),
+          );
           const contents = result.content as
             | Array<{ type: string; text?: string }>
             | undefined;

--- a/github/server/lib/mcp-proxy.ts
+++ b/github/server/lib/mcp-proxy.ts
@@ -168,6 +168,7 @@ export function buildUpstreamTools(
             name: toolDef.name,
             arguments: context as Record<string, unknown>,
           });
+          console.log(`[mcp-proxy] callTool result for ${toolDef.name}:`, JSON.stringify(result, null, 2));
           const contents = result.content as
             | Array<{ type: string; text?: string }>
             | undefined;
@@ -185,11 +186,10 @@ export function buildUpstreamTools(
           }
 
           const parsed = safeJsonParse(msg);
-          if (parsed) {
-            return parsed;
+          if (!parsed) {
+            throw new Error(`Failed to parse: ${msg}`);
           }
-
-          return msg ?? null;
+          return parsed;
         } finally {
           client.close().catch(() => {});
         }

--- a/github/server/lib/mcp-proxy.ts
+++ b/github/server/lib/mcp-proxy.ts
@@ -185,10 +185,11 @@ export function buildUpstreamTools(
           }
 
           const parsed = safeJsonParse(msg);
-          if (!parsed) {
-            throw new Error(`Failed to parse: ${msg}`);
+          if (parsed) {
+            return parsed;
           }
-          return parsed;
+
+          return msg ?? null;
         } finally {
           client.close().catch(() => {});
         }


### PR DESCRIPTION
## Summary
- Fix `get_file_contents` (and other tools) failing when the upstream GitHub MCP server returns plain text instead of JSON
- Previously, non-JSON responses like `"successfully downloaded text file (SHA: ...)"` caused a `Failed to parse` error
- Now returns the raw text message when JSON parsing fails, instead of throwing

## Test plan
- [ ] Call `get_file_contents` on a text file and verify it returns content without error
- [ ] Call tools that return JSON responses and verify they still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle non-JSON responses from the upstream GitHub MCP server so tools like `get_file_contents` don’t fail on plain-text messages. Added debug logging of upstream `callTool` results to help trace response formats.

- **Bug Fixes**
  - Parse JSON when available; otherwise return the original text (or null) instead of throwing.
  - Log upstream `callTool` responses (tool name and payload) to diagnose non-JSON cases.
  - Format the debug log to pass `oxfmt` checks.

<sup>Written for commit 528ed6d3a85e97edb67630a6be877e6ee136e7a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

