### PR TITLE
fix(github): send User-Agent on all GitHub API calls

### DIFF
--- a/github/server/lib/github-app-auth.ts
+++ b/github/server/lib/github-app-auth.ts
@@ -154,6 +154,7 @@ export async function getAppInstallationToken(): Promise<string> {
         Authorization: `Bearer ${jwt}`,
         Accept: "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "deco-cms-github-mcp",
       },
     },
   );
@@ -186,6 +187,7 @@ export async function getAppInstallationToken(): Promise<string> {
         Authorization: `Bearer ${jwt}`,
         Accept: "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "deco-cms-github-mcp",
       },
     },
   );

--- a/github/server/lib/github-client.ts
+++ b/github/server/lib/github-client.ts
@@ -26,6 +26,7 @@ async function postToGitHub(
     headers: {
       Accept: "application/json",
       "Content-Type": "application/json",
+      "User-Agent": "deco-cms-github-mcp",
     },
     body: JSON.stringify(body),
   });

--- a/github/server/lib/installation-map.ts
+++ b/github/server/lib/installation-map.ts
@@ -124,6 +124,7 @@ export async function captureInstallationMappings(
             Authorization: `Bearer ${token}`,
             Accept: "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "deco-cms-github-mcp",
           },
         },
       );

--- a/github/server/lib/mcp-proxy.ts
+++ b/github/server/lib/mcp-proxy.ts
@@ -29,6 +29,7 @@ function connectUpstreamClient(token: string): Promise<Client> {
       requestInit: {
         headers: {
           Authorization: `Bearer ${token}`,
+          "User-Agent": "deco-cms-github-mcp",
         },
       },
     },


### PR DESCRIPTION
## Summary

Post-deploy of #396, the worker crashed with CF error 1101 on the first `/mcp` request. Wrangler tail showed a 403 from GitHub:

> Request forbidden by administrative rules. Please make sure your request has a User-Agent header

Cloudflare Workers' `fetch` doesn't set a default \`User-Agent\`; Node/k8s did, which hid the issue until the cutover. Added \`User-Agent: deco-cms-github-mcp\` to every outbound GitHub API call: JWT-authed installations list, user installations list, OAuth token exchange/refresh, and the MCP proxy transport.

## Test plan

- [ ] After merge + Deploy GitHub MCP workflow: \`curl -X POST https://github-mcp.decocms.com/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'\` returns a tool list rather than CF 1101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `User-Agent: deco-cms-github-mcp` header to all GitHub API requests to stop 403s in Cloudflare Workers and fix the CF 1101 crash on the first `/mcp` request.

- **Bug Fixes**
  - App installation token requests (`github-app-auth.ts`)
  - Installation mapping fetches (`installation-map.ts`)
  - OAuth token exchange/refresh (`github-client.ts`)
  - MCP proxy upstream calls (`mcp-proxy.ts`)

<sup>Written for commit a2bc3cd1a68c01a18b09154944c39daf66c6b11c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

