### PR TITLE
feat(discord): persist full StateSchema to discord_connections.state

### DIFF
--- a/discord-read/server/lib/config-cache.ts
+++ b/discord-read/server/lib/config-cache.ts
@@ -28,6 +28,11 @@ export interface DiscordConfig {
   authorizedGuilds?: string[]; // List of guild IDs that can use this bot
   ownerId?: string; // Discord user ID of the bot owner
   commandPrefix?: string; // Command prefix (default: "!")
+  // Full StateSchema snapshot (excluding bindings like AGENT/CONNECTION).
+  // Used to rebuild env.MESH_REQUEST_CONTEXT.state on pod restart so fields
+  // like CONTEXT_CONFIG, RESPONSE_CONFIG, BOT_SUPER_ADMINS, ALLOW_DM, etc.
+  // survive without waiting for Mesh onChange to fire.
+  state?: Record<string, unknown>;
   configuredAt?: string;
   updatedAt?: string;
 }
@@ -75,6 +80,7 @@ export async function getDiscordConfig(
     authorizedGuilds: row.authorized_guilds || undefined,
     ownerId: row.owner_id || undefined,
     commandPrefix: row.command_prefix || "!",
+    state: row.state ?? undefined,
     configuredAt: row.configured_at,
     updatedAt: row.updated_at,
   };

--- a/discord-read/server/lib/supabase-client.ts
+++ b/discord-read/server/lib/supabase-client.ts
@@ -23,6 +23,9 @@ export interface DiscordConnectionRow {
   authorized_guilds: string[] | null; // Array of guild IDs
   owner_id: string | null; // Discord user ID of bot owner
   command_prefix: string;
+  // Full StateSchema snapshot (excluding bindings). Lets the bot rebuild its
+  // runtime state on pod restart without waiting for Mesh onChange to fire.
+  state: Record<string, unknown> | null;
   configured_at: string;
   updated_at: string;
 }
