### PR TITLE
fix(github): return raw callTool result without parsing

### DIFF
--- a/github/server/lib/mcp-proxy.ts
+++ b/github/server/lib/mcp-proxy.ts
@@ -23,13 +23,16 @@ const DEFAULT_UPSTREAM_URL = "https://api.githubcopilot.com/mcp/";
 function connectUpstreamClient(token: string): Promise<Client> {
   const client = new Client({ name: "github-mcp-proxy", version: "1.0.0" });
 
-  const transport = new StreamableHTTPClientTransport(new URL(DEFAULT_UPSTREAM_URL), {
-    requestInit: {
-      headers: {
-        Authorization: `Bearer ${token}`,
+  const transport = new StreamableHTTPClientTransport(
+    new URL(DEFAULT_UPSTREAM_URL),
+    {
+      requestInit: {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
       },
     },
-  });
+  );
 
   return client.connect(transport).then(() => client);
 }
@@ -124,7 +127,8 @@ async function discoverUpstreamToolDefs(): Promise<ToolsDef> {
  * Awaited in tools/index.ts before the server starts accepting requests.
  * If this fails, the server process crashes — by design.
  */
-export const upstreamToolDefsReady: Promise<ToolsDef> = discoverUpstreamToolDefs();
+export const upstreamToolDefsReady: Promise<ToolsDef> =
+  discoverUpstreamToolDefs();
 
 // ============================================================================
 // Upstream tool creation
@@ -134,14 +138,17 @@ export const upstreamToolDefsReady: Promise<ToolsDef> = discoverUpstreamToolDefs
  * Build createTool() instances from pre-discovered tool definitions.
  * Execution uses the per-request user token from ctx.
  */
-export function buildUpstreamTools(toolDefs: ToolsDef): ReturnType<typeof createTool>[] {
+export function buildUpstreamTools(
+  toolDefs: ToolsDef,
+): ReturnType<typeof createTool>[] {
   return toolDefs.map((toolDef) =>
     createTool({
       id: toolDef.name,
       description: toolDef.description || `GitHub tool: ${toolDef.name}`,
       inputSchema: jsonSchemaToZod(toolDef.inputSchema as any),
       execute: async ({ context }, ctx) => {
-        const currentToken = (ctx as AppContext<Env>).env.MESH_REQUEST_CONTEXT?.authorization;
+        const currentToken = (ctx as AppContext<Env>).env.MESH_REQUEST_CONTEXT
+          ?.authorization;
         if (!currentToken) {
           throw new Error("GitHub authorization token not found");
         }

--- a/github/server/lib/mcp-proxy.ts
+++ b/github/server/lib/mcp-proxy.ts
@@ -15,15 +15,6 @@ import { z } from "zod";
 import type { Env } from "../types/env.ts";
 import { getAppInstallationToken } from "./github-app-auth.ts";
 
-function safeJsonParse(text: string | undefined): unknown | null {
-  if (!text) return null;
-  try {
-    return JSON.parse(text);
-  } catch {
-    return null;
-  }
-}
-
 const DEFAULT_UPSTREAM_URL = "https://api.githubcopilot.com/mcp/";
 
 /**
@@ -32,16 +23,13 @@ const DEFAULT_UPSTREAM_URL = "https://api.githubcopilot.com/mcp/";
 function connectUpstreamClient(token: string): Promise<Client> {
   const client = new Client({ name: "github-mcp-proxy", version: "1.0.0" });
 
-  const transport = new StreamableHTTPClientTransport(
-    new URL(DEFAULT_UPSTREAM_URL),
-    {
-      requestInit: {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+  const transport = new StreamableHTTPClientTransport(new URL(DEFAULT_UPSTREAM_URL), {
+    requestInit: {
+      headers: {
+        Authorization: `Bearer ${token}`,
       },
     },
-  );
+  });
 
   return client.connect(transport).then(() => client);
 }
@@ -136,8 +124,7 @@ async function discoverUpstreamToolDefs(): Promise<ToolsDef> {
  * Awaited in tools/index.ts before the server starts accepting requests.
  * If this fails, the server process crashes — by design.
  */
-export const upstreamToolDefsReady: Promise<ToolsDef> =
-  discoverUpstreamToolDefs();
+export const upstreamToolDefsReady: Promise<ToolsDef> = discoverUpstreamToolDefs();
 
 // ============================================================================
 // Upstream tool creation
@@ -147,52 +134,24 @@ export const upstreamToolDefsReady: Promise<ToolsDef> =
  * Build createTool() instances from pre-discovered tool definitions.
  * Execution uses the per-request user token from ctx.
  */
-export function buildUpstreamTools(
-  toolDefs: ToolsDef,
-): ReturnType<typeof createTool>[] {
+export function buildUpstreamTools(toolDefs: ToolsDef): ReturnType<typeof createTool>[] {
   return toolDefs.map((toolDef) =>
     createTool({
       id: toolDef.name,
       description: toolDef.description || `GitHub tool: ${toolDef.name}`,
       inputSchema: jsonSchemaToZod(toolDef.inputSchema as any),
       execute: async ({ context }, ctx) => {
-        const currentToken = (ctx as AppContext<Env>).env.MESH_REQUEST_CONTEXT
-          ?.authorization;
+        const currentToken = (ctx as AppContext<Env>).env.MESH_REQUEST_CONTEXT?.authorization;
         if (!currentToken) {
           throw new Error("GitHub authorization token not found");
         }
 
         const client = await connectUpstreamClient(currentToken);
         try {
-          const result = await client.callTool({
+          return await client.callTool({
             name: toolDef.name,
             arguments: context as Record<string, unknown>,
           });
-          console.log(
-            `[mcp-proxy] callTool result for ${toolDef.name}:`,
-            JSON.stringify(result, null, 2),
-          );
-          const contents = result.content as
-            | Array<{ type: string; text?: string }>
-            | undefined;
-          const msg = contents?.find(
-            (c): c is { type: "text"; text: string } =>
-              c.type === "text" && typeof c.text === "string",
-          )?.text;
-
-          if (result.isError) {
-            throw new Error(msg || "Something went wrong");
-          }
-
-          if (result.structuredContent) {
-            return result.structuredContent;
-          }
-
-          const parsed = safeJsonParse(msg);
-          if (!parsed) {
-            throw new Error(`Failed to parse: ${msg}`);
-          }
-          return parsed;
         } finally {
           client.close().catch(() => {});
         }


### PR DESCRIPTION
## Summary

- Removes response parsing/transformation in the GitHub MCP proxy, returning the raw `callTool` result directly
- Fixes "Failed to parse" errors for upstream responses that return plain text (e.g. file download confirmations) instead of JSON
- Removes unused `safeJsonParse` helper and debug logging

## Test plan

- [ ] Verify GitHub file download tools no longer error with "Failed to parse"
- [ ] Verify JSON-returning tools still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return the raw MCP `callTool` result from the GitHub proxy instead of parsing it. This stops "Failed to parse" errors on plain-text responses and keeps JSON responses working.

- **Bug Fixes**
  - Non-JSON upstream responses (e.g., file download confirmations) no longer error.
  - JSON-returning tools are unaffected.

- **Refactors**
  - Removed unused `safeJsonParse` and debug logging.
  - Applied `oxfmt` formatting to the module.

<sup>Written for commit 2f2fe8a422c7bd39f20618e16e961e387b97b6cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

