### PR TITLE
fix(github): always return `scope` in token response

### DIFF
--- a/github/server/main.ts
+++ b/github/server/main.ts
@@ -20,6 +20,7 @@ import { handleGitHubWebhook } from "./webhook.ts";
 
 const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID || "";
 const GITHUB_CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET || "";
+const REQUESTED_SCOPES = "repo read:org read:user";
 
 function assertOAuthCredentials(): void {
   if (!GITHUB_CLIENT_ID || !GITHUB_CLIENT_SECRET) {
@@ -46,7 +47,7 @@ const runtime = withRuntime<Env, typeof StateSchema, Registry>({
       const url = new URL("https://github.com/login/oauth/authorize");
       url.searchParams.set("client_id", GITHUB_CLIENT_ID);
       url.searchParams.set("redirect_uri", redirectUri);
-      url.searchParams.set("scope", "repo read:org read:user");
+      url.searchParams.set("scope", REQUESTED_SCOPES);
 
       if (state) {
         url.searchParams.set("state", state);
@@ -71,7 +72,9 @@ const runtime = withRuntime<Env, typeof StateSchema, Registry>({
         expires_in: tokenResponse.expires_in,
         refresh_token: tokenResponse.refresh_token,
         refresh_token_expires_in: tokenResponse.refresh_token_expires_in,
-        scope: tokenResponse.scope,
+        // GitHub App user-to-server tokens don't echo `scope` — fall back to
+        // the scopes we requested so the mesh can store/display them per RFC 6749 §5.1.
+        scope: tokenResponse.scope || REQUESTED_SCOPES,
       };
     },
 
@@ -90,7 +93,7 @@ const runtime = withRuntime<Env, typeof StateSchema, Registry>({
         expires_in: tokenResponse.expires_in,
         refresh_token: tokenResponse.refresh_token,
         refresh_token_expires_in: tokenResponse.refresh_token_expires_in,
-        scope: tokenResponse.scope,
+        scope: tokenResponse.scope || REQUESTED_SCOPES,
       };
     },
   },


### PR DESCRIPTION
## Summary
GitHub App user-to-server token responses omit the `scope` field, so the `/token` endpoint was forwarding `undefined` and the mesh ended up with `scope: NULL` for every connection. Per RFC 6749 §5.1, `scope` is required in the token response when the granted scope differs from what was requested. Fall back to the scopes we request in the auth URL (`repo read:org read:user`) for both the `authorization_code` and `refresh_token` grant responses so downstream clients can store and display connection permissions.

## Test plan
- [ ] Complete a fresh OAuth flow from Deco studio; verify `SELECT "scope" FROM downstream_tokens ORDER BY "updatedAt" DESC LIMIT 1;` returns a non-null space-separated string
- [ ] Exchange a stored refresh token against `/token` with `grant_type=refresh_token` and confirm the JSON response includes a non-null `scope` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always return a non-null `scope` in GitHub OAuth token responses by falling back to the requested scopes (`repo read:org read:user`) when GitHub omits it. This prevents NULL scopes in downstream storage and lets clients display permissions.

- **Bug Fixes**
  - Added `REQUESTED_SCOPES` and use it in both the authorize URL and token responses (`authorization_code` and `refresh_token`) via `tokenResponse.scope || REQUESTED_SCOPES`, aligning with RFC 6749 §5.1.

<sup>Written for commit 529f06bf5b9731fdcc20740e9d0ab08e0ecdd833. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

