### PR TITLE
fix(dropbox): accept raw or Bearer-prefixed mesh authorization token

### DIFF
--- a/dropbox/server/lib/dropbox-client.ts
+++ b/dropbox/server/lib/dropbox-client.ts
@@ -39,11 +39,8 @@ export function getAccessToken(env: Env): string {
       "Missing authorization header. Please authenticate with Dropbox first.",
     );
   }
-  const match = auth.match(/^Bearer\s+(.+)$/i);
-  if (!match || !match[1].trim()) {
-    throw new Error("Invalid authorization header. Expected Bearer token.");
-  }
-  return match[1].trim();
+  // Mesh may deliver the token raw or with a "Bearer " prefix — strip if present.
+  return auth.replace(/^Bearer\s+/i, "").trim();
 }
 
 /** Convenience for tool execute(): pull env off the AppContext ctx arg. */


### PR DESCRIPTION
## Summary
- The mesh runtime delivers the OAuth access token in `MESH_REQUEST_CONTEXT.authorization` *without* a `Bearer ` prefix, so the strict `^Bearer\s+(.+)$` match in `getAccessToken()` was rejecting valid tokens with `Invalid authorization header. Expected Bearer token.` after a successful OAuth flow.
- Switch to the canonical pattern used by the other OAuth MCPs in this repo (gmail, drive, calendar, slides): strip the `Bearer ` prefix only if present, otherwise use the value as-is.

## Test plan
- [ ] After deploy, run `dropbox_list_folder` with `{ "path": "" }` against an authenticated connection — should return folder contents instead of the auth error.
- [ ] Verify other Dropbox tools (`dropbox_search`, `dropbox_get_metadata`, etc.) still work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept Dropbox OAuth tokens with or without the "Bearer " prefix to stop false “Invalid authorization header” errors after a successful OAuth flow. Matches token handling used in the other OAuth MCPs.

- **Bug Fixes**
  - Relaxed `getAccessToken()` to strip an optional `Bearer ` prefix.
  - Handles raw tokens from `MESH_REQUEST_CONTEXT.authorization`.

<sup>Written for commit 5d495f9a72e5eb76a5fa669a8dc16b08d93809c8. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/mcps/pull/410?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

