### PR TITLE
fix pandadoc logo image

### DIFF
--- a/pandadoc/app.json
+++ b/pandadoc/app.json
@@ -7,7 +7,7 @@
     "url": "https://sites-pandadoc.decocache.com/mcp"
   },
   "description": "Integração com PandaDoc para gerenciar documentos, templates e assinaturas eletrônicas.",
-  "icon": "https://assets.decocache.com/mcp/pandadoc.svg",
+  "icon": "https://assets.decocache.com/decocms/f28a98ba-9a15-4e6e-87c9-91dacabe1bf1/idScmnFR7z_1776887424611.jpeg",
   "unlisted": false,
   "auth": {
     "type": "token",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the PandaDoc app logo by updating the manifest `icon` URL to a stable hosted image, restoring the logo in the UI.

<sup>Written for commit 0605947e023cc44423477b40d61af834c0ca44e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

