### PR TITLE
feat: added pandadoc mcp

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -640,6 +640,17 @@
         "wrangler": "^4.28.0",
       },
     },
+    "pandadoc": {
+      "name": "pandadoc",
+      "version": "1.0.0",
+      "dependencies": {
+        "@decocms/runtime": "1.2.5",
+      },
+      "devDependencies": {
+        "@decocms/mcps-shared": "1.0.0",
+        "typescript": "^5.7.2",
+      },
+    },
     "perplexity": {
       "name": "perplexity",
       "version": "1.0.0",
@@ -2972,6 +2983,8 @@
 
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
+    "pandadoc": ["pandadoc@workspace:pandadoc"],
+
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
@@ -4120,6 +4133,8 @@
 
     "ora/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "pandadoc/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
+
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "perplexity/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
@@ -4642,6 +4657,12 @@
 
     "ora/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "pandadoc/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
+
+    "pandadoc/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
+
+    "pandadoc/@decocms/runtime/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "perplexity/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
 
     "perplexity/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
@@ -5083,6 +5104,8 @@
     "nanobanana/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "object-storage/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
+
+    "pandadoc/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "perplexity/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 

--- a/deploy.json
+++ b/deploy.json
@@ -126,6 +126,15 @@
       "shared/**"
     ]
   },
+  "pandadoc": {
+    "site": "pandadoc",
+    "entrypoint": "./dist/server/main.js",
+    "platformName": "kubernetes-bun",
+    "watch": [
+      "pandadoc/**",
+      "shared/**"
+    ]
+  },
   "hyperdx": {
     "site": "hyperdx",
     "entrypoint": "./dist/server/main.js",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "meta-ads",
     "multi-channel-inbox",
     "nanobanana",
+    "pandadoc",
     "object-storage",
     "openrouter",
     "perplexity",

--- a/pandadoc/app.json
+++ b/pandadoc/app.json
@@ -1,0 +1,24 @@
+{
+  "scopeName": "deco",
+  "name": "pandadoc",
+  "friendlyName": "PandaDoc",
+  "connection": {
+    "type": "HTTP",
+    "url": "https://sites-pandadoc.decocache.com/mcp"
+  },
+  "description": "Integração com PandaDoc para gerenciar documentos, templates e assinaturas eletrônicas.",
+  "icon": "https://assets.decocache.com/mcp/pandadoc.svg",
+  "unlisted": false,
+  "auth": {
+    "type": "token",
+    "header": "Authorization",
+    "prefix": "Bearer"
+  },
+  "metadata": {
+    "categories": ["Productivity"],
+    "official": false,
+    "tags": ["pandadoc", "documents", "esignature", "contracts"],
+    "short_description": "Manage PandaDoc documents, templates and e-signatures.",
+    "mesh_description": "PandaDoc MCP proxy that allows AI agents to interact with your PandaDoc account. Supports listing documents, creating documents from templates, sending for signature, and tracking document status.\n\nThis MCP acts as a proxy to the official PandaDoc MCP server, handling authentication transparently."
+  }
+}

--- a/pandadoc/package.json
+++ b/pandadoc/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "pandadoc",
+  "version": "1.0.0",
+  "description": "MCP proxy for PandaDoc official MCP server",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun run --hot server/main.ts",
+    "check": "tsc --noEmit",
+    "build:server": "NODE_ENV=production bun build server/main.ts --target=bun --outfile=dist/server/main.js",
+    "build": "bun run build:server"
+  },
+  "dependencies": {
+    "@decocms/runtime": "1.2.5"
+  },
+  "devDependencies": {
+    "@decocms/mcps-shared": "1.0.0",
+    "typescript": "^5.7.2"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/pandadoc/server/main.ts
+++ b/pandadoc/server/main.ts
@@ -45,7 +45,15 @@ async function handler(req: Request): Promise<Response> {
     return new Response(null, { status: 204, headers: CORS_HEADERS });
   }
 
-  // Forward all /mcp* requests to PandaDoc
+  // Only proxy /mcp* routes
+  if (!url.pathname.startsWith("/mcp")) {
+    return new Response(JSON.stringify({ error: "Not found" }), {
+      status: 404,
+      headers: { "content-type": "application/json", ...CORS_HEADERS },
+    });
+  }
+
+  // Forward /mcp* requests to PandaDoc
   const authorization = req.headers.get("Authorization") ?? "";
   const token = extractToken(authorization);
 

--- a/pandadoc/server/main.ts
+++ b/pandadoc/server/main.ts
@@ -1,0 +1,96 @@
+/**
+ * PandaDoc MCP Proxy Server
+ *
+ * Proxies all MCP requests to the official PandaDoc MCP server
+ * (https://developers.pandadoc.com/mcp), rewriting the Authorization header
+ * from "Bearer <token>" to "API-Key <token>" as required by PandaDoc.
+ */
+import { serve } from "@decocms/mcps-shared/serve";
+
+const PANDADOC_MCP_URL = "https://developers.pandadoc.com/mcp";
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers":
+    "Authorization, Content-Type, Accept, x-request-id",
+};
+
+/**
+ * Extracts the raw API key from an Authorization header value.
+ * Accepts both "Bearer <token>" and plain "<token>" formats.
+ */
+function extractToken(authorization: string): string {
+  if (authorization.startsWith("Bearer ")) {
+    return authorization.slice("Bearer ".length).trim();
+  }
+  if (authorization.startsWith("API-Key ")) {
+    return authorization.slice("API-Key ".length).trim();
+  }
+  return authorization.trim();
+}
+
+async function handler(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+
+  // Health check endpoint
+  if (url.pathname === "/health") {
+    return new Response(JSON.stringify({ status: "ok" }), {
+      headers: { "content-type": "application/json", ...CORS_HEADERS },
+    });
+  }
+
+  // Handle CORS preflight — must respond before auth check
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+
+  // Forward all /mcp* requests to PandaDoc
+  const authorization = req.headers.get("Authorization") ?? "";
+  const token = extractToken(authorization);
+
+  if (!token) {
+    return new Response(
+      JSON.stringify({ error: "Missing Authorization header" }),
+      {
+        status: 401,
+        headers: { "content-type": "application/json", ...CORS_HEADERS },
+      },
+    );
+  }
+
+  // Build forwarded headers — replace Authorization with PandaDoc's expected format
+  const forwardedHeaders = new Headers(req.headers);
+  forwardedHeaders.set("Authorization", `API-Key ${token}`);
+  // PandaDoc MCP requires both application/json and text/event-stream (SSE)
+  forwardedHeaders.set("Accept", "application/json, text/event-stream");
+  // Remove host header so it doesn't conflict with the upstream
+  forwardedHeaders.delete("host");
+
+  // Determine upstream URL (preserve path + query after /mcp)
+  const upstreamPath = url.pathname.replace(/^\/?mcp/, "") || "";
+  const upstreamUrl = `${PANDADOC_MCP_URL}${upstreamPath}${url.search}`;
+
+  const upstreamResponse = await fetch(upstreamUrl, {
+    method: req.method,
+    headers: forwardedHeaders,
+    body: req.body,
+    // @ts-ignore — Bun-specific: disable body auto-decompression for streaming
+    duplex: "half",
+  });
+
+  // Merge upstream headers with CORS headers
+  const responseHeaders = new Headers(upstreamResponse.headers);
+  for (const [key, value] of Object.entries(CORS_HEADERS)) {
+    responseHeaders.set(key, value);
+  }
+
+  // Stream response back to client
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    statusText: upstreamResponse.statusText,
+    headers: responseHeaders,
+  });
+}
+
+serve(handler);

