### PR TITLE
chore(github): bump @decocms/runtime to 1.5.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -225,7 +225,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@decocms/bindings": "^1.4.0",
-        "@decocms/runtime": "1.4.0",
+        "@decocms/runtime": "1.5.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "zod": "^4.0.0",
       },
@@ -3968,7 +3968,7 @@
 
     "github/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
-    "github/@decocms/runtime": ["@decocms/runtime@1.4.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-tWRsfJ8YxGPyVkrTWwQ9BNakThE7WCd1eWnPBAxzAeJn1ldMDzIrJMyi9bOkGqUB2mvswrDoVXNqFLPxbNEIPg=="],
+    "github/@decocms/runtime": ["@decocms/runtime@1.5.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-TVwuutWjghkDtt/6ylxXyUEgbjDA8xg9tjnMZ3kq3DO1RfhTuaAW0YKuf6AJPN+aYno89VSQ8HBVJ7phwIelpw=="],
 
     "github/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 

--- a/github/package.json
+++ b/github/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@decocms/bindings": "^1.4.0",
-    "@decocms/runtime": "1.4.0",
+    "@decocms/runtime": "1.5.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "zod": "^4.0.0"
   },


### PR DESCRIPTION
## Summary
- Bumps `@decocms/runtime` from 1.4.0 to 1.5.0 in the `github` package
- Updates `bun.lock` accordingly

## Test plan
- [ ] Verify the github MCP server builds and runs correctly with the new runtime version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@decocms/runtime` from 1.4.0 to 1.5.0 in the `github` package to pick up the latest runtime fixes and features for the GitHub MCP server. Updated `bun.lock` to reflect the change.

<sup>Written for commit 92c417a904ab3b6b92215e885c976a244bd24a31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

