### PR TITLE
fix(github): auto-repair missing installation mappings on tool calls

### DIFF
--- a/github/server/lib/installation-map.ts
+++ b/github/server/lib/installation-map.ts
@@ -10,7 +10,11 @@ interface KVNamespaceLike {
   get(key: string): Promise<string | null>;
   put(key: string, value: string): Promise<void>;
   delete(key: string): Promise<void>;
-  list(options?: { prefix?: string; cursor?: string }): Promise<{
+  list(options?: {
+    prefix?: string;
+    cursor?: string;
+    limit?: number;
+  }): Promise<{
     keys: Array<{ name: string }>;
     list_complete: boolean;
     cursor?: string;
@@ -21,6 +25,7 @@ export interface InstallationStore {
   get(installationId: number): Promise<string | undefined>;
   set(installationId: number, connectionId: string): Promise<void>;
   removeByConnection(connectionId: string): Promise<void>;
+  hasAnyForConnection(connectionId: string): Promise<boolean>;
 }
 
 class MemoryInstallationStore implements InstallationStore {
@@ -40,6 +45,13 @@ class MemoryInstallationStore implements InstallationStore {
         this.map.delete(id);
       }
     }
+  }
+
+  async hasAnyForConnection(connectionId: string): Promise<boolean> {
+    for (const conn of this.map.values()) {
+      if (conn === connectionId) return true;
+    }
+    return false;
   }
 }
 
@@ -91,6 +103,14 @@ class KvInstallationStore implements InstallationStore {
       cursor = list_complete ? undefined : nextCursor;
     } while (cursor);
   }
+
+  async hasAnyForConnection(connectionId: string): Promise<boolean> {
+    const { keys } = await this.kv.list({
+      prefix: `connection:${connectionId}:`,
+      limit: 1,
+    });
+    return keys.length > 0;
+  }
 }
 
 const memoryStore = new MemoryInstallationStore();
