### PR TITLE
fix(vtex): use catalog_system POST endpoint for product specifications

### DIFF
--- a/vtex/server/tools/custom/update-product-specifications.ts
+++ b/vtex/server/tools/custom/update-product-specifications.ts
@@ -40,16 +40,16 @@ export const updateProductSpecifications = (env: Env) =>
   createTool({
     id: "VTEX_UPDATE_PRODUCT_SPECIFICATIONS",
     description:
-      "Replace all specifications for a product (bulk PUT). Pass the complete set — values not included are removed. Caller does GET → merge → PUT for partial updates. Counterpart of VTEX_GET_PRODUCT_SPECIFICATIONS.",
+      "Replace all specifications for a product. Pass the complete set — values not included are removed. Caller does GET → merge → POST for partial updates. Counterpart of VTEX_GET_PRODUCT_SPECIFICATIONS.",
     inputSchema,
     outputSchema,
     execute: async ({ context }) => {
       const credentials = resolveCredentials(env.MESH_REQUEST_CONTEXT.state);
-      const url = `https://${credentials.accountName}.vtexcommercestable.com.br/api/catalog/pvt/product/${context.productId}/specification`;
-      console.log("[VTEX] PUT", url);
+      const url = `https://${credentials.accountName}.vtexcommercestable.com.br/api/catalog_system/pvt/products/${context.productId}/specification`;
+      console.log("[VTEX] POST", url);
 
       const response = await fetch(url, {
-        method: "PUT",
+        method: "POST",
         headers: {
           Accept: "application/json",
           "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- `VTEX_UPDATE_PRODUCT_SPECIFICATIONS` was returning `405 Method Not Allowed` because it called `PUT /api/catalog/pvt/product/{id}/specification` — that path only exposes `GET`, `POST` (associate one), and `DELETE`.
- Switched to `POST /api/catalog_system/pvt/products/{id}/specification`, the bulk-update endpoint VTEX actually exposes (matches the SDK's `updateProductSpecification`).

## Test plan
- [ ] Re-run the failing call (product 175036) and confirm `200 OK`.
- [ ] Verify `VTEX_GET_PRODUCT_SPECIFICATIONS` returns the updated set after the write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 405 Method Not Allowed when updating VTEX product specifications by using POST /api/catalog_system/pvt/products/{id}/specification (bulk update) instead of PUT /api/catalog/pvt/product/{id}/specification. Updates the `VTEX_UPDATE_PRODUCT_SPECIFICATIONS` tool to send POST and log the correct verb.

<sup>Written for commit 4697c701d34103fb9293baa1a0ab341edb8ada91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