@@ -93,6 +96,7 @@ export async function saveConnectionConfig(config: {
   authorizedGuilds?: string[];
   ownerId?: string;
   commandPrefix?: string;
+  state?: Record<string, unknown>; // Full StateSchema snapshot (no bindings)
 }): Promise<void> {
   const client = getSupabaseClient();
   if (!client) {
@@ -114,6 +118,7 @@ export async function saveConnectionConfig(config: {
     authorized_guilds: config.authorizedGuilds || null,
     owner_id: config.ownerId || null,
     command_prefix: config.commandPrefix || "!",
+    state: config.state ?? null,
     configured_at: now,
     updated_at: now,
   };

--- a/discord-read/server/main.ts
+++ b/discord-read/server/main.ts
@@ -48,6 +48,33 @@ console.log("=".repeat(80));
 const AUTO_RESTART_INTERVAL_MS = 60 * 60 * 1000;
 let autoRestartInterval: ReturnType<typeof setInterval> | null = null;
 
+// Keys in StateSchema that come from runtime bindings, not config — these
+// can't be JSON-serialized and must NOT be persisted to Supabase.
+const STATE_BINDING_KEYS = new Set(["CONNECTION", "AGENT"]);
+
+/**
+ * Extract a JSON-serializable snapshot of the current Mesh state, excluding
+ * bindings (CONNECTION, AGENT) which are runtime-only proxies. Persisted to
+ * `discord_connections.state` so a fresh pod can rebuild MESH_REQUEST_CONTEXT
+ * without waiting for the next onChange.
+ */
+function extractPersistableState(
+  state: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!state) return {};
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(state)) {
+    if (STATE_BINDING_KEYS.has(key)) continue;
+    try {
+      JSON.stringify(value);
+      out[key] = value;
+    } catch {
+      // skip non-serializable values
+    }
+  }
+  return out;
+}
+
 const runtime = withRuntime<Env, typeof StateSchema, Registry>({
   configuration: {
     onChange: async (env) => {
@@ -148,6 +175,8 @@ const runtime = withRuntime<Env, typeof StateSchema, Registry>({
           }
         }
 
+        const persistableState = extractPersistableState(state);
+
         const configToSave: DiscordConfig = {
           ...(existingConfig || {}),
           connectionId: mergedConnectionId,
@@ -165,6 +194,7 @@ const runtime = withRuntime<Env, typeof StateSchema, Registry>({
               : existingConfig?.authorizedGuilds,
           ownerId: botOwnerId || existingConfig?.ownerId,
           commandPrefix,
+          state: persistableState,
           updatedAt: new Date().toISOString(),
         };
 
@@ -354,7 +384,12 @@ async function bootstrapFromSupabase(): Promise<void> {
         commandPrefix: row.command_prefix || "!",
       });
 
-      // Build a synthetic env so ensureBotRunning can resolve the token
+      // Build a synthetic env so ensureBotRunning can resolve the token.
+      // state is restored from row.state (the StateSchema snapshot persisted
+      // on the last onChange). Bindings (AGENT, CONNECTION) stay missing
+      // until the real onChange re-injects them — but everything else
+      // (CONTEXT_CONFIG, RESPONSE_CONFIG, BOT_SUPER_ADMINS, ALLOW_DM,
+      // DEBUG_ERRORS_TO_CHAT, ...) is available immediately.
       const syntheticEnv = {
         MESH_REQUEST_CONTEXT: {
           connectionId,
@@ -362,7 +397,7 @@ async function bootstrapFromSupabase(): Promise<void> {
           meshUrl,
           token: meshApiKey || undefined,
           authorization: `Bearer ${row.bot_token}`,
-          state: {},
+          state: row.state ?? {},
         },
       } as unknown as Env;
 


### PR DESCRIPTION
## Summary
Round-trip the full Mesh `StateSchema` through `discord_connections.state` (a new JSONB column, DDL already applied in production) so admin-configured fields survive pod restarts.

## Why
Today only 5 of ~15 StateSchema fields are persisted to typed columns in `discord_connections`. The rest — `CONTEXT_CONFIG`, `RESPONSE_CONFIG`, `BOT_SUPER_ADMINS`, `ALLOW_DM`, `DM_ALLOWED_USERS`, `HYPERDX_API_KEY`, `DEBUG_ERRORS_TO_CHAT`, etc. — only live in Mesh runtime state. When `bootstrapFromSupabase` rehydrates a connection on pod startup it builds `syntheticEnv.state = {}`, so any of those fields is effectively missing until the user re-opens the Mesh admin UI and re-saves the connection (which fires `onChange` with the real state).

This caused real pain in today's incident: the new `DEBUG_ERRORS_TO_CHAT` flag the operator enabled in Mesh UI never made it to two of the three replying pods, because their bootstrap state was empty and only one pod saw the post-save `onChange`.

## Changes
- **`server/lib/supabase-client.ts`**: Add `state: Record<string, unknown> | null` to `DiscordConnectionRow` and to `saveConnectionConfig`'s parameter; write it on upsert.
- **`server/lib/config-cache.ts`**: Add `state?: Record<string, unknown>` to `DiscordConfig`; map `row.state` on read.
- **`server/main.ts`**:
  - New `extractPersistableState` helper: drops `CONNECTION` / `AGENT` bindings (runtime-only, non-serializable) and keeps anything that survives `JSON.stringify`.
  - `onChange` writes `state: extractPersistableState(state)` into the saved config so every Mesh save updates the column.
  - `bootstrapFromSupabase` populates `syntheticEnv.state = row.state ?? {}` instead of `{}`.

## Backwards compatibility
- Existing rows have `state IS NULL`. Bootstrap falls back to `{}` for those — same behaviour as before. The next time the user touches that connection in Mesh UI, `onChange` writes the column.
- Typed columns (`bot_token`, `mesh_url`, `mesh_api_key`, `discord_public_key`, `discord_application_id`, `authorized_guilds`, `owner_id`, `command_prefix`) are unchanged. They remain the source of truth for routing/auth fields that bootstrap needs to read before parsing state.
- No migration. No DDL in this PR — DDL was applied manually in production already.

## Test plan
- [ ] Deploy and confirm bootstrap logs do not error when row.state is null (existing rows).
- [ ] Edit any field in Mesh UI for an existing connection (e.g. toggle `DEBUG_ERRORS_TO_CHAT`), save, then check `SELECT state FROM discord_connections WHERE connection_id = ?` — confirm the new shape.
- [ ] Force a pod restart (or scale to 0 then 1). Send `@bot oi`. Confirm the previously-saved `state` fields take effect immediately (no need to re-open Mesh UI).
- [ ] Verify `state` does NOT contain `AGENT` or `CONNECTION` keys (those would be useless and would log noisy serialization errors).

## Follow-ups (not in this PR)
- Bootstrap currently doesn't replay all the side effects that `onChange` does (super admins set per-instance, HyperDX API key configured). After this PR, the data is there to drive those — a small follow-up can extract the side-effect block from `onChange` and run it from bootstrap too.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the full Mesh `StateSchema` snapshot to `discord_connections.state` and load it on boot so admin-configured flags survive pod restarts and stay consistent across pods.

- **New Features**
  - Save a JSON-serializable `state` snapshot on each `onChange` via `extractPersistableState` (drops `AGENT`/`CONNECTION`).
  - Rehydrate `syntheticEnv.state` from `row.state ?? {}` during bootstrap so fields like `DEBUG_ERRORS_TO_CHAT` apply immediately after restarts.
  - Add `state` to `DiscordConnectionRow`, `DiscordConfig`, and `saveConnectionConfig` upsert; backward compatible for NULL rows and no migration in this PR.

<sup>Written for commit 3ccacab454fcdfcbf909ae8e36b592fbba847ebb. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/mcps/pull/408?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

