### PR TITLE
fix(github): forward refresh tokens and implement refresh grant

### DIFF
--- a/github/server/lib/github-client.ts
+++ b/github/server/lib/github-client.ts
@@ -2,29 +2,26 @@
  * GitHub OAuth helpers
  */
 
-/**
- * Exchange an OAuth code for an access token
- *
- * This is used during the GitHub App OAuth flow to exchange
- * the authorization code for an installation access token.
- */
-export async function exchangeCodeForToken(
-  code: string,
-  clientId: string,
-  clientSecret: string,
-  redirectUri?: string,
-): Promise<{ access_token: string; token_type: string }> {
-  const body: Record<string, string> = {
-    client_id: clientId,
-    client_secret: clientSecret,
-    code,
-  };
+export interface GitHubTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in?: number;
+  refresh_token?: string;
+  refresh_token_expires_in?: number;
+  scope?: string;
+}
 
-  if (redirectUri) {
-    body.redirect_uri = redirectUri;
-  }
+interface RawGitHubTokenResponse extends GitHubTokenResponse {
+  error?: string;
+  error_description?: string;
+}
 
-  const response = await fetch("https://github.com/login/oauth/access_token", {
+const GITHUB_TOKEN_ENDPOINT = "https://github.com/login/oauth/access_token";
+
+async function postToGitHub(
+  body: Record<string, string>,
+): Promise<GitHubTokenResponse> {
+  const response = await fetch(GITHUB_TOKEN_ENDPOINT, {
     method: "POST",
     headers: {
       Accept: "application/json",
@@ -38,13 +35,7 @@ export async function exchangeCodeForToken(
     throw new Error(`GitHub OAuth failed: ${response.status} - ${errorText}`);
   }
 
-  const data = (await response.json()) as {
-    access_token: string;
-    token_type: string;
-    scope?: string;
-    error?: string;
-    error_description?: string;
-  };
+  const data = (await response.json()) as RawGitHubTokenResponse;
 
   if (data.error) {
     throw new Error(
@@ -55,5 +46,52 @@ export async function exchangeCodeForToken(
   return {
     access_token: data.access_token,
     token_type: data.token_type || "Bearer",
+    expires_in: data.expires_in,
+    refresh_token: data.refresh_token,
+    refresh_token_expires_in: data.refresh_token_expires_in,
+    scope: data.scope,
   };
+}
+
+/**
+ * Exchange an OAuth code for an access token.
+ *
+ * GitHub Apps with "Expire user authorization tokens" enabled return
+ * `refresh_token`, `expires_in`, and `refresh_token_expires_in` alongside
+ * the `access_token`; all fields are forwarded unchanged.
+ */
+export function exchangeCodeForToken(
+  code: string,
+  clientId: string,
+  clientSecret: string,
+  redirectUri?: string,
+): Promise<GitHubTokenResponse> {
+  const body: Record<string, string> = {
+    client_id: clientId,
+    client_secret: clientSecret,
+    code,
+  };
+
+  if (redirectUri) {
+    body.redirect_uri = redirectUri;
+  }
+
+  return postToGitHub(body);
+}
+
+/**
+ * Exchange a refresh token for a new access token.
+ * Only works for GitHub Apps that issue expiring user tokens.
+ */
+export function refreshAccessToken(
+  refreshToken: string,
+  clientId: string,
+  clientSecret: string,
+): Promise<GitHubTokenResponse> {
+  return postToGitHub({
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+  });
 }

--- a/github/server/main.ts
+++ b/github/server/main.ts
@@ -8,7 +8,10 @@
 import type { Registry } from "@decocms/mcps-shared/registry";
 import { serve } from "@decocms/mcps-shared/serve";
 import { withRuntime } from "@decocms/runtime";
-import { exchangeCodeForToken } from "./lib/github-client.ts";
+import {
+  exchangeCodeForToken,
+  refreshAccessToken,
+} from "./lib/github-client.ts";
 import { captureInstallationMappings } from "./lib/installation-map.ts";
 import { handleProxiedRequest } from "./lib/mcp-proxy.ts";
 import { tools } from "./tools/index.ts";
@@ -17,6 +20,15 @@ import { handleGitHubWebhook } from "./webhook.ts";
 
 const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID || "";
 const GITHUB_CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET || "";
+
+function assertOAuthCredentials(): void {
+  if (!GITHUB_CLIENT_ID || !GITHUB_CLIENT_SECRET) {
+    throw new Error(
+      "GitHub OAuth credentials not configured. " +
+        "Set GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET environment variables.",
+    );
+  }
+}
 
 const runtime = withRuntime<Env, typeof StateSchema, Registry>({
   oauth: {
@@ -44,12 +56,7 @@ const runtime = withRuntime<Env, typeof StateSchema, Registry>({
     },
 
     exchangeCode: async ({ code, redirect_uri }) => {
-      if (!GITHUB_CLIENT_ID || !GITHUB_CLIENT_SECRET) {
-        throw new Error(
-          "GitHub OAuth credentials not configured. " +
-            "Set GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET environment variables.",
-        );
-      }
+      assertOAuthCredentials();
 
       const tokenResponse = await exchangeCodeForToken(
         code,
@@ -61,6 +68,29 @@ const runtime = withRuntime<Env, typeof StateSchema, Registry>({
       return {
         access_token: tokenResponse.access_token,
         token_type: tokenResponse.token_type,
+        expires_in: tokenResponse.expires_in,
+        refresh_token: tokenResponse.refresh_token,
+        refresh_token_expires_in: tokenResponse.refresh_token_expires_in,
+        scope: tokenResponse.scope,
+      };
+    },
+
+    refreshToken: async (refreshToken) => {
+      assertOAuthCredentials();
+
+      const tokenResponse = await refreshAccessToken(
+        refreshToken,
+        GITHUB_CLIENT_ID,
+        GITHUB_CLIENT_SECRET,
+      );
+
+      return {
+        access_token: tokenResponse.access_token,
+        token_type: tokenResponse.token_type,
+        expires_in: tokenResponse.expires_in,
+        refresh_token: tokenResponse.refresh_token,
+        refresh_token_expires_in: tokenResponse.refresh_token_expires_in,
+        scope: tokenResponse.scope,
       };
     },
   },


### PR DESCRIPTION
## Summary

The `sites-github-mcp` OAuth proxy advertised `refresh_token` support in its discovery doc but didn't implement it: `exchangeCodeForToken` dropped `refresh_token`/`expires_in` from GitHub's response, and no `refreshToken` handler was wired on the runtime OAuth config, so `/token` returned `unsupported_grant_type` for refresh requests.

This forwards every field GitHub returns (`refresh_token`, `expires_in`, `refresh_token_expires_in`, `scope`) and adds a `refreshToken` handler that POSTs to GitHub's token endpoint with `grant_type=refresh_token`. Only effective for GitHub Apps with "Expire user authorization tokens" enabled.

## Test plan

- [ ] `curl /.well-known/oauth-authorization-server` still lists `refresh_token` in `grant_types_supported`
- [ ] After a fresh OAuth flow, the stored downstream token row has non-null `refreshToken` and `expiresAt`
- [ ] `POST /token` with `grant_type=refresh_token` returns 200 with a new `access_token`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GitHub OAuth refresh flow by forwarding refresh-token fields and implementing the refresh grant so `/token` with `grant_type=refresh_token` returns new access tokens. Effective for GitHub Apps with “Expire user authorization tokens” enabled.

- **Bug Fixes**
  - Forwarded GitHub token response fields: `refresh_token`, `expires_in`, `refresh_token_expires_in`, `scope`.
  - Implemented `refreshToken` handler that calls GitHub’s token endpoint with `grant_type=refresh_token`.

- **Refactors**
  - Centralized token POST logic and added a credentials check for `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET`.

<sup>Written for commit 1f2213aad82aca714b8ae25723de809e62c8d85e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

