### PR TITLE
fix(github): surface GitHub invalid_grant as OAuthInvalidGrantError

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -225,13 +225,14 @@
       "version": "1.0.0",
       "dependencies": {
         "@decocms/bindings": "^1.4.0",
-        "@decocms/runtime": "1.5.0",
+        "@decocms/runtime": "^1.6.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "zod": "^4.0.0",
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251014.0",
         "@decocms/mcps-shared": "1.0.0",
+        "@types/bun": "^1.2.14",
         "@types/node": "^22.0.0",
         "typescript": "^5.7.2",
         "wrangler": "^4.28.0",
@@ -3982,7 +3983,7 @@
 
     "github/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
-    "github/@decocms/runtime": ["@decocms/runtime@1.5.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-TVwuutWjghkDtt/6ylxXyUEgbjDA8xg9tjnMZ3kq3DO1RfhTuaAW0YKuf6AJPN+aYno89VSQ8HBVJ7phwIelpw=="],
+    "github/@decocms/runtime": ["@decocms/runtime@1.6.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-iVRp3yUvPd5x1nQ+WbsTOHA3KKBRMq6kGnJLoV1oyjIFm1uyxK69IihnYp1B49sQxlWAfPAJco3AZ8TuvF3T6A=="],
 
     "github/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 

--- a/github/package.json
+++ b/github/package.json
@@ -7,18 +7,20 @@
   "scripts": {
     "dev": "bunx wrangler dev",
     "check": "tsc --noEmit",
+    "test": "bun test",
     "build": "bunx wrangler deploy --dry-run --outdir=dist",
     "deploy": "bunx wrangler deploy"
   },
   "dependencies": {
     "@decocms/bindings": "^1.4.0",
-    "@decocms/runtime": "1.5.0",
+    "@decocms/runtime": "^1.6.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "zod": "^4.0.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251014.0",
     "@decocms/mcps-shared": "1.0.0",
+    "@types/bun": "^1.2.14",
     "@types/node": "^22.0.0",
     "typescript": "^5.7.2",
     "wrangler": "^4.28.0"

--- a/github/server/lib/github-client.test.ts
+++ b/github/server/lib/github-client.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { OAuthInvalidGrantError } from "@decocms/runtime";
+import { refreshAccessToken } from "./github-client.ts";
+
+const realFetch = globalThis.fetch;
+
+type FetchMock = (
+  input: Request | URL | string,
+  init?: RequestInit,
+) => Promise<Response>;
+
+function mockFetch(impl: FetchMock) {
+  globalThis.fetch = impl as typeof globalThis.fetch;
+}
+
+describe("refreshAccessToken", () => {
+  beforeEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  test("throws OAuthInvalidGrantError when GitHub returns 200 with error=invalid_grant", async () => {
+    mockFetch(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: "invalid_grant",
+            error_description:
+              "The refresh token has expired or has been revoked",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    let caught: unknown;
+    try {
+      await refreshAccessToken("rt", "client_id", "client_secret");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(OAuthInvalidGrantError);
+    const typed = caught as OAuthInvalidGrantError;
+    expect(typed.error).toBe("invalid_grant");
+    expect(typed.errorDescription).toBe(
+      "The refresh token has expired or has been revoked",
+    );
+  });
+
+  test("throws OAuthInvalidGrantError when GitHub returns error=bad_refresh_token", async () => {
+    mockFetch(
+      async () =>
+        new Response(JSON.stringify({ error: "bad_refresh_token" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    let caught: unknown;
+    try {
+      await refreshAccessToken("rt", "client_id", "client_secret");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(OAuthInvalidGrantError);
+    expect((caught as OAuthInvalidGrantError).error).toBe("bad_refresh_token");
+  });
+
+  test("throws OAuthInvalidGrantError on 400 invalid_grant", async () => {
+    mockFetch(
+      async () =>
+        new Response(JSON.stringify({ error: "invalid_grant" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    let caught: unknown;
+    try {
+      await refreshAccessToken("rt", "client_id", "client_secret");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(OAuthInvalidGrantError);
+  });
+
+  test("throws plain Error (not OAuthInvalidGrantError) on 5xx", async () => {
+    mockFetch(
+      async () =>
+        new Response("Bad Gateway", {
+          status: 502,
+          headers: { "Content-Type": "text/plain" },
+        }),
+    );
+
+    let caught: unknown;
+    try {
+      await refreshAccessToken("rt", "client_id", "client_secret");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).not.toBeInstanceOf(OAuthInvalidGrantError);
+  });
+
+  test("propagates plain Error on network failure", async () => {
+    mockFetch(async () => {
+      throw new Error("network down");
+    });
+
+    let caught: unknown;
+    try {
+      await refreshAccessToken("rt", "client_id", "client_secret");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).not.toBeInstanceOf(OAuthInvalidGrantError);
+    expect((caught as Error).message).toBe("network down");
+  });
+
+  test("returns token response on success", async () => {
+    mockFetch(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: "new-access",
+            token_type: "Bearer",
+            expires_in: 28800,
+            refresh_token: "new-refresh",
+            refresh_token_expires_in: 15897600,
+            scope: "repo",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    const result = await refreshAccessToken("rt", "client_id", "client_secret");
+
+    expect(result.access_token).toBe("new-access");
+    expect(result.refresh_token).toBe("new-refresh");
+    expect(result.scope).toBe("repo");
+  });
+});

--- a/github/server/lib/github-client.ts
+++ b/github/server/lib/github-client.ts
@@ -2,6 +2,8 @@
  * GitHub OAuth helpers
  */
 
+import { OAuthInvalidGrantError } from "@decocms/runtime";
+
 export interface GitHubTokenResponse {
   access_token: string;
   token_type: string;
@@ -83,16 +85,63 @@ export function exchangeCodeForToken(
 /**
  * Exchange a refresh token for a new access token.
  * Only works for GitHub Apps that issue expiring user tokens.
+ *
+ * Throws `OAuthInvalidGrantError` for the spec-compliant permanent-failure
+ * cases (`invalid_grant` / `bad_refresh_token`) so the runtime's `/token`
+ * handler can map it to `400 invalid_grant` and let mesh evict the cached
+ * refresh_token. Anything else (5xx, network, malformed body) propagates
+ * as a plain `Error` and surfaces as `500` — treated as transient by mesh.
  */
-export function refreshAccessToken(
+export async function refreshAccessToken(
   refreshToken: string,
   clientId: string,
   clientSecret: string,
 ): Promise<GitHubTokenResponse> {
-  return postToGitHub({
-    client_id: clientId,
-    client_secret: clientSecret,
-    grant_type: "refresh_token",
-    refresh_token: refreshToken,
+  const response = await fetch(GITHUB_TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "User-Agent": "deco-cms-github-mcp",
+    },
+    body: JSON.stringify({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
   });
+
+  // Per RFC 6749 §5.2 the canonical signal is the body's `error` field, not
+  // the HTTP status — and GitHub historically returns `200 { error: "..." }`
+  // when `Accept: application/json` is set. Read the body before branching
+  // on status so we can recognise the typed error in either shape.
+  const data = (await response.json().catch(() => ({}))) as
+    | RawGitHubTokenResponse
+    | Record<string, never>;
+
+  if (data.error === "invalid_grant" || data.error === "bad_refresh_token") {
+    throw new OAuthInvalidGrantError(data.error, data.error_description);
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub OAuth failed: ${response.status} - ${data.error ?? "unknown"}`,
+    );
+  }
+
+  if (data.error) {
+    throw new Error(
+      `GitHub OAuth error: ${data.error_description || data.error}`,
+    );
+  }
+
+  return {
+    access_token: data.access_token,
+    token_type: data.token_type || "Bearer",
+    expires_in: data.expires_in,
+    refresh_token: data.refresh_token,
+    refresh_token_expires_in: data.refresh_token_expires_in,
+    scope: data.scope,
+  };
 }

--- a/github/tsconfig.json
+++ b/github/tsconfig.json
@@ -24,7 +24,8 @@
     /* Types */
     "types": [
       "@types/node",
-      "@cloudflare/workers-types"
+      "@cloudflare/workers-types",
+      "bun"
     ]
   },
   "include": [


### PR DESCRIPTION
## Summary

- When GitHub responds to a refresh-token exchange with `invalid_grant` or `bad_refresh_token`, throw the typed `OAuthInvalidGrantError` from `@decocms/runtime` instead of a generic `Error`. The runtime's `/token` handler maps it to a spec-compliant `400 invalid_grant`, which lets mesh evict the dead refresh_token and prompt the user to reconnect.
- Transient failures (5xx, network, malformed body) keep throwing a plain `Error` and surface as `500`, so mesh leaves the cached row intact for retry — fixes the bug where revoked installations couldn't be cleaned up because everything was being laundered into 500s.
- Bumps `@decocms/runtime` to `^1.6.0` (the version that exports `OAuthInvalidGrantError`).

## Context

Pairs with [decocms/studio#3201](https://github.com/decocms/studio/pull/3201). The studio side now only deletes cached tokens on a spec-compliant `400 invalid_grant`; this PR makes this Worker throw the typed error so the studio can recognise real revocations.

Per RFC 6749 §5.2 the canonical signal is the body's `error` field, not the HTTP status — and GitHub historically returns `200 { error: "..." }` when `Accept: application/json` is set. The new code reads the body before branching on status so it recognises the typed error in either shape, and treats `bad_refresh_token` as equivalent to `invalid_grant` since GitHub uses both.

`exchangeCode`, `authorizationUrl`, scopes, `/register`, callback handling, and webhook flow are all untouched per the task spec — the bug is purely in error-shape propagation, not in the OAuth flow itself.

## Test plan

- [x] Unit tests in `github/server/lib/github-client.test.ts` cover:
  - `200 { error: "invalid_grant" }` → throws `OAuthInvalidGrantError` with `error_description` propagated
  - `200 { error: "bad_refresh_token" }` → throws `OAuthInvalidGrantError`
  - `400 { error: "invalid_grant" }` → throws `OAuthInvalidGrantError`
  - `502` upstream → throws plain `Error` (not `OAuthInvalidGrantError`)
  - Network failure → propagates plain `Error` (not `OAuthInvalidGrantError`)
  - Successful refresh → returns the parsed token response
- [x] `bun test`, `tsc --noEmit`, `oxfmt --check`, `oxlint` all clean for this workspace
- [ ] After deploy + studio rollout: revoke a test GitHub App installation, hit mesh, verify the row is deleted and the user gets the reconnect prompt
- [ ] Cause a transient 5xx and verify the row is preserved and the next request retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces GitHub refresh-token errors (`invalid_grant`/`bad_refresh_token`) as `OAuthInvalidGrantError` so the `/token` route returns a spec-compliant 400 invalid_grant. This lets mesh evict dead refresh tokens and prompt a reconnect; transient failures still bubble as 500 for retry.

- **Bug Fixes**
  - Parse the JSON body before checking status to catch GitHub’s `200 { error: ... }` shape.
  - Map `invalid_grant` and `bad_refresh_token` to `OAuthInvalidGrantError`; other failures throw a plain `Error`.
  - Added tests for success, invalid_grant/bad_refresh_token, 400, 5xx, and network errors.

- **Dependencies**
  - Bumped `@decocms/runtime` to `^1.6.0` to use `OAuthInvalidGrantError`.
  - Added `@types/bun` and included Bun types in `tsconfig`.

<sup>Written for commit e2d7d2c48b742eb4f054d99a79e72c36a8a51c37. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/mcps/pull/405?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

