### PR TITLE
fix(github): emit repo under canonical `repo` key so automations match

### DIFF
--- a/github/server/webhook.ts
+++ b/github/server/webhook.ts
@@ -156,6 +156,11 @@ export async function handleGitHubWebhook(
       event: fullEventType,
       subject,
       sender: payload.sender?.login,
+      // `repo` is the canonical key — matches the trigger params schema
+      // defined in trigger-store.ts (`z.object({ repo: z.string() })`) so
+      // Mesh's paramsMatch (strict `data[key] === value`) can filter by
+      // repository. `repository` is kept as an alias for payload clarity.
+      repo: payload.repository?.full_name,
       repository: payload.repository?.full_name,
       action: payload.action,
       payload,


### PR DESCRIPTION
## Context

Full webhook path worked end-to-end — verified in production logs:

\`\`\`
[Webhook] ← delivery=b9903d64… event=issues hook=609463396
[Webhook] → delivery=b9903d64… event=github.issues.opened subject=decocms/studio installation=120173638 connection=conn_LY5860COJlW4bIZqLufd5 sender=viktormarinho action=opened
[Webhook] ✓ delivery=b9903d64… mesh callback delivered (202)
\`\`\`

Mesh accepted with 202 but the matching automation never fired. Confirmed the Studio-side trigger was configured correctly:

\`\`\`
automation.active = true
trigger.event_type = 'github.issues.opened'
trigger.connection_id = 'conn_LY5860COJlW4bIZqLufd5'
trigger.params = {"repo": "decocms/studio"}
\`\`\`

## Root cause

\`EventTriggerEngine.paramsMatch\` in Studio does strict key equality:

\`\`\`ts
return Object.entries(params).every(([key, value]) => data[key] === value);
\`\`\`

So it looked up \`data.repo\` — but our webhook handler was shipping the repo under \`data.repository\`, leaving \`data.repo === undefined\` and the match failed silently.

## Fix

Emit the repo full name under the canonical \`repo\` key (what the trigger params schema in \`trigger-store.ts\` declares). Kept \`repository\` as an alias for downstream consumers that might already depend on it.

## Test plan

- [ ] After deploy, create an issue in \`decocms/studio\`. Expect \`[Webhook] ✓ delivery=… mesh callback delivered (202)\` in worker logs as before, AND a new \`threads\` row in Studio's DB with \`status = in_progress → completed\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GitHub webhook events so the repo is emitted under the canonical `repo` key, allowing automations that filter by `repo` to match. Keeps `repository` as an alias for backward compatibility.

<sup>Written for commit 717388ff3e6101f7855f78b48cbe14344b45a511. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