@@ -99,6 +119,23 @@ export function getInstallationStore(
   kv: KVNamespaceLike | undefined,
 ): InstallationStore {
   return kv ? new KvInstallationStore(kv) : memoryStore;
+}
+
+/**
+ * Opportunistic bootstrap: if this connection has no installation mappings
+ * yet, run captureInstallationMappings. A single KV list() when mappings
+ * already exist (common case), one GitHub API round-trip per installation
+ * when they don't (one-time per connection).
+ *
+ * Safe to call on every MCP request — cheap when already populated.
+ */
+export async function ensureInstallationMappings(
+  token: string,
+  connectionId: string,
+  store: InstallationStore,
+): Promise<void> {
+  if (await store.hasAnyForConnection(connectionId)) return;
+  await captureInstallationMappings(token, connectionId, store);
 }
 
 /**

--- a/github/server/lib/mcp-proxy.ts
+++ b/github/server/lib/mcp-proxy.ts
@@ -14,6 +14,10 @@ import { createTool, type AppContext } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../types/env.ts";
 import { getAppInstallationToken } from "./github-app-auth.ts";
+import {
+  ensureInstallationMappings,
+  getInstallationStore,
+} from "./installation-map.ts";
 
 const DEFAULT_UPSTREAM_URL = "https://api.githubcopilot.com/mcp/";
 
@@ -154,10 +158,23 @@ export function buildUpstreamTools(
       description: toolDef.description || `GitHub tool: ${toolDef.name}`,
       inputSchema: jsonSchemaToZod(toolDef.inputSchema as any),
       execute: async ({ context }, ctx) => {
-        const currentToken = (ctx as unknown as AppContext<Env>).env
-          .MESH_REQUEST_CONTEXT?.authorization;
+        const env = (ctx as unknown as AppContext<Env>).env;
+        const currentToken = env.MESH_REQUEST_CONTEXT?.authorization;
+        const connectionId = env.MESH_REQUEST_CONTEXT?.connectionId;
         if (!currentToken) {
           throw new Error("GitHub authorization token not found");
+        }
+
+        // Repair any connection whose installation mappings are missing
+        // (e.g. first OAuth happened before the User-Agent fix was
+        // deployed, so the original captureInstallationMappings silently
+        // 403'd). Cheap — one KV list() when already populated.
+        if (connectionId) {
+          await ensureInstallationMappings(
+            currentToken,
+            connectionId,
+            getInstallationStore(env.INSTALLATIONS),
+          );
         }
 
         const client = await connectUpstreamClient(currentToken);

--- a/github/server/main.ts
+++ b/github/server/main.ts
@@ -16,7 +16,7 @@ import {
   refreshAccessToken,
 } from "./lib/github-client.ts";
 import {
-  captureInstallationMappings,
+  ensureInstallationMappings,
   getInstallationStore,
 } from "./lib/installation-map.ts";
 import { handleProxiedRequest } from "./lib/mcp-proxy.ts";
@@ -129,7 +129,7 @@ async function getRuntime(): Promise<Runtime> {
             const connectionId = env.MESH_REQUEST_CONTEXT?.connectionId;
             if (token && connectionId) {
               const store = getInstallationStore(env.INSTALLATIONS);
-              await captureInstallationMappings(token, connectionId, store);
+              await ensureInstallationMappings(token, connectionId, store);
             }
           },
           state: StateSchema,


### PR DESCRIPTION
## Context

Confirmed via \`wrangler kv key list\` on the prod \`INSTALLATIONS\` namespace:

\`\`\`
[
  { "name": "triggers:conn_0dviUelZu80E9zZSrAa_v" },
  { "name": "triggers:conn_I1KBBnrohC6orbVqXPIcv" }
]
\`\`\`

Two \`triggers:*\` entries (good — TRIGGER_CONFIGURE populated them) but zero \`installation:*\` entries. Webhook deliveries have been arriving correctly and immediately skipping with \`no mapping for installation=120173638\` because the first OAuth completed before the User-Agent fix was deployed — \`captureInstallationMappings\` silently caught the 403 from \`GET /user/installations\` and never wrote anything.

## Fix

- New \`InstallationStore.hasAnyForConnection(connectionId)\` method — single KV \`list({ prefix: 'connection:<id>:', limit: 1 })\`.
- New \`ensureInstallationMappings()\` wrapper: no-op if the connection already has mappings, otherwise runs the full capture.
- Injected into \`buildUpstreamTools\`' execute path in \`mcp-proxy.ts\` so the next MCP tool call each affected user makes auto-rebuilds their mapping.
- \`onChange\` in \`main.ts\` now uses the \`ensureInstallationMappings\` variant too (same effect for the common path, cheaper for repeat OAuth refreshes).

## Test plan

- [ ] After merge + deploy, issue a single MCP tool call from an already-connected user. Expect \`[Installation] Mapped <id> (<login>) → <connectionId>\` in worker logs.
- [ ] Re-run \`bunx wrangler kv key list --namespace-id c81656fe... --remote\` — should now include \`installation:*\` and \`connection:<id>:*\` entries.
- [ ] Create an issue on a repo where the App is installed. Expect \`[Webhook] → delivery=... event=github.issues.opened …\` followed by \`[Webhook] ✓ delivery=... mesh callback delivered (2xx)\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically rebuilds missing GitHub installation mappings during MCP tool calls, fixing skipped webhooks for affected users without re-auth. Adds a cheap pre-check and only runs the full capture when needed.

- **Bug Fixes**
  - Added `InstallationStore.hasAnyForConnection(connectionId)` using KV `list({ prefix: 'connection:<id>:', limit: 1 })`.
  - Introduced `ensureInstallationMappings(token, connectionId, store)` to capture mappings only when absent.
  - Wired into `buildUpstreamTools` execute in `mcp-proxy.ts`, and switched `main.ts` `onChange` to use it.
  - Addresses cases where `captureInstallationMappings` previously swallowed `403` from `GET /user/installations`, leaving no `installation:*` keys.

<sup>Written for commit ef6e1c9f39f6a3ea1fcce586ad8597a5abe83f0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

