### PR TITLE
feat(vtex): add VTEX_UPDATE_PRODUCT_SPECIFICATIONS tool

### DIFF
--- a/vtex/server/tools/custom/update-product-specifications.ts
+++ b/vtex/server/tools/custom/update-product-specifications.ts
@@ -1,0 +1,75 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { resolveCredentials } from "../../lib/client-factory.ts";
+import type { Env } from "../../types/env.ts";
+
+const inputSchema = z.object({
+  productId: z.coerce.number().int().positive().describe("Catalog product ID."),
+  specifications: z
+    .array(
+      z.object({
+        Id: z.coerce
+          .number()
+          .int()
+          .positive()
+          .describe(
+            "FieldId of the specification (e.g. 109 for 'Descrição DECO'). Must already exist in the product's category — VTEX rejects unknown FieldIds. Specs never previously written are not returned by VTEX_GET_PRODUCT_SPECIFICATIONS, so the caller must know the FieldId.",
+          ),
+        Value: z
+          .array(z.string())
+          .describe("Values to write. For free-text specs, pass [text]."),
+        Text: z
+          .string()
+          .optional()
+          .describe(
+            "Optional flat text version of the value; some VTEX clients require it.",
+          ),
+      }),
+    )
+    .describe(
+      "Complete spec set to write. Replaces the entire collection of the product's specs — anything not included is removed. To patch, call VTEX_GET_PRODUCT_SPECIFICATIONS, merge, and pass the result here.",
+    ),
+});
+
+const outputSchema = z.object({
+  ok: z.literal(true),
+  productId: z.number().int().positive(),
+});
+
+export const updateProductSpecifications = (env: Env) =>
+  createTool({
+    id: "VTEX_UPDATE_PRODUCT_SPECIFICATIONS",
+    description:
+      "Replace all specifications for a product (bulk PUT). Pass the complete set — values not included are removed. Caller does GET → merge → PUT for partial updates. Counterpart of VTEX_GET_PRODUCT_SPECIFICATIONS.",
+    inputSchema,
+    outputSchema,
+    execute: async ({ context }) => {
+      const credentials = resolveCredentials(env.MESH_REQUEST_CONTEXT.state);
+      const url = `https://${credentials.accountName}.vtexcommercestable.com.br/api/catalog/pvt/product/${context.productId}/specification`;
+      console.log("[VTEX] PUT", url);
+
+      const response = await fetch(url, {
+        method: "PUT",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          ...(credentials.appKey
+            ? { "X-VTEX-API-AppKey": credentials.appKey }
+            : {}),
+          ...(credentials.appToken
+            ? { "X-VTEX-API-AppToken": credentials.appToken }
+            : {}),
+        },
+        body: JSON.stringify(context.specifications),
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(
+          `VTEX update product specifications failed (${response.status}): ${body}`,
+        );
+      }
+
+      return { ok: true as const, productId: context.productId };
+    },
+  });

--- a/vtex/server/tools/index.ts
+++ b/vtex/server/tools/index.ts
@@ -83,6 +83,7 @@ import {
 // ── Custom tools ──────────────────────────────────────────────────────────────
 import { searchCollections } from "./custom/search-collections.ts";
 import { reorderCollection } from "./custom/reorder-collection.ts";
+import { updateProductSpecifications } from "./custom/update-product-specifications.ts";
 
 // ── Tool registry factories (env: Env) => Tool ────────────────────────────────
 const registryFactories = [
@@ -165,6 +166,8 @@ const customFactories = [
   searchCollections,
   // Collection overwrite/reorder via XML import flow
   reorderCollection,
+  // Bulk replace product specifications (PUT v2, missing from generated SDK)
+  updateProductSpecifications,
 ];
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

Adds `VTEX_UPDATE_PRODUCT_SPECIFICATIONS` — the write counterpart of `VTEX_GET_PRODUCT_SPECIFICATIONS`. Maps to `PUT /api/catalog/pvt/product/{productId}/specification` (Catalog API v2, bulk replace). Ships as a custom tool because the endpoint exists in VTEX docs but is missing from the auto-generated OpenAPI SDK. Replaces the entire spec set, propagates VTEX HTTP errors with status + body, idempotent. Caller is responsible for GET → merge → PUT for partial updates.

## Test plan

- [ ] Smoke test direct via curl: `PUT /api/catalog/pvt/product/<id>/specification` with `[{Id, Value, Text}]` body
- [ ] Round-trip via MCP: `VTEX_GET_PRODUCT_SPECIFICATIONS` → merge new value → `VTEX_UPDATE_PRODUCT_SPECIFICATIONS` → `VTEX_GET_PRODUCT_SPECIFICATIONS` again to confirm new value persisted and other specs preserved
- [ ] Error path: invalid `Id` → expect thrown error with VTEX status + body
- [ ] Idempotency: same payload twice → identical state

🤖 Generated with [Claude Code](https://claude.com/claude-code)