### PR TITLE
feat(discord): add DEBUG_ERRORS_TO_CHAT flag and richer error logs

### DIFF
--- a/discord-read/server/discord/handlers/messageHandler.ts
+++ b/discord-read/server/discord/handlers/messageHandler.ts
@@ -314,6 +314,9 @@ async function handleDefaultAgent(
 
   logger.info("Processing AI agent request", {
     trace_id: traceId,
+    connectionId: env.MESH_REQUEST_CONTEXT?.connectionId,
+    botUserId: message.client.user?.id,
+    botTag: message.client.user?.tag,
     messageId: message.id,
     guildId: message.guild?.id,
     guildName: message.guild?.name,
@@ -597,6 +600,9 @@ async function handleDefaultAgent(
   } catch (error) {
     logger.error("AI agent error", {
       trace_id: traceId,
+      connectionId: env.MESH_REQUEST_CONTEXT?.connectionId,
+      botUserId: message.client.user?.id,
+      botTag: message.client.user?.tag,
       messageId: message.id,
       guildId: message.guild?.id,
       channelId: message.channel.id,
@@ -634,8 +640,20 @@ async function handleDefaultAgent(
       errorResponse = `⚠️ Bot não está totalmente inicializado. Tente novamente em alguns segundos.`;
     } else if (errorMsg.includes("timed out") || errorMsg.includes("aborted")) {
       errorResponse = `⏱️ A requisição demorou muito. Tente novamente.`;
+    } else if (
+      errorMsg.toLowerCase().includes("agent not configured") ||
+      errorMsg.includes("AGENT binding")
+    ) {
+      errorResponse = `🔧 O agente de IA não está configurado nesta conexão. Avise o admin.`;
     } else {
       errorResponse = `❌ Erro ao processar sua mensagem.`;
+    }
+
+    // Diagnostic flag: append underlying error to chat for active debugging.
+    // Why: the catch-all above hides the real cause. Operators need a fast loop.
+    // How to apply: set DEBUG_ERRORS_TO_CHAT=true in the connection's StateSchema.
+    if (env.MESH_REQUEST_CONTEXT?.state?.DEBUG_ERRORS_TO_CHAT) {
+      errorResponse += `\n\`\`\`\n${errorMsg.slice(0, 500)}\n\`\`\``;
     }
 
     // Update thinking message with error, or send new message

--- a/discord-read/server/types/env.ts
+++ b/discord-read/server/types/env.ts
@@ -146,6 +146,14 @@ export const StateSchema = z.object({
     .describe(
       "HyperDX API key for advanced logging and observability. If not provided, logs will only go to stdout.",
     ),
+
+  // Diagnostics
+  DEBUG_ERRORS_TO_CHAT: z
+    .boolean()
+    .default(false)
+    .describe(
+      "When true, append the underlying error message to the user-facing reply when the bot fails. Use only when actively debugging — exposes internal details.",
+    ),
 });
 
 export type Env = DefaultEnv<typeof StateSchema, Registry>;


### PR DESCRIPTION
## Summary
Diagnostic-flag for the Discord bot to surface the underlying error directly in the chat reply, plus richer log fields and a dedicated "Agent not configured" branch. Built to debug the recurring `❌ Erro ao processar sua mensagem.` 3x reply in production.

- New `DEBUG_ERRORS_TO_CHAT` boolean in `StateSchema`. Default `false`. When set to `true` on a connection, the user-facing reply appends the first 500 chars of `error.message` inside a markdown code block.
- New error branch: messages containing "agent not configured" or "AGENT binding" now reply `🔧 O agente de IA não está configurado nesta conexão. Avise o admin.` instead of the catch-all generic.
- `Processing AI agent request` and `AI agent error` log lines now carry `connectionId`, `botUserId` and `botTag` so it's possible to grep "which bot fired this" across pod logs.

## How to use
1. Deploy `discord-read`.
2. In the Mesh UI for the broken connection, set `DEBUG_ERRORS_TO_CHAT = true`.
3. Mention the bot from Discord. The next error reply contains the actual exception in a code block.
4. Disable the flag once diagnosed.

## Test plan
- [ ] Deploy and confirm the bot still answers normal mentions when the flag is off (no behaviour change).
- [ ] Toggle the flag on a connection where the bot is currently failing; confirm the reply contains the underlying error.
- [ ] Toggle the flag off; confirm the reply reverts to the generic message.
- [ ] In Lens, confirm the new log fields (`connectionId`, `botUserId`, `botTag`) appear on `Processing AI agent request`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a debug flag to surface underlying errors in Discord replies and enriches logs with connection and bot identifiers. Also adds a clear “agent not configured” reply.

- **New Features**
  - `DEBUG_ERRORS_TO_CHAT` in `StateSchema` (default `false`): when `true`, appends the first 500 chars of `error.message` in a code block to the user reply.
  - Specific reply for unconfigured agent errors: “🔧 O agente de IA não está configurado nesta conexão. Avise o admin.”
  - Logs for “Processing AI agent request” and “AI agent error” now include `connectionId`, `botUserId`, and `botTag`.

- **Migration**
  - No behavior change by default. To debug, enable `DEBUG_ERRORS_TO_CHAT` on the connection and disable it after diagnosis.

<sup>Written for commit 2a8abc2d7832862187e90720f25e40be6ecbd228. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/mcps/pull/406?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

