### PR TITLE
fix(discord): order connections by updated_at + log pod hostname

### DIFF
--- a/discord-read/server/lib/supabase-client.ts
+++ b/discord-read/server/lib/supabase-client.ts
@@ -172,7 +172,15 @@ export async function loadAllConnectionConfigs(): Promise<
     throw new Error("Supabase client not initialized");
   }
 
-  const { data, error } = await client.from("discord_connections").select("*");
+  // Order by updated_at DESC so the most recently saved config wins when
+  // multiple rows share the same bot_token. The bootstrap dedups by token
+  // and picks the first row it sees as "owner"; without ordering, Postgres
+  // returns rows in physical order which is non-deterministic. With this
+  // ordering the freshest, fully-configured row always becomes the owner.
+  const { data, error } = await client
+    .from("discord_connections")
+    .select("*")
+    .order("updated_at", { ascending: false });
 
   if (error) {
     throw new Error(`Failed to load configs: ${error.message}`);

--- a/discord-read/server/main.ts
+++ b/discord-read/server/main.ts
@@ -36,6 +36,7 @@ const INSTANCE_ID = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 console.log("=".repeat(80));
 console.log("[STARTUP] Discord MCP Server initializing...");
 console.log(`[STARTUP] Instance ID: ${INSTANCE_ID}`);
+console.log(`[STARTUP] K8s pod: ${process.env.HOSTNAME || "n/a"}`);
 console.log(`[STARTUP] Node.js version: ${process.version}`);
 console.log(`[STARTUP] Bun version: ${Bun.version}`);
 console.log(`[STARTUP] NODE_ENV: ${process.env.NODE_ENV || "not set"}`);


### PR DESCRIPTION
## Summary
Two small follow-up changes after the diagnostic flag PR (#406). Together they make the bootstrap deterministic and pod logs traceable, and they trigger a deploy that scales `discord-read` down to a single pod (the operational fix for the recent triple-reply incident).

### `loadAllConnectionConfigs` orders by `updated_at DESC`
The bootstrap deduplicates by `bot_token` and picks the **first** row it sees as the "owner" instance for that bot's client. Without an `ORDER BY`, Postgres returns rows in physical order — which is non-deterministic across calls. When duplicate rows existed for the same bot_token (e.g., from interrupted save flows in the Mesh UI), each pod could randomly land on a half-saved orphan with no AGENT binding, producing the "Agent not configured" error sporadically. Ordering by `updated_at DESC` guarantees the freshest, fully-configured row always wins.

### Startup banner prints `K8s pod: $HOSTNAME`
Lens cross-pod log filtering becomes trivial.

## Context (incident)
Today's symptom was the bot replying 3× to a single `@bot` mention, with two of the replies hitting the new "Agent not configured" branch and one hitting the catch-all. Root cause was 3 K8s replicas + duplicate orphan rows in `discord_connections`, leading each pod to randomly pick a different orphan as the bootstrap owner. Database has been cleaned up; this deploy will scale to 1 replica and start a fresh pod with a deterministic owner selection.

## Test plan
- [ ] Deploy and confirm the pod count settles to 1.
- [ ] Mention the bot from Discord; expect a single reply (or a single deterministic error).
- [ ] In Lens, confirm `[STARTUP] K8s pod: <pod-name>` is printed and matches `kubectl get pods`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Order `discord_connections` by `updated_at DESC` to make the Discord bootstrap deterministic, and print the K8s pod hostname on startup for easier cross‑pod log tracing. This prevents stale configs from being selected when duplicate `bot_token` rows exist.

<sup>Written for commit 8e28a682bf9fb8e0ca9e6460600416aabb5e13c5. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/mcps/pull/407?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