--- a/pandadoc/tsconfig.json
+++ b/pandadoc/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2023", "ES2024"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "allowJs": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["server"]
+}


### PR DESCRIPTION
Added Pandadoc MCP to list contracts documents for finantial team

<img width="1576" height="738" alt="image" src="https://github.com/user-attachments/assets/63ea358b-92b2-433a-b0d6-ff115497d39a" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `pandadoc` MCP proxy so the finance team can list and track contract documents in PandaDoc. It forwards `/mcp` to PandaDoc, rewrites `Authorization` to `API-Key`, and supports CORS, OPTIONS preflight, and streaming.

- **New Features**
  - New `pandadoc` service that proxies to https://developers.pandadoc.com/mcp.
  - Auth rewrite: accepts `Authorization: Bearer <token>` or `API-Key <token>`, forwards as `API-Key <token>`.
  - CORS headers, OPTIONS preflight, SSE-friendly `Accept` header, and `/health` endpoint.
  - Deployment added in `deploy.json` (kubernetes-bun), workspace entry in root `package.json`, and build scripts.

- **Migration**
  - Deploy the new `pandadoc` site and call `/mcp` with `Authorization: Bearer <PandaDoc API key>`.
  - Use the connection URL defined in `pandadoc/app.json`.

<sup>Written for commit df4f909631ec68be95fa6e5c571d085aa8aed172. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

