### PR TITLE
feat(discord): add event-driven Discord MCP

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -145,6 +145,24 @@
         "wrangler": "^4.28.0",
       },
     },
+    "discord": {
+      "name": "discord",
+      "version": "1.0.0",
+      "dependencies": {
+        "@decocms/bindings": "^1.0.8",
+        "@decocms/runtime": "^1.3.0",
+        "@supabase/supabase-js": "^2.47.10",
+        "discord.js": "14.25.1",
+        "hono": "^4.0.0",
+        "tweetnacl": "^1.0.3",
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@decocms/mcps-shared": "1.0.0",
+        "deco-cli": "^0.28.0",
+        "typescript": "^5.7.2",
+      },
+    },
     "discord-read": {
       "name": "discord-read",
       "version": "1.0.0",
@@ -2499,6 +2517,8 @@
 
     "dingbat-to-unicode": ["dingbat-to-unicode@1.0.1", "", {}, "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w=="],
 
+    "discord": ["discord@workspace:discord"],
+
     "discord-api-types": ["discord-api-types@0.38.38", "", {}, "sha512-7qcM5IeZrfb+LXW07HvoI5L+j4PQeMZXEkSm1htHAHh4Y9JSMXBWjy/r7zmUCOj4F7zNjMcm7IMWr131MT2h0Q=="],
 
     "discord-read": ["discord-read@workspace:discord-read"],
@@ -3967,6 +3987,12 @@
 
     "defaults/clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
 
+    "discord/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
+
+    "discord/@decocms/runtime": ["@decocms/runtime@1.6.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-iVRp3yUvPd5x1nQ+WbsTOHA3KKBRMq6kGnJLoV1oyjIFm1uyxK69IihnYp1B49sQxlWAfPAJco3AZ8TuvF3T6A=="],
+
+    "discord/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "discord-read/@decocms/bindings": ["@decocms/bindings@1.3.4", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-TVNvJVsgHVv+1M28HfgfY+8/vAsxt6nD6wzGR8LsDPtWuvAbqtsAHNvQyiiaP0vEpSILlJsI2saxnrDZ9yBpBA=="],
 
     "discord-read/@decocms/runtime": ["@decocms/runtime@1.3.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-xRFTV9gqrdsUCAkJ3xoBOeDGXps6moZeZB/NNL+XZ7LNa4qzfmL3BGWG42n8xbFyEpprfEfOtOD+tVgWhkPDxQ=="],
@@ -4493,6 +4519,10 @@
 
     "discord-read/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
+    "discord/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
+
+    "discord/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
+
     "dropbox/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
     "dropbox/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
@@ -4972,6 +5002,10 @@
     "discord-read/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
     "discord-read/@decocms/runtime/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
+
+    "discord/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
+
+    "discord/@decocms/runtime/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
     "farmrio-reorder-collection-db/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 

--- a/deploy.json
+++ b/deploy.json
@@ -296,6 +296,15 @@
       "shared/**"
     ]
   },
+  "discord": {
+    "site": "discord",
+    "entrypoint": "./dist/server/main.js",
+    "platformName": "kubernetes-bun",
+    "watch": [
+      "discord/**",
+      "shared/**"
+    ]
+  },
   "mcp-studio": {
     "site": "mcp-studio",
     "entrypoint": "./dist/server/main.js",

--- a/discord/README.md
+++ b/discord/README.md
@@ -1,0 +1,194 @@
+# Discord MCP (event-driven)
+
+Pure event-driven Discord MCP. The bot listens to every Discord Gateway
+event and emits each one as a Studio trigger. Your agent — running in
+Studio — subscribes to the triggers it cares about and calls back into
+this MCP via tools to send messages, manage members, respond to
+interactions, etc.
+
+This is a from-scratch successor to `discord-read/`. The hybrid LLM logic
+that lived inside `discord-read` (`messageHandler.handleDefaultAgent`,
+`llm.streamAgentResponse`, channel-context prompts, model resolution) is
+**not** here — those concerns belong on the Studio agent.
+
+---
+
+## Architecture
+
+```
+┌──────────┐  Gateway WS  ┌────────────────────┐  trigger  ┌────────┐
+│ Discord  │─────────────▶│ Discord MCP (this) │──────────▶│ Studio │
+└──────────┘              │  - listens         │   POST    │ agent  │
+                          │  - publishes       │           └────┬───┘
+                          │  - tools (REST)    │                │
+                          └────────────────────┘                │
+                                  ▲                             │
+                                  │   tool call (FOLLOWUP, etc) │
+                                  └─────────────────────────────┘
+```
+
+- **Multi-tenant:** one Discord.js Client per Mesh `connectionId`.
+  Connections sharing a `bot_token` share a single Client (deduped on
+  bootstrap) — saves memory and avoids duplicate Gateway connections.
+- **K8s pod restarts:** every config is persisted in Supabase
+  (`discord2_connections`). On boot, `bootstrapFromSupabase()` loads
+  every saved row and calls `ensureBotRunning()` for each unique token.
+  No manual "start" tool required — the bot is up before you ask.
+- **Health watchdog:** an hourly cron checks `client.isReady()` for every
+  instance and restarts dead clients automatically.
+
+---
+
+## Triggers (26 default + 3 opt-in)
+
+See `server/triggers/definitions.ts` for the full catalog with filter
+schemas. Categories:
+
+| Category | Triggers |
+|---|---|
+| Messages | `discord.message.{created,updated,deleted,bulk_deleted}` |
+| Reactions | `discord.reaction.{added,removed}` |
+| Members | `discord.member.{joined,left,updated,role.added,role.removed}` |
+| Threads | `discord.thread.{created,updated,deleted}` |
+| Channels | `discord.channel.{created,updated,deleted}` |
+| Roles | `discord.role.{created,updated,deleted}` |
+| Guild lifecycle | `discord.guild.{joined,left}` |
+| **Interactions (NEW)** | `discord.interaction.{button,select,modal_submit,slash_command}` |
+| Opt-in | `discord.{presence.updated,typing.started,voice.state.updated}` |
+
+### DM privacy
+DMs fire `discord.message.created` with `is_dm: true` and `dm_user_id`
+populated. The publisher only notifies the connection that **owns** the
+bot which received the DM — no cross-tenant leakage. Filter your trigger
+with `is_dm: true` to subscribe to DMs only.
+
+---
+
+## The interaction flow (the new thing)
+
+Discord requires an ACK within 3 seconds of any interaction. A round-trip
+to Studio always takes longer, so the MCP **auto-defers** every
+interaction within ~50ms, then emits the trigger:
+
+1. User clicks a button (or submits a select/modal).
+2. `events.ts:interactionCreate` fires:
+   - `await interaction.deferUpdate()` (component) or
+     `await interaction.deferReply({ flags: ephemeral })` (slash/modal_submit) — done in <100ms.
+   - The token is recorded in `interaction-store.ts` (15-min TTL).
+   - The trigger is emitted with the payload below.
+3. Studio agent receives the trigger and has up to **15 minutes** to
+   call `DISCORD_INTERACTION_FOLLOWUP` with the `interaction_token`.
+
+Interaction trigger payload:
+
+```jsonc
+{
+  "event": "discord.interaction.button",
+  "interaction_id": "...",
+  "interaction_token": "...",       // 15-min lifetime
+  "application_id": "...",          // pass back to FOLLOWUP
+  "expires_at": "2026-05-01T12:15:00.000Z",
+  "custom_id": "approve_order_42",  // matches your button's custom_id
+  "message_id": "...",
+  "channel_id": "...",
+  "guild_id": "...",
+  "user_id": "...",
+  "username": "..."
+}
+```
+
+### Auto-defer modes (StateSchema.AUTO_DEFER_MODE)
+
+- `"ephemeral"` (default): users see "Bot is thinking..." privately.
+- `"visible"`: everyone sees it.
+- `"off"`: skip the defer. Only safe if the agent always responds in
+  <3s. Use this to enable modals (modals must be the FIRST response).
+
+### Idempotency for shared bot tokens
+
+If two Mesh connections happen to share the same `bot_token`, both will
+receive the trigger (they have separate trigger callbacks). Pass
+`interaction_id` to `DISCORD_INTERACTION_FOLLOWUP` and the
+local interaction-store will dedupe — only the first call gets through;
+the second returns `{ success: false, already_responded: true }`.
+
+---
+
+## Tools
+
+| Group | Tools |
+|---|---|
+| Config | `DISCORD_SAVE_CONFIG`, `DISCORD_GET_CONFIG` (token redacted), `DISCORD_DELETE_CONFIG` |
+| Bot | `DISCORD_BOT_STATUS`, `DISCORD_BOT_STOP` |
+| Interactions | `DISCORD_INTERACTION_FOLLOWUP`, `DISCORD_INTERACTION_UPDATE`, `DISCORD_INTERACTION_SHOW_MODAL` |
+| Messages | `DISCORD_SEND_MESSAGE` (with optional `components`), `EDIT`, `DELETE`, `BULK_DELETE`, `PURGE`, `GET`, `GET_CHANNEL_MESSAGES`, `PIN`, `UNPIN`, `GET_PINNED`, reactions |
+| Channels | `LIST`, `GET`, `CREATE`, `EDIT`, `DELETE`, threads (active/archived/join/leave/lock/archive) |
+| Guilds/members | `GET_GUILD`, `LIST_BOT_GUILDS`, `LIST_MEMBERS`, `SEARCH`, `GET_USER`, `GET_MEMBER`, `EDIT_MEMBER`, role management, `KICK`/`BAN`/`UNBAN`/`TIMEOUT`/`REMOVE_TIMEOUT`, role CRUD |
+| Webhooks | `CREATE`, `LIST`, `EDIT`, `DELETE`, `EXECUTE` (with components) |
+
+`DISCORD_SEND_MESSAGE` accepts `components`: pass Discord's component
+JSON shape directly (`[{ type: 1, components: [{ type: 2, label, style,
+custom_id }] }]` for a button row). Click events fire
+`discord.interaction.button` matching the `custom_id` you set.
+
+Slash commands: not registered by this MCP. Register externally via the
+Discord Developer Portal — when the user invokes one, the
+`discord.interaction.slash_command` trigger fires (auto-deferred unless
+`AUTO_DEFER_MODE='off'`).
+
+---
+
+## Migration from `discord-read`
+
+`discord/` and `discord-read/` are independent — different Supabase
+tables (`discord2_*` vs `discord_*`), different MCPs in the registry.
+Migrate connection by connection:
+
+1. **In Studio, install the new `discord` MCP** alongside `discord-read`.
+2. **Save the same bot token** via `DISCORD_SAVE_CONFIG` on the new
+   connection. The MCP will start the bot.
+3. **Recreate triggers** on the agent that previously ran inside
+   `discord-read`. The agent now subscribes to events and calls back via
+   tools instead of having logic inside the MCP.
+4. **Verify** the bot responds via the new trigger flow.
+5. **Remove** the old connection on `discord-read`.
+
+Both MCPs can run side-by-side during migration. They each have their
+own Supabase rows and won't step on each other.
+
+If both connections share the same `bot_token`, you'll see duplicate
+events (both bots are running the same Discord client). Either change
+the token on one of them, or delete the old `discord-read` connection
+once the new one is verified.
+
+---
+
+## Configuration
+
+Required env vars:
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+
+State (set per-connection in the Mesh dashboard):
+- `DISCORD_APPLICATION_ID` — required for interaction follow-ups.
+- `DISCORD_PUBLIC_KEY` — only if you plan to use HTTP webhook fallback (not active in v1).
+- `AUTHORIZED_GUILDS` — CSV of guild IDs; empty = all guilds.
+- `AUTO_DEFER_MODE` — `ephemeral` | `visible` | `off`.
+- `ENABLE_PRESENCE_EVENTS` / `ENABLE_TYPING_EVENTS` / `ENABLE_VOICE_EVENTS` — opt-ins.
+
+The bot token is passed via the `Authorization: Bearer <token>` header
+(captured by Mesh's onChange) or directly via `DISCORD_SAVE_CONFIG`.
+
+---
+
+## SQL migrations
+
+Apply once per Supabase project:
+
+```bash
+psql $DATABASE_URL -f migrations/001_discord2_connections.sql
+psql $DATABASE_URL -f migrations/002_discord2_trigger_credentials.sql
+```
+
+Both tables are protected by RLS (service role only). Bot tokens are
+plaintext — never expose `discord2_connections` via an MCP tool.

--- a/discord/app.json
+++ b/discord/app.json
@@ -1,0 +1,20 @@
+{
+  "scopeName": "deco",
+  "name": "discord",
+  "friendlyName": "Discord (Events)",
+  "connection": {
+    "type": "HTTP",
+    "url": "https://sites-discord.decocache.com/mcp"
+  },
+  "description": "Event-driven Discord MCP. Emits every Discord event as a Studio trigger; provides management tools for the agent to send messages, manage channels, members, roles, webhooks, and respond to interactive components (buttons, selects, modals).",
+  "icon": "https://assets.decocache.com/decocms/c84a9954-d171-4b02-8bf2-906ad913b16e/discord-logo.jpeg",
+  "unlisted": false,
+  "auth": null,
+  "metadata": {
+    "categories": ["Communication", "Automation"],
+    "official": false,
+    "tags": ["discord", "events", "triggers", "interactions", "buttons", "messages", "roles", "members", "server-management", "webhooks"],
+    "short_description": "Event-driven Discord bot. Emits every Discord event for Studio agents to react to via triggers, and exposes tools to manage the server.",
+    "mesh_description": "Pure event-driven Discord MCP. The bot listens to all Discord events (messages, members, reactions, threads, channels, roles, button clicks, select menus, modal submissions, slash commands) and emits them as Studio triggers — your agent decides what to do. Provides a complete management toolkit: send/edit messages with interactive components (buttons, selects, modals), manage channels, members, roles, moderation (kick/ban/timeout), and webhooks. Auto-defers Discord interactions within 100ms so your agent has 15 minutes to respond, regardless of LLM latency. Multi-tenant safe: bot tokens persist in Supabase and survive pod restarts; DMs are scoped to the originating connection only."
+  }
+}

--- a/discord/migrations/001_discord2_connections.sql
+++ b/discord/migrations/001_discord2_connections.sql
@@ -1,0 +1,32 @@
+-- Discord (events) MCP — connections table.
+-- Stores per-connection bot config. Bot token is plaintext — protect via RLS
+-- (only service role allowed to SELECT) and never expose this table via tools.
+
+CREATE TABLE IF NOT EXISTS discord2_connections (
+  connection_id TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL,
+  mesh_url TEXT NOT NULL,
+  mesh_token TEXT,
+  mesh_api_key TEXT,
+  bot_token TEXT NOT NULL,
+  discord_public_key TEXT,
+  discord_application_id TEXT,
+  authorized_guilds TEXT[],
+  state JSONB,
+  configured_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_discord2_connections_org
+  ON discord2_connections(organization_id);
+
+CREATE INDEX IF NOT EXISTS idx_discord2_connections_updated
+  ON discord2_connections(updated_at DESC);
+
+ALTER TABLE discord2_connections ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_all" ON discord2_connections;
+CREATE POLICY "service_role_all" ON discord2_connections
+  AS PERMISSIVE FOR ALL
+  TO service_role
+  USING (true) WITH CHECK (true);

--- a/discord/migrations/002_discord2_trigger_credentials.sql
+++ b/discord/migrations/002_discord2_trigger_credentials.sql
@@ -1,0 +1,20 @@
+-- Discord (events) MCP — trigger callback credentials.
+-- Stores callback URLs the @decocms/runtime/triggers system uses to deliver
+-- events to Studio agents. One row per Mesh connection.
+
+CREATE TABLE IF NOT EXISTS discord2_trigger_credentials (
+  connection_id TEXT PRIMARY KEY,
+  callback_url TEXT NOT NULL,
+  callback_token TEXT NOT NULL,
+  active_trigger_types TEXT[] NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL
+);
+
+ALTER TABLE discord2_trigger_credentials ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role_all" ON discord2_trigger_credentials;
+CREATE POLICY "service_role_all" ON discord2_trigger_credentials
+  AS PERMISSIVE FOR ALL
+  TO service_role
+  USING (true) WITH CHECK (true);

--- a/discord/package.json
+++ b/discord/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "discord",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "description": "Event-driven Discord MCP — emits every Discord event as a trigger and provides server management tools",
+  "scripts": {
+    "dev": "bun run --hot server/main.ts",
+    "configure": "deco configure",
+    "gen": "deco gen --output=shared/deco.gen.ts",
+    "check": "tsc --noEmit",
+    "build:server": "NODE_ENV=production bun build server/main.ts --target=bun --outdir=dist/server --entry-naming [name].js",
+    "build": "bun run build:server",
+    "start": "NODE_ENV=production bun run dist/main.js",
+    "build:start": "bun run build && bun run start",
+    "publish": "cat app.json | deco registry publish -w /shared/deco -y"
+  },
+  "dependencies": {
+    "@decocms/bindings": "^1.0.8",
+    "@decocms/runtime": "^1.3.0",
+    "@supabase/supabase-js": "^2.47.10",
+    "discord.js": "14.25.1",
+    "hono": "^4.0.0",
+    "tweetnacl": "^1.0.3",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@decocms/mcps-shared": "1.0.0",
+    "deco-cli": "^0.28.0",
+    "typescript": "^5.7.2"
+  },
+  "overrides": {
+    "zod": "^4.0.0"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/discord/server/bot/events.ts
+++ b/discord/server/bot/events.ts
@@ -1,0 +1,419 @@
+/**
+ * Discord.js Gateway event handlers — wires every event to a publisher.
+ *
+ * No business logic lives here: every handler is a thin adapter that calls
+ * the right publish* helper. Multi-tenant safety + privacy filters are in
+ * `triggers/publisher.ts`.
+ */
+
+import {
+  type Client,
+  type Message,
+  type MessageReaction,
+  type User,
+  type GuildMember,
+  type PartialMessage,
+  type PartialMessageReaction,
+  type PartialUser,
+  type GuildChannel,
+  type ButtonInteraction,
+  type AnySelectMenuInteraction,
+  type ModalSubmitInteraction,
+  type ChatInputCommandInteraction,
+  MessageFlags,
+} from "discord.js";
+import type { BotInstance } from "./instance.ts";
+import {
+  publishMessageCreated,
+  publishMessageUpdated,
+  publishMessageDeleted,
+  publishMessageBulkDeleted,
+  publishReactionAdded,
+  publishReactionRemoved,
+  publishMemberJoined,
+  publishMemberLeft,
+  publishMemberUpdated,
+  publishMemberRoleAdded,
+  publishMemberRoleRemoved,
+  publishThreadCreated,
+  publishThreadUpdated,
+  publishThreadDeleted,
+  publishChannelCreated,
+  publishChannelUpdated,
+  publishChannelDeleted,
+  publishRoleCreated,
+  publishRoleUpdated,
+  publishRoleDeleted,
+  publishGuildJoined,
+  publishGuildLeft,
+  publishPresenceUpdated,
+  publishTypingStarted,
+  publishVoiceStateUpdated,
+  publishInteractionButton,
+  publishInteractionSelect,
+  publishInteractionModalSubmit,
+  publishInteractionSlashCommand,
+} from "../triggers/publisher.ts";
+import * as interactionStore from "../triggers/interaction-store.ts";
+
+// Debounce window for processedMessageIds: discord.js can emit duplicate
+// events on reconnect; 10s is enough to drop the duplicate without holding memory.
+const MESSAGE_DEDUP_TTL_MS = 10_000;
+
+/**
+ * Wrap a Discord.js event listener with a swallowing try/catch so a single
+ * bad event doesn't propagate up to the gateway client and crash the loop.
+ */
+function wrap<TArgs extends unknown[]>(
+  fn: (...args: TArgs) => void | Promise<void>,
+): (...args: TArgs) => Promise<void> {
+  return async (...args) => {
+    try {
+      await fn(...args);
+    } catch {
+      // swallow: we don't log, but a bad event must not bring down the bot
+    }
+  };
+}
+
+export function registerEventHandlers(
+  client: Client,
+  instance: BotInstance,
+): void {
+  client.removeAllListeners();
+  const processedMessageIds = new Set<string>();
+
+  // ============================================================================
+  // Messages
+  // ============================================================================
+  client.on(
+    "messageCreate",
+    wrap(async (message: Message) => {
+      if (processedMessageIds.has(message.id)) return;
+      processedMessageIds.add(message.id);
+      setTimeout(
+        () => processedMessageIds.delete(message.id),
+        MESSAGE_DEDUP_TTL_MS,
+      );
+      publishMessageCreated(instance.env, message);
+    }),
+  );
+
+  client.on(
+    "messageUpdate",
+    wrap(async (oldMessage, newMessage) => {
+      if (newMessage.partial) await newMessage.fetch();
+      publishMessageUpdated(
+        instance.env,
+        oldMessage as Message | PartialMessage,
+        newMessage as Message,
+      );
+    }),
+  );
+
+  client.on(
+    "messageDelete",
+    wrap(async (message) => {
+      publishMessageDeleted(instance.env, message as Message | PartialMessage);
+    }),
+  );
+
+  client.on(
+    "messageDeleteBulk",
+    wrap(async (messages) => {
+      publishMessageBulkDeleted(instance.env, messages);
+    }),
+  );
+
+  // ============================================================================
+  // Reactions
+  // ============================================================================
+  client.on(
+    "messageReactionAdd",
+    wrap(
+      async (
+        reaction: MessageReaction | PartialMessageReaction,
+        user: User | PartialUser,
+      ) => {
+        if (reaction.partial) await reaction.fetch();
+        if (user.partial) await user.fetch();
+        if (!reaction.partial && !user.partial) {
+          publishReactionAdded(
+            instance.env,
+            reaction as MessageReaction,
+            user as User,
+          );
+        }
+      },
+    ),
+  );
+
+  client.on(
+    "messageReactionRemove",
+    wrap(
+      async (
+        reaction: MessageReaction | PartialMessageReaction,
+        user: User | PartialUser,
+      ) => {
+        if (reaction.partial) await reaction.fetch();
+        if (user.partial) await user.fetch();
+        if (!reaction.partial && !user.partial) {
+          publishReactionRemoved(
+            instance.env,
+            reaction as MessageReaction,
+            user as User,
+          );
+        }
+      },
+    ),
+  );
+
+  // ============================================================================
+  // Members
+  // ============================================================================
+  client.on(
+    "guildMemberAdd",
+    wrap(async (member) => {
+      publishMemberJoined(instance.env, member);
+    }),
+  );
+
+  client.on(
+    "guildMemberRemove",
+    wrap(async (member) => {
+      publishMemberLeft(instance.env, member);
+    }),
+  );
+
+  client.on(
+    "guildMemberUpdate",
+    wrap(async (oldMember, newMember) => {
+      publishMemberUpdated(instance.env, oldMember, newMember as GuildMember);
+
+      if (!oldMember.partial) {
+        const oldRoles = oldMember.roles.cache;
+        const newRoles = newMember.roles.cache;
+
+        newRoles.forEach((role) => {
+          if (!oldRoles.has(role.id)) {
+            publishMemberRoleAdded(
+              instance.env,
+              newMember as GuildMember,
+              role.id,
+              role.name,
+            );
+          }
+        });
+
+        oldRoles.forEach((role) => {
+          if (!newRoles.has(role.id)) {
+            publishMemberRoleRemoved(
+              instance.env,
+              newMember as GuildMember,
+              role.id,
+              role.name,
+            );
+          }
+        });
+      }
+    }),
+  );
+
+  // ============================================================================
+  // Threads
+  // ============================================================================
+  client.on(
+    "threadCreate",
+    wrap(async (thread) => {
+      publishThreadCreated(instance.env, thread);
+    }),
+  );
+
+  client.on(
+    "threadUpdate",
+    wrap(async (oldThread, newThread) => {
+      publishThreadUpdated(instance.env, oldThread, newThread);
+    }),
+  );
+
+  client.on(
+    "threadDelete",
+    wrap(async (thread) => {
+      publishThreadDeleted(instance.env, thread);
+    }),
+  );
+
+  // ============================================================================
+  // Channels
+  // ============================================================================
+  client.on(
+    "channelCreate",
+    wrap(async (channel) => {
+      if (!("guild" in channel) || !channel.guild) return;
+      publishChannelCreated(instance.env, channel as GuildChannel);
+    }),
+  );
+
+  client.on(
+    "channelUpdate",
+    wrap(async (oldChannel, newChannel) => {
+      if (!("guild" in newChannel) || !newChannel.guild) return;
+      publishChannelUpdated(
+        instance.env,
+        oldChannel as GuildChannel,
+        newChannel as GuildChannel,
+      );
+    }),
+  );
+
+  client.on(
+    "channelDelete",
+    wrap(async (channel) => {
+      if (!("guild" in channel) || !channel.guild) return;
+      publishChannelDeleted(instance.env, channel as GuildChannel);
+    }),
+  );
+
+  // ============================================================================
+  // Roles
+  // ============================================================================
+  client.on(
+    "roleCreate",
+    wrap(async (role) => {
+      publishRoleCreated(instance.env, role);
+    }),
+  );
+
+  client.on(
+    "roleUpdate",
+    wrap(async (oldRole, newRole) => {
+      publishRoleUpdated(instance.env, oldRole, newRole);
+    }),
+  );
+
+  client.on(
+    "roleDelete",
+    wrap(async (role) => {
+      publishRoleDeleted(instance.env, role);
+    }),
+  );
+
+  // ============================================================================
+  // Guild lifecycle
+  // ============================================================================
+  client.on(
+    "guildCreate",
+    wrap(async (guild) => {
+      publishGuildJoined(instance.env, guild);
+    }),
+  );
+
+  client.on(
+    "guildDelete",
+    wrap(async (guild) => {
+      publishGuildLeft(instance.env, guild);
+    }),
+  );
+
+  // ============================================================================
+  // Interactions (button / select / modal_submit / slash command)
+  //
+  // Discord requires ACK within 3s. Round-trip MCP→Studio→agent→tool→MCP is
+  // too slow, so we auto-defer immediately, record the token in the local
+  // interaction-store, then emit the trigger. Agent has 15 minutes to call
+  // DISCORD_INTERACTION_FOLLOWUP / _UPDATE.
+  // ============================================================================
+  client.on(
+    "interactionCreate",
+    wrap(async (interaction) => {
+      const autoDeferMode =
+        instance.env.MESH_REQUEST_CONTEXT?.state?.AUTO_DEFER_MODE ??
+        "ephemeral";
+      const ephemeralFlag =
+        autoDeferMode === "ephemeral" ? MessageFlags.Ephemeral : undefined;
+
+      // Defer FIRST. Anything async before this risks the 3s deadline.
+      if (interaction.isButton() || interaction.isAnySelectMenu()) {
+        if (autoDeferMode !== "off") {
+          await interaction.deferUpdate();
+        }
+      } else if (
+        interaction.isChatInputCommand() ||
+        interaction.isModalSubmit()
+      ) {
+        if (autoDeferMode !== "off") {
+          await interaction.deferReply({ flags: ephemeralFlag });
+        }
+      } else {
+        return; // Autocomplete and other types: not handled here.
+      }
+
+      interactionStore.set({
+        interaction_id: interaction.id,
+        token: interaction.token,
+        application_id: interaction.applicationId,
+        type: interaction.type as number,
+        custom_id:
+          "customId" in interaction
+            ? (interaction.customId as string | undefined)
+            : undefined,
+        channel_id: interaction.channelId ?? undefined,
+        guild_id: interaction.guildId ?? undefined,
+      });
+
+      if (interaction.isButton()) {
+        publishInteractionButton(
+          instance.env,
+          interaction as ButtonInteraction,
+        );
+      } else if (interaction.isAnySelectMenu()) {
+        publishInteractionSelect(
+          instance.env,
+          interaction as AnySelectMenuInteraction,
+        );
+      } else if (interaction.isModalSubmit()) {
+        publishInteractionModalSubmit(
+          instance.env,
+          interaction as ModalSubmitInteraction,
+        );
+      } else if (interaction.isChatInputCommand()) {
+        publishInteractionSlashCommand(
+          instance.env,
+          interaction as ChatInputCommandInteraction,
+        );
+      }
+    }),
+  );
+
+  // ============================================================================
+  // Opt-in (gated by StateSchema flags)
+  // ============================================================================
+  const state = instance.env.MESH_REQUEST_CONTEXT?.state;
+
+  if (state?.ENABLE_PRESENCE_EVENTS) {
+    client.on(
+      "presenceUpdate",
+      wrap(async (_oldPresence, newPresence) => {
+        publishPresenceUpdated(instance.env, newPresence);
+      }),
+    );
+  }
+
+  if (state?.ENABLE_TYPING_EVENTS) {
+    client.on(
+      "typingStart",
+      wrap(async (typing) => {
+        publishTypingStarted(instance.env, typing);
+      }),
+    );
+  }
+
+  if (state?.ENABLE_VOICE_EVENTS) {
+    client.on(
+      "voiceStateUpdate",
+      wrap(async (oldState, newState) => {
+        publishVoiceStateUpdated(instance.env, oldState, newState);
+      }),
+    );
+  }
+}

--- a/discord/server/bot/gateway.ts
+++ b/discord/server/bot/gateway.ts
@@ -1,0 +1,137 @@
+/**
+ * Discord.js Gateway client — initialization, login, intents.
+ *
+ * One client per Mesh connectionId; instances sharing a bot_token share a
+ * single client (the bootstrap dedup logic in main.ts handles that).
+ *
+ * Event handlers live in ./events.ts to keep this file focused on lifecycle.
+ */
+
+import { Client, GatewayIntentBits, Partials } from "discord.js";
+import type { Env } from "../types/env.ts";
+import {
+  getOrCreateInstance,
+  getInstance,
+  type BotInstance,
+} from "./instance.ts";
+import { registerEventHandlers } from "./events.ts";
+import { getDiscordConfig } from "../lib/config-cache.ts";
+
+function buildIntents(env: Env): number[] {
+  const state = env.MESH_REQUEST_CONTEXT?.state;
+  const intents: number[] = [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.GuildMembers,
+    GatewayIntentBits.GuildMessageReactions,
+    GatewayIntentBits.MessageContent,
+    GatewayIntentBits.DirectMessages,
+    GatewayIntentBits.DirectMessageReactions,
+  ];
+  if (state?.ENABLE_PRESENCE_EVENTS) {
+    intents.push(GatewayIntentBits.GuildPresences);
+  }
+  if (state?.ENABLE_TYPING_EVENTS) {
+    intents.push(GatewayIntentBits.GuildMessageTyping);
+    intents.push(GatewayIntentBits.DirectMessageTyping);
+  }
+  if (state?.ENABLE_VOICE_EVENTS) {
+    intents.push(GatewayIntentBits.GuildVoiceStates);
+  }
+  return intents;
+}
+
+export function getGatewayClient(connectionId: string): Client | null {
+  return getInstance(connectionId)?.client ?? null;
+}
+
+export async function initializeGateway(env: Env): Promise<Client> {
+  const connectionId =
+    env.MESH_REQUEST_CONTEXT?.connectionId || "default-connection";
+  const instance = getOrCreateInstance(connectionId, env);
+
+  if (instance.initializingPromise) return instance.initializingPromise;
+  if (instance.client?.isReady()) return instance.client;
+
+  if (instance.client) {
+    try {
+      instance.client.removeAllListeners();
+      instance.client.destroy();
+    } catch {
+      // ignore destroy errors
+    }
+    instance.client = null;
+  }
+
+  instance.initializingPromise = (async () => {
+    try {
+      return await doInitialize(instance, env);
+    } finally {
+      instance.initializingPromise = null;
+    }
+  })();
+
+  return instance.initializingPromise;
+}
+
+async function doInitialize(instance: BotInstance, env: Env): Promise<Client> {
+  instance.env = env;
+
+  const token = await resolveBotToken(env);
+  if (!token) {
+    throw new Error(`No bot token available for ${instance.connectionId}`);
+  }
+
+  const client = new Client({
+    intents: buildIntents(env),
+    partials: [
+      Partials.Message,
+      Partials.Reaction,
+      Partials.User,
+      Partials.Channel,
+      Partials.GuildMember,
+      Partials.ThreadMember,
+    ],
+  });
+
+  instance.client = client;
+  registerEventHandlers(client, instance);
+
+  await client.login(token);
+
+  if (!client.isReady()) {
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(() => resolve(), 10000);
+      client.once("clientReady", () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+  }
+
+  return client;
+}
+
+async function resolveBotToken(env: Env): Promise<string | null> {
+  const auth = env.MESH_REQUEST_CONTEXT?.authorization;
+  if (auth) {
+    const m = auth.match(/^Bearer\s+(.+)$/i);
+    if (m) return m[1];
+    return auth;
+  }
+
+  const connectionId = env.MESH_REQUEST_CONTEXT?.connectionId;
+  if (!connectionId) return null;
+
+  const config = await getDiscordConfig(connectionId).catch(() => null);
+  return config?.botToken ?? null;
+}
+
+export async function shutdownGateway(connectionId: string): Promise<void> {
+  const instance = getInstance(connectionId);
+  if (instance?.client) {
+    instance.client.removeAllListeners();
+    instance.client.destroy();
+    instance.client = null;
+  }
+}

--- a/discord/server/bot/instance.ts
+++ b/discord/server/bot/instance.ts
@@ -1,0 +1,59 @@
+/**
+ * Bot instance registry — keyed by Mesh connectionId.
+ *
+ * Each tenant (Mesh connection) gets its own BotInstance: a discord.js Client
+ * + the env that came in via onChange. Instances sharing a bot_token share a
+ * single Client (deduped at bootstrap).
+ */
+
+import type { Client } from "discord.js";
+import type { Env } from "../types/env.ts";
+
+export interface BotInstance {
+  connectionId: string;
+  client: Client | null;
+  env: Env;
+  initializing: boolean;
+  initialized: boolean;
+  initializingPromise: Promise<Client> | null;
+}
+
+const instances = new Map<string, BotInstance>();
+
+export function getInstance(connectionId: string): BotInstance | undefined {
+  return instances.get(connectionId);
+}
+
+export function getOrCreateInstance(
+  connectionId: string,
+  env: Env,
+): BotInstance {
+  let instance = instances.get(connectionId);
+  if (!instance) {
+    instance = {
+      connectionId,
+      client: null,
+      env,
+      initializing: false,
+      initialized: false,
+      initializingPromise: null,
+    };
+    instances.set(connectionId, instance);
+  }
+  return instance;
+}
+
+export function removeInstance(connectionId: string): void {
+  instances.delete(connectionId);
+}
+
+export function getAllInstances(): BotInstance[] {
+  return Array.from(instances.values());
+}
+
+export function getInstanceByClient(client: Client): BotInstance | undefined {
+  for (const instance of instances.values()) {
+    if (instance.client === client) return instance;
+  }
+  return undefined;
+}

--- a/discord/server/bot/manager.ts
+++ b/discord/server/bot/manager.ts
@@ -1,0 +1,111 @@
+/**
+ * Bot lifecycle manager. Tools and `onChange` call into here to start/stop bots
+ * for a given connection.
+ */
+
+import type { Env } from "../types/env.ts";
+import { initializeGateway, shutdownGateway } from "./gateway.ts";
+import {
+  getInstance,
+  getOrCreateInstance,
+  getAllInstances,
+  removeInstance,
+} from "./instance.ts";
+import { getDiscordConfig } from "../lib/config-cache.ts";
+
+function getConnectionId(env: Env): string {
+  return env.MESH_REQUEST_CONTEXT?.connectionId || "default-connection";
+}
+
+export function updateEnv(env: Env): void {
+  const connectionId = getConnectionId(env);
+  const instance = getOrCreateInstance(connectionId, env);
+  instance.env = env;
+}
+
+export function getCurrentEnv(connectionId?: string): Env | null {
+  if (!connectionId) return null;
+  return getInstance(connectionId)?.env ?? null;
+}
+
+export async function ensureBotRunning(env: Env): Promise<boolean> {
+  const connectionId = getConnectionId(env);
+  const instance = getOrCreateInstance(connectionId, env);
+
+  instance.env = env;
+
+  if (instance.client?.isReady()) return true;
+
+  if (instance.initializing) {
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    return instance.client?.isReady() ?? false;
+  }
+
+  let savedConfig;
+  try {
+    savedConfig = await getDiscordConfig(connectionId);
+  } catch {
+    savedConfig = null;
+  }
+
+  const hasAuth = !!env.MESH_REQUEST_CONTEXT?.authorization;
+  const hasSavedConfig = !!savedConfig?.botToken;
+
+  if (!hasAuth && !hasSavedConfig) return false;
+
+  instance.initializing = true;
+
+  try {
+    await initializeGateway(env);
+    instance.initialized = true;
+    return true;
+  } catch {
+    return false;
+  } finally {
+    instance.initializing = false;
+  }
+}
+
+export function isBotRunning(env: Env): boolean {
+  const connectionId = getConnectionId(env);
+  return getInstance(connectionId)?.client?.isReady() ?? false;
+}
+
+export function getBotStatus(env: Env) {
+  const connectionId = getConnectionId(env);
+  const instance = getInstance(connectionId);
+
+  if (!instance?.client || !instance.client.isReady()) {
+    return {
+      running: false,
+      initializing: instance?.initializing ?? false,
+    };
+  }
+
+  return {
+    running: true,
+    initializing: false,
+    user: instance.client.user?.tag,
+    guilds: instance.client.guilds.cache.size,
+    uptime: instance.client.uptime,
+    ping: instance.client.ws.ping,
+  };
+}
+
+export async function shutdownBot(env: Env): Promise<void> {
+  const connectionId = getConnectionId(env);
+  await shutdownGateway(connectionId);
+  removeInstance(connectionId);
+}
+
+export async function shutdownAllBots(): Promise<void> {
+  const list = getAllInstances();
+  for (const instance of list) {
+    try {
+      await shutdownGateway(instance.connectionId);
+      removeInstance(instance.connectionId);
+    } catch {
+      // swallow per-instance errors so others can shut down
+    }
+  }
+}

--- a/discord/server/discord-rest/api.ts
+++ b/discord/server/discord-rest/api.ts
@@ -1,0 +1,161 @@
+/**
+ * Rate-limit-aware Discord REST client.
+ *
+ * Used by every management tool that hits Discord's HTTP API. Handles 429
+ * with retry-after parsing, exponential backoff for 5xx, and X-Audit-Log-Reason.
+ */
+
+import type { Env } from "../types/env.ts";
+import { getInstance } from "../bot/instance.ts";
+import { getDiscordBotToken } from "../lib/env-resolver.ts";
+
+const DISCORD_API_BASE = "https://discord.com/api/v10";
+const MAX_RETRIES = 5;
+const BASE_DELAY_MS = 100;
+const MAX_DELAY_MS = 5000;
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export interface DiscordAPIOptions {
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  body?: unknown;
+  reason?: string;
+}
+
+interface RateLimitInfo {
+  retryAfter: number;
+  global: boolean;
+  bucket?: string;
+}
+
+function parseRateLimitInfo(response: Response, body?: string): RateLimitInfo {
+  let retryAfter = 1;
+  let global = false;
+  const retryHeader = response.headers.get("Retry-After");
+  const globalHeader = response.headers.get("X-RateLimit-Global");
+  const bucket = response.headers.get("X-RateLimit-Bucket") || undefined;
+
+  if (retryHeader) retryAfter = parseFloat(retryHeader);
+  if (globalHeader === "true") global = true;
+
+  if (body) {
+    try {
+      const json = JSON.parse(body);
+      if (json.retry_after !== undefined) retryAfter = json.retry_after;
+      if (json.global !== undefined) global = json.global;
+    } catch {
+      // ignore
+    }
+  }
+
+  return { retryAfter, global, bucket };
+}
+
+export async function discordAPI<T>(
+  env: Env,
+  endpoint: string,
+  options: DiscordAPIOptions = {},
+): Promise<T> {
+  let botToken: string;
+  try {
+    botToken = await getDiscordBotToken(env);
+  } catch (err) {
+    const connectionId =
+      env.MESH_REQUEST_CONTEXT?.connectionId || "default-connection";
+    const instance = getInstance(connectionId);
+    if (instance?.env) {
+      botToken = await getDiscordBotToken(instance.env);
+    } else {
+      throw err;
+    }
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bot ${botToken}`,
+    "Content-Type": "application/json",
+  };
+  if (options.reason) {
+    headers["X-Audit-Log-Reason"] = encodeURIComponent(options.reason);
+  }
+
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    const response = await fetch(`${DISCORD_API_BASE}${endpoint}`, {
+      method: options.method || "GET",
+      headers,
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+
+    if (response.status === 429) {
+      const errorText = await response.text().catch(() => "");
+      const info = parseRateLimitInfo(response, errorText);
+      const waitMs = Math.min((info.retryAfter + 0.1) * 1000, MAX_DELAY_MS);
+      await delay(waitMs);
+      continue;
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "");
+      lastError = new Error(
+        `Discord API ${response.status}: ${errorText || response.statusText}`,
+      );
+      if (response.status >= 400 && response.status < 500) throw lastError;
+
+      const backoffMs = Math.min(
+        BASE_DELAY_MS * Math.pow(2, attempt),
+        MAX_DELAY_MS,
+      );
+      await delay(backoffMs);
+      continue;
+    }
+
+    if (response.status === 204) return {} as T;
+    return response.json() as Promise<T>;
+  }
+
+  throw lastError || new Error("Discord API: max retries exceeded");
+}
+
+export function encodeEmoji(emoji: string): string {
+  if (emoji.includes(":")) return emoji;
+  return encodeURIComponent(emoji);
+}
+
+/**
+ * Run an operation across many items sequentially with rate-limit-aware delays.
+ * Used by bulk-delete tools that hit Discord per-item.
+ */
+export async function discordAPIBatch<T, R>(
+  _env: Env,
+  items: T[],
+  operation: (item: T) => Promise<R>,
+  options: {
+    delayMs?: number;
+    onProgress?: (completed: number, total: number, result: R) => void;
+    onError?: (item: T, error: Error) => "skip" | "stop";
+  } = {},
+): Promise<{ results: R[]; errors: Array<{ item: T; error: string }> }> {
+  const { delayMs = BASE_DELAY_MS, onProgress, onError } = options;
+  const results: R[] = [];
+  const errors: Array<{ item: T; error: string }> = [];
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    try {
+      const result = await operation(item);
+      results.push(result);
+      if (onProgress) onProgress(i + 1, items.length, result);
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      errors.push({ item, error: errorMsg });
+      if (onError) {
+        const action = onError(item, err as Error);
+        if (action === "stop") break;
+      }
+    }
+    if (i < items.length - 1) await delay(delayMs);
+  }
+
+  return { results, errors };
+}

--- a/discord/server/lib/config-cache.ts
+++ b/discord/server/lib/config-cache.ts
@@ -1,0 +1,87 @@
+/**
+ * In-memory config cache (30s TTL) backed by Supabase.
+ * Used by tools, gateway init, and webhook handlers to fetch the bot token
+ * + connection metadata without round-tripping to Supabase on every call.
+ */
+
+import {
+  loadConnectionConfig,
+  saveConnectionConfig,
+  deleteConnectionConfig,
+} from "./supabase.ts";
+
+export interface DiscordConfig {
+  connectionId: string;
+  organizationId: string;
+  meshUrl: string;
+  meshToken?: string;
+  meshApiKey?: string;
+  botToken: string;
+  discordPublicKey?: string;
+  discordApplicationId?: string;
+  authorizedGuilds?: string[];
+  state?: Record<string, unknown>;
+  configuredAt?: string;
+  updatedAt?: string;
+}
+
+interface CacheEntry {
+  config: DiscordConfig;
+  timestamp: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const CACHE_TTL_MS = 30_000;
+
+export async function getDiscordConfig(
+  connectionId: string,
+): Promise<DiscordConfig | null> {
+  const cached = cache.get(connectionId);
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+    return cached.config;
+  }
+
+  const row = await loadConnectionConfig(connectionId);
+  if (!row) {
+    cache.delete(connectionId);
+    return null;
+  }
+
+  const config: DiscordConfig = {
+    connectionId: row.connection_id,
+    organizationId: row.organization_id,
+    meshUrl: row.mesh_url,
+    meshToken: row.mesh_token || undefined,
+    meshApiKey: row.mesh_api_key || undefined,
+    botToken: row.bot_token,
+    discordPublicKey: row.discord_public_key || undefined,
+    discordApplicationId: row.discord_application_id || undefined,
+    authorizedGuilds: row.authorized_guilds || undefined,
+    state: row.state ?? undefined,
+    configuredAt: row.configured_at,
+    updatedAt: row.updated_at,
+  };
+
+  cache.set(connectionId, { config, timestamp: Date.now() });
+  return config;
+}
+
+export async function setDiscordConfig(config: DiscordConfig): Promise<void> {
+  await saveConnectionConfig(config);
+  cache.set(config.connectionId, { config, timestamp: Date.now() });
+}
+
+export async function deleteDiscordConfig(connectionId: string): Promise<void> {
+  await deleteConnectionConfig(connectionId);
+  cache.delete(connectionId);
+}
+
+export function isGuildAuthorized(
+  config: DiscordConfig,
+  guildId: string,
+): boolean {
+  if (!config.authorizedGuilds || config.authorizedGuilds.length === 0) {
+    return true;
+  }
+  return config.authorizedGuilds.includes(guildId);
+}

--- a/discord/server/lib/env-resolver.ts
+++ b/discord/server/lib/env-resolver.ts
@@ -1,0 +1,32 @@
+/**
+ * Resolve the Discord bot token for a given env.
+ *
+ * Priority:
+ *   1. Authorization header (Bearer <token> or raw token)
+ *   2. Supabase config-cache via connectionId
+ */
+
+import type { Env } from "../types/env.ts";
+
+export const getDiscordBotToken = async (env: Env): Promise<string> => {
+  const connectionId =
+    env.MESH_REQUEST_CONTEXT?.connectionId || "default-connection";
+
+  const authHeader = env.MESH_REQUEST_CONTEXT?.authorization;
+  if (authHeader) {
+    const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+    if (token && token.length > 20) return token;
+  }
+
+  const { getDiscordConfig } = await import("./config-cache.ts");
+  const config = await getDiscordConfig(connectionId);
+
+  if (!config?.botToken) {
+    throw new Error(
+      `Discord bot token not configured for ${connectionId}. ` +
+        `Use DISCORD_SAVE_CONFIG to save a token, or pass it via Authorization header.`,
+    );
+  }
+
+  return config.botToken;
+};

--- a/discord/server/lib/supabase.ts
+++ b/discord/server/lib/supabase.ts
@@ -1,0 +1,250 @@
+/**
+ * Supabase client + CRUD for the `discord2_*` tables.
+ *
+ * Tables (see migrations/):
+ *   - discord2_connections           (per-connection bot config + state snapshot)
+ *   - discord2_trigger_credentials   (callback URLs for the runtime triggers system)
+ *
+ * SECURITY: bot_token is plaintext; the service-role-only RLS policy is the
+ * only thing standing between this row and a public dump. Never expose any of
+ * the functions below as MCP tools.
+ */
+
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+export interface DiscordConnectionRow {
+  connection_id: string;
+  organization_id: string;
+  mesh_url: string;
+  mesh_token: string | null;
+  mesh_api_key: string | null;
+  bot_token: string;
+  discord_public_key: string | null;
+  discord_application_id: string | null;
+  authorized_guilds: string[] | null;
+  state: Record<string, unknown> | null;
+  configured_at: string;
+  updated_at: string;
+}
+
+interface TriggerCredentialsRow {
+  connection_id: string;
+  callback_url: string;
+  callback_token: string;
+  active_trigger_types: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+interface TriggerState {
+  credentials: { callbackUrl: string; callbackToken: string };
+  activeTriggerTypes: string[];
+}
+
+let supabaseClient: SupabaseClient | null = null;
+
+export function getSupabaseClient(): SupabaseClient | null {
+  if (supabaseClient) return supabaseClient;
+
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_ANON_KEY;
+  if (!url || !key) return null;
+
+  try {
+    supabaseClient = createClient(url, key, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+    return supabaseClient;
+  } catch {
+    return null;
+  }
+}
+
+export function isSupabaseConfigured(): boolean {
+  return !!process.env.SUPABASE_URL && !!process.env.SUPABASE_ANON_KEY;
+}
+
+// ============================================================================
+// discord2_connections
+// ============================================================================
+
+export async function saveConnectionConfig(config: {
+  connectionId: string;
+  organizationId: string;
+  meshUrl: string;
+  meshToken?: string;
+  meshApiKey?: string;
+  botToken: string;
+  discordPublicKey?: string;
+  discordApplicationId?: string;
+  authorizedGuilds?: string[];
+  state?: Record<string, unknown>;
+}): Promise<void> {
+  const client = getSupabaseClient();
+  if (!client) throw new Error("Supabase client not initialized");
+
+  const now = new Date().toISOString();
+  const row: Partial<DiscordConnectionRow> = {
+    connection_id: config.connectionId,
+    organization_id: config.organizationId,
+    mesh_url: config.meshUrl,
+    mesh_token: config.meshToken || null,
+    mesh_api_key: config.meshApiKey || null,
+    bot_token: config.botToken,
+    discord_public_key: config.discordPublicKey || null,
+    discord_application_id: config.discordApplicationId || null,
+    authorized_guilds: config.authorizedGuilds || null,
+    state: config.state ?? null,
+    configured_at: now,
+    updated_at: now,
+  };
+
+  const { error } = await client
+    .from("discord2_connections")
+    .upsert(row as Record<string, unknown>, { onConflict: "connection_id" });
+
+  if (error) throw new Error(`Failed to save config: ${error.message}`);
+}
+
+export async function loadConnectionConfig(
+  connectionId: string,
+): Promise<DiscordConnectionRow | null> {
+  const client = getSupabaseClient();
+  if (!client) throw new Error("Supabase client not initialized");
+
+  const { data, error } = await client
+    .from("discord2_connections")
+    .select("*")
+    .eq("connection_id", connectionId)
+    .single();
+
+  if (error) {
+    if (error.code === "PGRST116") return null;
+    throw new Error(`Failed to load config: ${error.message}`);
+  }
+  return data as DiscordConnectionRow;
+}
+
+export async function loadAllConnectionConfigs(): Promise<
+  DiscordConnectionRow[]
+> {
+  const client = getSupabaseClient();
+  if (!client) throw new Error("Supabase client not initialized");
+
+  // updated_at DESC: when multiple rows share a bot_token, the freshest config
+  // becomes the primary owner during bootstrap dedup.
+  const { data, error } = await client
+    .from("discord2_connections")
+    .select("*")
+    .order("updated_at", { ascending: false });
+
+  if (error) throw new Error(`Failed to load configs: ${error.message}`);
+  return (data || []) as DiscordConnectionRow[];
+}
+
+export async function deleteConnectionConfig(
+  connectionId: string,
+): Promise<void> {
+  const client = getSupabaseClient();
+  if (!client) throw new Error("Supabase client not initialized");
+
+  const { error } = await client
+    .from("discord2_connections")
+    .delete()
+    .eq("connection_id", connectionId);
+
+  if (error) throw new Error(`Failed to delete config: ${error.message}`);
+}
+
+// ============================================================================
+// discord2_trigger_credentials
+// ============================================================================
+
+export async function saveTriggerCredentials(
+  connectionId: string,
+  state: TriggerState,
+): Promise<void> {
+  const client = getSupabaseClient();
+  if (!client) throw new Error("Supabase client not initialized");
+
+  const { error } = await client.from("discord2_trigger_credentials").upsert(
+    {
+      connection_id: connectionId,
+      callback_url: state.credentials.callbackUrl,
+      callback_token: state.credentials.callbackToken,
+      active_trigger_types: state.activeTriggerTypes,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "connection_id" },
+  );
+
+  if (error)
+    throw new Error(`Failed to save trigger credentials: ${error.message}`);
+}
+
+export async function loadTriggerCredentials(
+  connectionId: string,
+): Promise<TriggerState | null> {
+  const client = getSupabaseClient();
+  if (!client) throw new Error("Supabase client not initialized");
+
+  const { data, error } = await client
+    .from("discord2_trigger_credentials")
+    .select("*")
+    .eq("connection_id", connectionId)
+    .single();
+
+  if (error) {
+    if (error.code === "PGRST116") return null;
+    throw new Error(`Failed to load trigger credentials: ${error.message}`);
+  }
+
+  const row = data as TriggerCredentialsRow;
+  return {
+    credentials: {
+      callbackUrl: row.callback_url,
+      callbackToken: row.callback_token,
+    },
+    activeTriggerTypes: row.active_trigger_types,
+  };
+}
+
+export async function deleteTriggerCredentials(
+  connectionId: string,
+): Promise<void> {
+  const client = getSupabaseClient();
+  if (!client) throw new Error("Supabase client not initialized");
+
+  const { error } = await client
+    .from("discord2_trigger_credentials")
+    .delete()
+    .eq("connection_id", connectionId);
+
+  if (error)
+    throw new Error(`Failed to delete trigger credentials: ${error.message}`);
+}
+
+export async function loadAllTriggerCredentials(): Promise<
+  Array<{ connectionId: string; state: TriggerState }>
+> {
+  const client = getSupabaseClient();
+  if (!client) throw new Error("Supabase client not initialized");
+
+  const { data, error } = await client
+    .from("discord2_trigger_credentials")
+    .select("*");
+
+  if (error)
+    throw new Error(`Failed to load trigger credentials: ${error.message}`);
+
+  return ((data || []) as TriggerCredentialsRow[]).map((row) => ({
+    connectionId: row.connection_id,
+    state: {
+      credentials: {
+        callbackUrl: row.callback_url,
+        callbackToken: row.callback_token,
+      },
+      activeTriggerTypes: row.active_trigger_types,
+    },
+  }));
+}

--- a/discord/server/main.ts
+++ b/discord/server/main.ts
@@ -1,0 +1,281 @@
+/**
+ * Discord (events) MCP — entrypoint.
+ *
+ * Multi-tenant: each Mesh connectionId gets its own Discord.js Gateway client,
+ * dedupe by bot_token in the same pod (one Client per token, several
+ * connections can point at it).
+ *
+ * Pod-boot lifecycle:
+ *   1. Mesh runtime spins up the worker, calls withRuntime() — this returns a
+ *      fetch handler (`runtime.fetch`).
+ *   2. We wrap it with our Hono router (/health) and start a Bun HTTP server.
+ *   3. setImmediate kicks off `bootstrapFromSupabase` which loads every
+ *      saved config and starts a bot per unique bot_token.
+ *   4. setInterval runs an hourly health check — restarts any dead clients.
+ *
+ * Mesh `onChange` is the source of truth for fresh configs (header-borne bot
+ * token, latest state). It writes to Supabase so future pod restarts can
+ * rebuild without waiting for the user to "Save" in the dashboard.
+ */
+
+import { serve } from "@decocms/mcps-shared/serve";
+import { withRuntime } from "@decocms/runtime";
+import {
+  updateEnv,
+  ensureBotRunning,
+  shutdownAllBots,
+  isBotRunning,
+} from "./bot/manager.ts";
+import {
+  getAllInstances,
+  getOrCreateInstance,
+  getInstance,
+} from "./bot/instance.ts";
+import { tools } from "./tools/index.ts";
+import { type Env, type Registry, StateSchema } from "./types/env.ts";
+import { app as router } from "./router.ts";
+import {
+  setDiscordConfig,
+  getDiscordConfig,
+  type DiscordConfig,
+} from "./lib/config-cache.ts";
+import { loadAllConnectionConfigs } from "./lib/supabase.ts";
+import * as interactionStore from "./triggers/interaction-store.ts";
+
+export { StateSchema };
+
+const AUTO_RESTART_INTERVAL_MS = 60 * 60 * 1000;
+let autoRestartInterval: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Pull a JSON-serializable snapshot of MESH_REQUEST_CONTEXT.state. After
+ * onChange returns, env.state's binding values turn into Proxies that
+ * serialize to `{}` — we want only the raw values, so we filter by
+ * JSON.stringify.
+ */
+function extractPersistableState(
+  state: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!state) return {};
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(state)) {
+    try {
+      JSON.stringify(value);
+      out[key] = value;
+    } catch {
+      // skip non-serializable values
+    }
+  }
+  return out;
+}
+
+const runtime = withRuntime<Env, typeof StateSchema, Registry>({
+  configuration: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onChange: async (env, config?: any) => {
+      const connectionId = env.MESH_REQUEST_CONTEXT?.connectionId;
+
+      updateEnv(env);
+
+      // Prefer raw config.state (has serializable binding metadata);
+      // fall back to env.state when config isn't provided.
+      const rawState = config?.state ?? env.MESH_REQUEST_CONTEXT?.state;
+      const state = env.MESH_REQUEST_CONTEXT?.state;
+      const meshUrl = env.MESH_REQUEST_CONTEXT?.meshUrl;
+      const organizationId = env.MESH_REQUEST_CONTEXT?.organizationId;
+      const token = env.MESH_REQUEST_CONTEXT?.token;
+
+      if (connectionId) getOrCreateInstance(connectionId, env);
+
+      const authorization = env.MESH_REQUEST_CONTEXT?.authorization;
+      const discordPublicKey = state?.DISCORD_PUBLIC_KEY;
+      const discordApplicationId = state?.DISCORD_APPLICATION_ID;
+      const authorizedGuildsStr = state?.AUTHORIZED_GUILDS;
+
+      const authorizedGuilds = authorizedGuildsStr
+        ? authorizedGuildsStr
+            .split(",")
+            .map((g: string) => g.trim())
+            .filter(Boolean)
+        : [];
+
+      const existingConfig = connectionId
+        ? await getDiscordConfig(connectionId).catch(() => null)
+        : null;
+
+      const mergedConnectionId = connectionId || existingConfig?.connectionId;
+      const mergedOrgId = organizationId || existingConfig?.organizationId;
+      const mergedMeshUrl = meshUrl || existingConfig?.meshUrl;
+
+      if (mergedConnectionId && mergedOrgId && mergedMeshUrl) {
+        let botToken = existingConfig?.botToken || "";
+        if (authorization) {
+          const m = authorization.match(/^Bearer\s+(.+)$/i);
+          if (m) botToken = m[1];
+          else botToken = authorization;
+        }
+
+        const persistableState = extractPersistableState(rawState);
+
+        const configToSave: DiscordConfig = {
+          ...(existingConfig || {}),
+          connectionId: mergedConnectionId,
+          organizationId: mergedOrgId,
+          meshUrl: mergedMeshUrl,
+          meshToken: token || existingConfig?.meshToken,
+          botToken,
+          discordPublicKey:
+            discordPublicKey || existingConfig?.discordPublicKey,
+          discordApplicationId:
+            discordApplicationId || existingConfig?.discordApplicationId,
+          authorizedGuilds:
+            authorizedGuilds.length > 0
+              ? authorizedGuilds
+              : existingConfig?.authorizedGuilds,
+          state: persistableState,
+          updatedAt: new Date().toISOString(),
+        };
+
+        await setDiscordConfig(configToSave);
+      }
+
+      if (env.MESH_REQUEST_CONTEXT?.authorization && !isBotRunning(env)) {
+        try {
+          await ensureBotRunning(env);
+        } catch {
+          // bot will retry on next health check
+        }
+      }
+    },
+    scopes: ["CONNECTION::*", "*"],
+    state: StateSchema,
+  },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tools: tools as any,
+  prompts: [],
+});
+
+// ============================================================================
+// GRACEFUL SHUTDOWN
+// ============================================================================
+async function gracefulShutdown(_signal: string) {
+  try {
+    if (autoRestartInterval) {
+      clearInterval(autoRestartInterval);
+      autoRestartInterval = null;
+    }
+    interactionStore.stopSweeper();
+    await shutdownAllBots();
+  } catch {
+    // best-effort
+  }
+  process.exit(0);
+}
+
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+process.on("beforeExit", () => gracefulShutdown("beforeExit"));
+process.on("uncaughtException", () => gracefulShutdown("uncaughtException"));
+
+// ============================================================================
+// HTTP SERVER
+// ============================================================================
+serve(async (req, env, ctx) => {
+  const routerResponse = await router.fetch(req, env, ctx);
+  if (routerResponse.status === 404) {
+    return runtime.fetch(req, env, ctx);
+  }
+  return routerResponse;
+});
+
+// ============================================================================
+// BOOTSTRAP FROM SUPABASE
+// ============================================================================
+async function bootstrapFromSupabase(): Promise<void> {
+  let rows;
+  try {
+    rows = await loadAllConnectionConfigs();
+  } catch {
+    return;
+  }
+
+  if (rows.length === 0) return;
+
+  // Dedup by bot_token: only one Client per token, others share it.
+  const tokenToOwner = new Map<string, string>();
+
+  for (const row of rows) {
+    const connectionId = row.connection_id;
+    if (!row.bot_token) continue;
+
+    const meshUrl = row.mesh_url;
+    const meshApiKey = row.mesh_api_key || row.mesh_token;
+
+    await setDiscordConfig({
+      connectionId,
+      organizationId: row.organization_id,
+      meshUrl,
+      meshToken: row.mesh_token || undefined,
+      meshApiKey: row.mesh_api_key || undefined,
+      botToken: row.bot_token,
+      discordPublicKey: row.discord_public_key || undefined,
+      discordApplicationId: row.discord_application_id || undefined,
+      authorizedGuilds: row.authorized_guilds || undefined,
+      state: row.state ?? undefined,
+    });
+
+    // Build a synthetic env so ensureBotRunning can resolve the token
+    // without waiting for Mesh to fire onChange.
+    const syntheticEnv = {
+      MESH_REQUEST_CONTEXT: {
+        connectionId,
+        organizationId: row.organization_id,
+        meshUrl,
+        token: meshApiKey || undefined,
+        authorization: `Bearer ${row.bot_token}`,
+        state: row.state ?? {},
+      },
+    } as unknown as Env;
+
+    const instance = getOrCreateInstance(connectionId, syntheticEnv);
+
+    // Share an existing client if another connection already owns this token.
+    const ownerConnectionId = tokenToOwner.get(row.bot_token);
+    if (ownerConnectionId) {
+      const ownerInstance = getInstance(ownerConnectionId);
+      if (ownerInstance?.client) {
+        instance.client = ownerInstance.client;
+        instance.initialized = true;
+      }
+      continue;
+    }
+
+    try {
+      const started = await ensureBotRunning(syntheticEnv);
+      if (started) tokenToOwner.set(row.bot_token, connectionId);
+    } catch {
+      // will retry on next health check
+    }
+  }
+}
+
+async function autoRestartCheck(): Promise<void> {
+  const list = getAllInstances();
+  for (const instance of list) {
+    if (!instance.client || !instance.client.isReady()) {
+      const hasAuth = !!instance.env.MESH_REQUEST_CONTEXT?.authorization;
+      if (!hasAuth) continue;
+      try {
+        await ensureBotRunning(instance.env);
+      } catch {
+        // retry on the next interval
+      }
+    }
+  }
+}
+
+setImmediate(async () => {
+  await bootstrapFromSupabase();
+  autoRestartInterval = setInterval(autoRestartCheck, AUTO_RESTART_INTERVAL_MS);
+  interactionStore.startSweeper();
+});

--- a/discord/server/router.ts
+++ b/discord/server/router.ts
@@ -1,0 +1,14 @@
+/**
+ * HTTP router. Currently exposes only /health — the gateway client receives
+ * all Discord events via WebSocket, so we don't need an interactions
+ * webhook endpoint. If a future deployment requires HTTP-only mode,
+ * wire it up here.
+ */
+
+import { Hono } from "hono";
+
+export const app = new Hono();
+
+app.get("/health", (c) => {
+  return c.json({ status: "ok", service: "discord-events" });
+});

--- a/discord/server/tools/bot/index.ts
+++ b/discord/server/tools/bot/index.ts
@@ -1,0 +1,4 @@
+import { createBotStatusTool } from "./status.ts";
+import { createBotStopTool } from "./stop.ts";
+
+export const botTools = [createBotStatusTool, createBotStopTool];

--- a/discord/server/tools/bot/status.ts
+++ b/discord/server/tools/bot/status.ts
@@ -1,0 +1,27 @@
+import { createPrivateTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import type { Env } from "../../types/env.ts";
+import { getBotStatus } from "../../bot/manager.ts";
+
+export const createBotStatusTool = (_env: Env) =>
+  createPrivateTool({
+    id: "DISCORD_BOT_STATUS",
+    description:
+      "Return runtime status of the Discord bot for this connection: ready, guild count, gateway ping, uptime.",
+    annotations: { readOnlyHint: true },
+    inputSchema: z.object({}).strict(),
+    outputSchema: z
+      .object({
+        running: z.boolean(),
+        initializing: z.boolean(),
+        user: z.string().optional(),
+        guilds: z.number().optional(),
+        uptime: z.number().nullable().optional(),
+        ping: z.number().optional(),
+      })
+      .strict(),
+    execute: async (params: any) => {
+      const env = params.runtimeContext?.env;
+      return getBotStatus(env);
+    },
+  });

--- a/discord/server/tools/bot/stop.ts
+++ b/discord/server/tools/bot/stop.ts
@@ -1,0 +1,31 @@
+import { createPrivateTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import type { Env } from "../../types/env.ts";
+import { shutdownBot } from "../../bot/manager.ts";
+
+export const createBotStopTool = (_env: Env) =>
+  createPrivateTool({
+    id: "DISCORD_BOT_STOP",
+    description:
+      "Stop the Discord bot for this connection (disconnects from the Gateway). Bot will auto-restart on next config save or hourly health check.",
+    annotations: { destructiveHint: true },
+    inputSchema: z.object({}).strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        message: z.string(),
+      })
+      .strict(),
+    execute: async (params: any) => {
+      const env = params.runtimeContext?.env;
+      try {
+        await shutdownBot(env);
+        return { success: true, message: "Discord bot stopped." };
+      } catch (err) {
+        return {
+          success: false,
+          message: `Failed to stop bot: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    },
+  });

--- a/discord/server/tools/channels/index.ts
+++ b/discord/server/tools/channels/index.ts
@@ -1,0 +1,603 @@
+/**
+ * Discord Channel Tools
+ *
+ * Tools for managing channels and threads.
+ */
+
+import { createTool } from "@decocms/runtime/tools";
+import z from "zod";
+import type { Env } from "../../types/env.ts";
+import { discordAPI } from "../../discord-rest/api.ts";
+
+// Channel types enum
+const ChannelType = {
+  GUILD_TEXT: 0,
+  DM: 1,
+  GUILD_VOICE: 2,
+  GROUP_DM: 3,
+  GUILD_CATEGORY: 4,
+  GUILD_ANNOUNCEMENT: 5,
+  ANNOUNCEMENT_THREAD: 10,
+  PUBLIC_THREAD: 11,
+  PRIVATE_THREAD: 12,
+  GUILD_STAGE_VOICE: 13,
+  GUILD_DIRECTORY: 14,
+  GUILD_FORUM: 15,
+  GUILD_MEDIA: 16,
+};
+
+// ============================================================================
+// List Guild Channels
+// ============================================================================
+
+export const createListGuildChannelsTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_LIST_CHANNELS",
+    description: "List all channels from a Discord guild",
+    annotations: { readOnlyHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        channels: z.array(
+          z.object({
+            id: z.string(),
+            name: z.string(),
+            type: z.number(),
+            type_name: z.string(),
+            parent_id: z.string().nullable(),
+            position: z.number(),
+          }),
+        ),
+        count: z.number(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as { guild_id: string };
+
+      const channels = await discordAPI<
+        Array<{
+          id: string;
+          name: string;
+          type: number;
+          parent_id: string | null;
+          position: number;
+        }>
+      >(env, `/guilds/${input.guild_id}/channels`);
+
+      const typeNames: Record<number, string> = {
+        0: "text",
+        2: "voice",
+        4: "category",
+        5: "announcement",
+        13: "stage",
+        15: "forum",
+        16: "media",
+      };
+
+      return {
+        channels: channels.map((c) => ({
+          id: c.id,
+          name: c.name,
+          type: c.type,
+          type_name: typeNames[c.type] || "unknown",
+          parent_id: c.parent_id,
+          position: c.position,
+        })),
+        count: channels.length,
+      };
+    },
+  });
+
+// ============================================================================
+// Create Channel
+// ============================================================================
+
+export const createCreateChannelTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_CREATE_CHANNEL",
+    description: "Create a new channel in a Discord guild",
+    annotations: { destructiveHint: false, openWorldHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID"),
+        name: z.string().describe("Channel name (1-100 characters)"),
+        type: z
+          .enum(["text", "voice", "category", "announcement", "stage", "forum"])
+          .default("text")
+          .describe("Channel type"),
+        topic: z
+          .string()
+          .optional()
+          .describe("Channel topic (0-1024 characters)"),
+        parent_id: z.string().optional().describe("Category ID to nest under"),
+        nsfw: z.boolean().optional().describe("Whether the channel is NSFW"),
+        position: z.number().optional().describe("Sorting position"),
+        reason: z
+          .string()
+          .optional()
+          .describe("Reason for creation (audit log)"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        id: z.string(),
+        name: z.string(),
+        type: z.number(),
+        guild_id: z.string(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        guild_id: string;
+        name: string;
+        type: string;
+        topic?: string;
+        parent_id?: string;
+        nsfw?: boolean;
+        position?: number;
+        reason?: string;
+      };
+
+      const typeMap: Record<string, number> = {
+        text: ChannelType.GUILD_TEXT,
+        voice: ChannelType.GUILD_VOICE,
+        category: ChannelType.GUILD_CATEGORY,
+        announcement: ChannelType.GUILD_ANNOUNCEMENT,
+        stage: ChannelType.GUILD_STAGE_VOICE,
+        forum: ChannelType.GUILD_FORUM,
+      };
+
+      const body: Record<string, unknown> = {
+        name: input.name,
+        type: typeMap[input.type] ?? ChannelType.GUILD_TEXT,
+      };
+
+      if (input.topic) body.topic = input.topic;
+      if (input.parent_id) body.parent_id = input.parent_id;
+      if (input.nsfw !== undefined) body.nsfw = input.nsfw;
+      if (input.position !== undefined) body.position = input.position;
+
+      const result = await discordAPI<{
+        id: string;
+        name: string;
+        type: number;
+        guild_id: string;
+      }>(env, `/guilds/${input.guild_id}/channels`, {
+        method: "POST",
+        body,
+        reason: input.reason,
+      });
+
+      return result;
+    },
+  });
+
+// ============================================================================
+// Create Thread
+// ============================================================================
+
+export const createCreateThreadTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_CREATE_THREAD",
+    description: "Create a thread or forum post in a Discord channel",
+    annotations: { destructiveHint: false, openWorldHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z
+          .string()
+          .describe("The channel ID (text channel or forum)"),
+        name: z.string().describe("Thread name (1-100 characters)"),
+        message_id: z
+          .string()
+          .optional()
+          .describe("Message ID to create thread from (for text channels)"),
+        auto_archive_duration: z
+          .enum(["60", "1440", "4320", "10080"])
+          .optional()
+          .describe("Minutes until auto-archive (60, 1440, 4320, 10080)"),
+        type: z
+          .enum(["public", "private"])
+          .default("public")
+          .describe("Thread type (public or private)"),
+        content: z
+          .string()
+          .optional()
+          .describe("Initial message content (for forum posts)"),
+        reason: z.string().optional().describe("Reason (audit log)"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        id: z.string(),
+        name: z.string(),
+        parent_id: z.string(),
+        type: z.number(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        channel_id: string;
+        name: string;
+        message_id?: string;
+        auto_archive_duration?: string;
+        type: string;
+        content?: string;
+        reason?: string;
+      };
+
+      let endpoint: string;
+      const body: Record<string, unknown> = { name: input.name };
+
+      if (input.auto_archive_duration) {
+        body.auto_archive_duration = parseInt(input.auto_archive_duration, 10);
+      }
+
+      if (input.message_id) {
+        // Create thread from message
+        endpoint = `/channels/${input.channel_id}/messages/${input.message_id}/threads`;
+      } else if (input.content) {
+        // Forum post with initial message
+        endpoint = `/channels/${input.channel_id}/threads`;
+        body.message = { content: input.content };
+      } else {
+        // Thread without message
+        endpoint = `/channels/${input.channel_id}/threads`;
+        body.type =
+          input.type === "private"
+            ? ChannelType.PRIVATE_THREAD
+            : ChannelType.PUBLIC_THREAD;
+      }
+
+      const result = await discordAPI<{
+        id: string;
+        name: string;
+        parent_id: string;
+        type: number;
+      }>(env, endpoint, {
+        method: "POST",
+        body,
+        reason: input.reason,
+      });
+
+      return result;
+    },
+  });
+
+// ============================================================================
+// Get Active Threads
+// ============================================================================
+
+export const createGetActiveThreadsTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_GET_ACTIVE_THREADS",
+    description:
+      "Get all active threads in a Discord server (includes forum posts)",
+    annotations: { readOnlyHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        threads: z.array(
+          z.object({
+            id: z.string(),
+            name: z.string(),
+            parent_id: z.string(),
+            type: z.number(),
+            message_count: z.number().optional(),
+            member_count: z.number().optional(),
+          }),
+        ),
+        count: z.number(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as { guild_id: string };
+
+      const result = await discordAPI<{
+        threads: Array<{
+          id: string;
+          name: string;
+          parent_id: string;
+          type: number;
+          message_count?: number;
+          member_count?: number;
+        }>;
+      }>(env, `/guilds/${input.guild_id}/threads/active`);
+
+      return {
+        threads: result.threads.map((t) => ({
+          id: t.id,
+          name: t.name,
+          parent_id: t.parent_id,
+          type: t.type,
+          message_count: t.message_count,
+          member_count: t.member_count,
+        })),
+        count: result.threads.length,
+      };
+    },
+  });
+
+// ============================================================================
+// Get Archived Threads
+// ============================================================================
+
+export const createGetArchivedThreadsTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_GET_ARCHIVED_THREADS",
+    description: "Get archived threads from a Discord channel",
+    annotations: { readOnlyHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z.string().describe("The channel ID"),
+        type: z
+          .enum(["public", "private"])
+          .default("public")
+          .describe("Thread type"),
+        limit: z.number().min(1).max(100).default(50).describe("Max threads"),
+        before: z.string().optional().describe("ISO8601 timestamp"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        threads: z.array(
+          z.object({
+            id: z.string(),
+            name: z.string(),
+            archived: z.boolean(),
+            archive_timestamp: z.string().optional(),
+          }),
+        ),
+        has_more: z.boolean(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        channel_id: string;
+        type: string;
+        limit: number;
+        before?: string;
+      };
+
+      const params = new URLSearchParams();
+      params.set("limit", String(input.limit));
+      if (input.before) params.set("before", input.before);
+
+      const endpoint =
+        input.type === "private"
+          ? `/channels/${input.channel_id}/threads/archived/private`
+          : `/channels/${input.channel_id}/threads/archived/public`;
+
+      const result = await discordAPI<{
+        threads: Array<{
+          id: string;
+          name: string;
+          thread_metadata: { archived: boolean; archive_timestamp?: string };
+        }>;
+        has_more: boolean;
+      }>(env, `${endpoint}?${params.toString()}`);
+
+      return {
+        threads: result.threads.map((t) => ({
+          id: t.id,
+          name: t.name,
+          archived: t.thread_metadata.archived,
+          archive_timestamp: t.thread_metadata.archive_timestamp,
+        })),
+        has_more: result.has_more,
+      };
+    },
+  });
+
+// ============================================================================
+// Join/Leave Thread
+// ============================================================================
+
+export const createJoinThreadTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_JOIN_THREAD",
+    description: "Join a thread with the bot",
+    annotations: { destructiveHint: false, openWorldHint: true },
+    inputSchema: z
+      .object({
+        thread_id: z.string().describe("The thread ID to join"),
+      })
+      .strict(),
+    outputSchema: z.object({ success: z.boolean() }).strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as { thread_id: string };
+
+      await discordAPI(env, `/channels/${input.thread_id}/thread-members/@me`, {
+        method: "PUT",
+      });
+
+      return { success: true };
+    },
+  });
+
+export const createLeaveThreadTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_LEAVE_THREAD",
+    description: "Leave a thread with the bot",
+    annotations: { destructiveHint: false, openWorldHint: true },
+    inputSchema: z
+      .object({
+        thread_id: z.string().describe("The thread ID to leave"),
+      })
+      .strict(),
+    outputSchema: z.object({ success: z.boolean() }).strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as { thread_id: string };
+
+      await discordAPI(env, `/channels/${input.thread_id}/thread-members/@me`, {
+        method: "DELETE",
+      });
+
+      return { success: true };
+    },
+  });
+
+// ============================================================================
+// Edit Thread
+// ============================================================================
+
+export const createEditThreadTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_EDIT_THREAD",
+    description:
+      "Edit a thread or forum post — change name, archive status, or applied tags (for forum posts, use applied_tags to add/remove tags like 'Solved')",
+    annotations: { destructiveHint: false, openWorldHint: true },
+    inputSchema: z
+      .object({
+        thread_id: z.string().describe("The thread/forum post ID to edit"),
+        name: z
+          .string()
+          .optional()
+          .describe("New thread name (1-100 characters)"),
+        archived: z
+          .boolean()
+          .optional()
+          .describe("Whether to archive the thread"),
+        locked: z.boolean().optional().describe("Whether to lock the thread"),
+        applied_tags: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Tag IDs to apply (forum posts only). Replaces all current tags. Max 5.",
+          ),
+        auto_archive_duration: z
+          .enum(["60", "1440", "4320", "10080"])
+          .optional()
+          .describe("Minutes until auto-archive"),
+        reason: z.string().optional().describe("Reason (audit log)"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        id: z.string(),
+        name: z.string(),
+        archived: z.boolean(),
+        locked: z.boolean(),
+        applied_tags: z.array(z.string()).optional(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        thread_id: string;
+        name?: string;
+        archived?: boolean;
+        locked?: boolean;
+        applied_tags?: string[];
+        auto_archive_duration?: string;
+        reason?: string;
+      };
+
+      const body: Record<string, unknown> = {};
+      if (input.name !== undefined) body.name = input.name;
+      if (input.archived !== undefined) body.archived = input.archived;
+      if (input.locked !== undefined) body.locked = input.locked;
+      if (input.applied_tags !== undefined)
+        body.applied_tags = input.applied_tags;
+      if (input.auto_archive_duration !== undefined)
+        body.auto_archive_duration = parseInt(input.auto_archive_duration, 10);
+
+      const result = await discordAPI<{
+        id: string;
+        name: string;
+        thread_metadata: { archived: boolean; locked: boolean };
+        applied_tags?: string[];
+      }>(env, `/channels/${input.thread_id}`, {
+        method: "PATCH",
+        body,
+        reason: input.reason,
+      });
+
+      return {
+        id: result.id,
+        name: result.name,
+        archived: result.thread_metadata?.archived ?? false,
+        locked: result.thread_metadata?.locked ?? false,
+        applied_tags: result.applied_tags,
+      };
+    },
+  });
+
+// ============================================================================
+// Get Forum Tags
+// ============================================================================
+
+export const createGetForumTagsTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_GET_FORUM_TAGS",
+    description:
+      "Get available tags from a forum channel. Use this to find tag IDs (e.g. 'Solved') before applying them with DISCORD_EDIT_THREAD.",
+    annotations: { readOnlyHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z.string().describe("The forum channel ID"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        tags: z.array(
+          z.object({
+            id: z.string(),
+            name: z.string(),
+            moderated: z.boolean(),
+            emoji_id: z.string().nullable(),
+            emoji_name: z.string().nullable(),
+          }),
+        ),
+        channel_name: z.string(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as { channel_id: string };
+
+      const channel = await discordAPI<{
+        id: string;
+        name: string;
+        available_tags?: Array<{
+          id: string;
+          name: string;
+          moderated: boolean;
+          emoji_id: string | null;
+          emoji_name: string | null;
+        }>;
+      }>(env, `/channels/${input.channel_id}`);
+
+      return {
+        tags: (channel.available_tags ?? []).map((t) => ({
+          id: t.id,
+          name: t.name,
+          moderated: t.moderated,
+          emoji_id: t.emoji_id,
+          emoji_name: t.emoji_name,
+        })),
+        channel_name: channel.name,
+      };
+    },
+  });
+
+// ============================================================================
+// Export
+// ============================================================================
+
+export const discordChannelTools = [
+  createListGuildChannelsTool,
+  createCreateChannelTool,
+  createCreateThreadTool,
+  createEditThreadTool,
+  createGetActiveThreadsTool,
+  createGetArchivedThreadsTool,
+  createGetForumTagsTool,
+  createJoinThreadTool,
+  createLeaveThreadTool,
+];

--- a/discord/server/tools/config/delete.ts
+++ b/discord/server/tools/config/delete.ts
@@ -1,0 +1,54 @@
+import { createPrivateTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import type { Env } from "../../types/env.ts";
+import { deleteDiscordConfig } from "../../lib/config-cache.ts";
+import { isSupabaseConfigured } from "../../lib/supabase.ts";
+
+export const createDeleteConfigTool = (_env: Env) =>
+  createPrivateTool({
+    id: "DISCORD_DELETE_CONFIG",
+    description:
+      "Delete the Discord bot configuration for this connection. Stops the bot and removes the saved token from Supabase. Cannot be undone.",
+    annotations: { destructiveHint: true },
+    inputSchema: z.object({}).strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        message: z.string(),
+      })
+      .strict(),
+    execute: async (params: any) => {
+      const env = params.runtimeContext?.env;
+
+      if (!isSupabaseConfigured()) {
+        return {
+          success: false,
+          message: "Supabase not configured.",
+        };
+      }
+
+      const connectionId =
+        env?.MESH_REQUEST_CONTEXT?.connectionId || "default-connection";
+
+      try {
+        try {
+          const { shutdownBot } = await import("../../bot/manager.ts");
+          if (env) await shutdownBot(env);
+        } catch {
+          // bot may not have been running; proceed with config delete
+        }
+
+        await deleteDiscordConfig(connectionId);
+
+        return {
+          success: true,
+          message: `Configuration deleted for ${connectionId}.`,
+        };
+      } catch (err) {
+        return {
+          success: false,
+          message: `Failed to delete configuration: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    },
+  });

--- a/discord/server/tools/config/get.ts
+++ b/discord/server/tools/config/get.ts
@@ -1,0 +1,82 @@
+import { createPrivateTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import type { Env } from "../../types/env.ts";
+import { getDiscordConfig } from "../../lib/config-cache.ts";
+import { isSupabaseConfigured } from "../../lib/supabase.ts";
+
+function maskToken(token: string | null | undefined): string {
+  if (!token) return "MISSING";
+  if (token.length < 16) return "***";
+  return `${token.slice(0, 10)}...${token.slice(-4)}`;
+}
+
+export const createGetConfigTool = (_env: Env) =>
+  createPrivateTool({
+    id: "DISCORD_GET_CONFIG",
+    description:
+      "Read the saved Discord bot configuration for this connection. Bot token is redacted to first10+last4 characters; never returned in full.",
+    annotations: { readOnlyHint: true },
+    inputSchema: z.object({}).strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        message: z.string(),
+        config: z
+          .object({
+            connectionId: z.string(),
+            organizationId: z.string(),
+            botTokenMasked: z.string(),
+            discordApplicationId: z.string().optional(),
+            discordPublicKey: z.string().optional(),
+            authorizedGuilds: z.array(z.string()).optional(),
+            configuredAt: z.string().optional(),
+            updatedAt: z.string().optional(),
+          })
+          .optional(),
+      })
+      .strict(),
+    execute: async (params: any) => {
+      const env = params.runtimeContext?.env;
+
+      if (!isSupabaseConfigured()) {
+        return {
+          success: false,
+          message:
+            "Supabase not configured. Set SUPABASE_URL and SUPABASE_ANON_KEY environment variables.",
+        };
+      }
+
+      const connectionId =
+        env?.MESH_REQUEST_CONTEXT?.connectionId || "default-connection";
+
+      try {
+        const config = await getDiscordConfig(connectionId);
+        if (!config) {
+          return {
+            success: false,
+            message: `No configuration found for connection ${connectionId}. Use DISCORD_SAVE_CONFIG first.`,
+          };
+        }
+
+        return {
+          success: true,
+          message: "Configuration loaded.",
+          config: {
+            connectionId: config.connectionId,
+            organizationId: config.organizationId,
+            botTokenMasked: maskToken(config.botToken),
+            discordApplicationId: config.discordApplicationId,
+            discordPublicKey: config.discordPublicKey,
+            authorizedGuilds: config.authorizedGuilds,
+            configuredAt: config.configuredAt,
+            updatedAt: config.updatedAt,
+          },
+        };
+      } catch (err) {
+        return {
+          success: false,
+          message: `Failed to load configuration: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    },
+  });

--- a/discord/server/tools/config/index.ts
+++ b/discord/server/tools/config/index.ts
@@ -1,0 +1,9 @@
+import { createSaveConfigTool } from "./save.ts";
+import { createGetConfigTool } from "./get.ts";
+import { createDeleteConfigTool } from "./delete.ts";
+
+export const configTools = [
+  createSaveConfigTool,
+  createGetConfigTool,
+  createDeleteConfigTool,
+];

--- a/discord/server/tools/config/save.ts
+++ b/discord/server/tools/config/save.ts
@@ -1,0 +1,117 @@
+import { createPrivateTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import type { Env } from "../../types/env.ts";
+import {
+  setDiscordConfig,
+  type DiscordConfig,
+} from "../../lib/config-cache.ts";
+import { isSupabaseConfigured } from "../../lib/supabase.ts";
+
+export const createSaveConfigTool = (_env: Env) =>
+  createPrivateTool({
+    id: "DISCORD_SAVE_CONFIG",
+    description:
+      "Save Discord bot configuration (bot token, public key, application ID, authorized guilds). The bot will auto-start once configured. Token is persisted in Supabase and survives pod restarts.",
+    annotations: { destructiveHint: false },
+    inputSchema: z
+      .object({
+        botToken: z
+          .string()
+          .describe("Discord bot token from the Discord Developer Portal."),
+        discordApplicationId: z
+          .string()
+          .optional()
+          .describe(
+            "Discord Application ID. Required for the agent to respond to interactions (button/select/modal events).",
+          ),
+        discordPublicKey: z
+          .string()
+          .optional()
+          .describe(
+            "Discord application public key. Only needed if you plan to use HTTP webhook delivery for slash commands (gateway delivery does not need it).",
+          ),
+        authorizedGuilds: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Guild IDs allowed to use this bot. Empty array (or omitted) = all guilds.",
+          ),
+        meshApiKey: z
+          .string()
+          .optional()
+          .describe(
+            "Persistent Mesh API key (never expires). Recommended over the auto-rotated session token.",
+          ),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        message: z.string(),
+        connectionId: z.string(),
+      })
+      .strict(),
+    execute: async (params: any) => {
+      const env = params.runtimeContext?.env;
+      const ctx = params.context as {
+        botToken: string;
+        discordApplicationId?: string;
+        discordPublicKey?: string;
+        authorizedGuilds?: string[];
+        meshApiKey?: string;
+      };
+
+      if (!isSupabaseConfigured()) {
+        return {
+          success: false,
+          message:
+            "Supabase not configured. Set SUPABASE_URL and SUPABASE_ANON_KEY environment variables.",
+          connectionId: "",
+        };
+      }
+
+      const connectionId =
+        env?.MESH_REQUEST_CONTEXT?.connectionId || "default-connection";
+      const organizationId =
+        env?.MESH_REQUEST_CONTEXT?.organizationId || "default-org";
+      const meshUrl = env?.MESH_REQUEST_CONTEXT?.meshUrl || "";
+
+      const config: DiscordConfig = {
+        connectionId,
+        organizationId,
+        meshUrl,
+        meshApiKey: ctx.meshApiKey,
+        botToken: ctx.botToken,
+        discordApplicationId: ctx.discordApplicationId,
+        discordPublicKey: ctx.discordPublicKey,
+        authorizedGuilds: ctx.authorizedGuilds || [],
+      };
+
+      try {
+        await setDiscordConfig(config);
+
+        // Try to start the bot now; failure is non-fatal (auto-restart cron retries).
+        try {
+          const { ensureBotRunning } = await import("../../bot/manager.ts");
+          if (env) await ensureBotRunning(env);
+        } catch {
+          // ignore
+        }
+
+        return {
+          success: true,
+          message:
+            ctx.authorizedGuilds && ctx.authorizedGuilds.length > 0
+              ? `Discord bot configured for ${ctx.authorizedGuilds.length} authorized guild(s).`
+              : "Discord bot configured (allowed in all guilds).",
+          connectionId,
+        };
+      } catch (err) {
+        return {
+          success: false,
+          message: `Failed to save configuration: ${err instanceof Error ? err.message : String(err)}`,
+          connectionId,
+        };
+      }
+    },
+  });

--- a/discord/server/tools/guilds/index.ts
+++ b/discord/server/tools/guilds/index.ts
@@ -1,0 +1,1496 @@
+/**
+ * Discord Guild Tools
+ *
+ * Tools for managing guilds, members, and roles.
+ */
+
+import { createTool } from "@decocms/runtime/tools";
+import z from "zod";
+import type { Env } from "../../types/env.ts";
+import { discordAPI, discordAPIBatch } from "../../discord-rest/api.ts";
+
+// ============================================================================
+// Get Guild
+// ============================================================================
+
+export const createGetGuildTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_GET_GUILD",
+    description: "Get information about a Discord guild",
+    annotations: { readOnlyHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID"),
+        with_counts: z
+          .boolean()
+          .default(true)
+          .describe("Include member/presence counts"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        id: z.string(),
+        name: z.string(),
+        icon: z.string().nullable(),
+        owner_id: z.string(),
+        member_count: z.number().optional(),
+        presence_count: z.number().optional(),
+        description: z.string().nullable(),
+        premium_tier: z.number(),
+        features: z.array(z.string()),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as { guild_id: string; with_counts: boolean };
+
+      const params = input.with_counts ? "?with_counts=true" : "";
+
+      const result = await discordAPI<{
+        id: string;
+        name: string;
+        icon: string | null;
+        owner_id: string;
+        approximate_member_count?: number;
+        approximate_presence_count?: number;
+        description: string | null;
+        premium_tier: number;
+        features: string[];
+      }>(env, `/guilds/${input.guild_id}${params}`);
+
+      return {
+        id: result.id,
+        name: result.name,
+        icon: result.icon,
+        owner_id: result.owner_id,
+        member_count: result.approximate_member_count,
+        presence_count: result.approximate_presence_count,
+        description: result.description,
+        premium_tier: result.premium_tier,
+        features: result.features,
+      };
+    },
+  });
+
+// ============================================================================
+// List Bot Guilds
+// ============================================================================
+
+export const createListBotGuildsTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_LIST_BOT_GUILDS",
+    description: "List all guilds where the bot is present",
+    annotations: { readOnlyHint: true },
+    inputSchema: z
+      .object({
+        limit: z.number().min(1).max(200).default(100).describe("Max guilds"),
+        before: z.string().optional().describe("Get guilds before this ID"),
+        after: z.string().optional().describe("Get guilds after this ID"),
+      })
+      .strict(),
+    outputSchema: z.object({
+      guilds: z.array(
+        z
+          .object({
+            id: z.string(),
+            name: z.string(),
+            icon: z.string().nullable(),
+            owner: z.boolean().optional(),
+            permissions: z.string().optional(),
+            banner: z.string().nullable().optional(),
+            features: z.array(z.string()).optional(),
+            approximate_member_count: z.number().optional(),
+            approximate_presence_count: z.number().optional(),
+          })
+          .catchall(z.unknown()),
+      ),
+      count: z.number(),
+    }),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        limit: number;
+        before?: string;
+        after?: string;
+      };
+
+      const params = new URLSearchParams();
+      params.set("limit", String(input.limit));
+      if (input.before) params.set("before", input.before);
+      if (input.after) params.set("after", input.after);
+
+      const guilds = await discordAPI<
+        Array<{
+          id: string;
+          name: string;
+          icon: string | null;
+          owner: boolean;
+          permissions: string;
+        }>
+      >(env, `/users/@me/guilds?${params.toString()}`);
+
+      return {
+        guilds,
+        count: guilds.length,
+      };
+    },
+  });
+
+// ============================================================================
+// Get Guild Members
+// ============================================================================
+
+export const createGetGuildMembersTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_GET_MEMBERS",
+    description: "List members of a Discord guild",
+    annotations: { readOnlyHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID"),
+        limit: z.number().min(1).max(1000).default(100).describe("Max members"),
+        after: z.string().optional().describe("Get members after this user ID"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        members: z.array(
+          z.object({
+            user_id: z.string(),
+            username: z.string(),
+            nick: z.string().nullable(),
+            roles: z.array(z.string()),
+            joined_at: z.string(),
+            bot: z.boolean(),
+          }),
+        ),
+        count: z.number(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        guild_id: string;
+        limit: number;
+        after?: string;
+      };
+
+      const params = new URLSearchParams();
+      params.set("limit", String(input.limit));
+      if (input.after) params.set("after", input.after);
+
+      const members = await discordAPI<
+        Array<{
+          user: { id: string; username: string; bot?: boolean };
+          nick: string | null;
+          roles: string[];
+          joined_at: string;
+        }>
+      >(env, `/guilds/${input.guild_id}/members?${params.toString()}`);
+
+      return {
+        members: members.map((m) => ({
+          user_id: m.user.id,
+          username: m.user.username,
+          nick: m.nick,
+          roles: m.roles,
+          joined_at: m.joined_at,
+          bot: m.user.bot ?? false,
+        })),
+        count: members.length,
+      };
+    },
+  });
+
+// ============================================================================
+// Search Members by Name
+// ============================================================================
+
+export const createSearchMembersTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_SEARCH_MEMBERS",
+    description:
+      "Search guild members by username or nickname. Returns members whose username or nickname starts with the query.",
+    annotations: { readOnlyHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID"),
+        query: z
+          .string()
+          .min(1)
+          .describe("Username or nickname to search (prefix match)"),
+        limit: z
+          .number()
+          .min(1)
+          .max(1000)
+          .default(100)
+          .describe("Max members to return"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        members: z.array(
+          z.object({
+            user_id: z.string(),
+            username: z.string(),
+            global_name: z.string().nullable(),
+            nick: z.string().nullable(),
+            avatar: z.string().nullable(),
+            roles: z.array(z.string()),
+            joined_at: z.string(),
+            bot: z.boolean(),
+          }),
+        ),
+        count: z.number(),
+        query: z.string(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        guild_id: string;
+        query: string;
+        limit: number;
+      };
+
+      const params = new URLSearchParams();
+      params.set("query", input.query);
+      params.set("limit", String(input.limit));
+
+      const members = await discordAPI<
+        Array<{
+          user: {
+            id: string;
+            username: string;
+            global_name: string | null;
+            avatar: string | null;
+            bot?: boolean;
+          };
+          nick: string | null;
+          roles: string[];
+          joined_at: string;
+        }>
+      >(env, `/guilds/${input.guild_id}/members/search?${params.toString()}`);
+
+      return {
+        members: members.map((m) => ({
+          user_id: m.user.id,
+          username: m.user.username,
+          global_name: m.user.global_name,
+          nick: m.nick,
+          avatar: m.user.avatar,
+          roles: m.roles,
+          joined_at: m.joined_at,
+          bot: m.user.bot ?? false,
+        })),
+        count: members.length,
+        query: input.query,
+      };
+    },
+  });
+
+// ============================================================================
+// Get User (global info only)
+// ============================================================================
+
+export const createGetUserTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_GET_USER",
+    description:
+      "Get GLOBAL information about a Discord user (no roles/server info). Use DISCORD_GET_MEMBER for server-specific info like roles.",
+    annotations: { readOnlyHint: true },
+    inputSchema: z
+      .object({
+        user_id: z.string().describe("The user ID"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        id: z.string(),
+        username: z.string(),
+        global_name: z.string().nullable(),
+        avatar: z.string().nullable(),
+        bot: z.boolean(),
+        banner: z.string().nullable(),
+        accent_color: z.number().nullable(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as { user_id: string };
+
+      const result = await discordAPI<{
+        id: string;
+        username: string;
+        global_name: string | null;
+        avatar: string | null;
+        bot?: boolean;
+        banner: string | null;
+        accent_color: number | null;
+      }>(env, `/users/${input.user_id}`);
+
+      return {
+        id: result.id,
+        username: result.username,
+        global_name: result.global_name,
+        avatar: result.avatar,
+        bot: result.bot ?? false,
+        banner: result.banner,
+        accent_color: result.accent_color,
+      };
+    },
+  });
+
+// ============================================================================
+// Get Guild Member (with roles and server-specific info)
+// ============================================================================
+
+export const createGetMemberTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_GET_MEMBER",
+    description:
+      "Get a member's info in a server INCLUDING their roles, nickname, join date. Use this to check user roles!",
+    annotations: { readOnlyHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild/server ID"),
+        user_id: z.string().describe("The user ID"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        user: z.object({
+          id: z.string(),
+          username: z.string(),
+          global_name: z.string().nullable(),
+          avatar: z.string().nullable(),
+          bot: z.boolean(),
+        }),
+        nick: z.string().nullable(),
+        roles: z.array(z.string()),
+        joined_at: z.string(),
+        premium_since: z.string().nullable(),
+        deaf: z.boolean(),
+        mute: z.boolean(),
+        pending: z.boolean().optional(),
+        communication_disabled_until: z.string().nullable().optional(),
+      })
+      .passthrough(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as { guild_id: string; user_id: string };
+
+      const result = await discordAPI<{
+        user: {
+          id: string;
+          username: string;
+          global_name: string | null;
+          avatar: string | null;
+          bot?: boolean;
+        };
+        nick: string | null;
+        roles: string[];
+        joined_at: string;
+        premium_since: string | null;
+        deaf: boolean;
+        mute: boolean;
+        pending?: boolean;
+        communication_disabled_until?: string | null;
+      }>(env, `/guilds/${input.guild_id}/members/${input.user_id}`);
+
+      return {
+        user: {
+          id: result.user.id,
+          username: result.user.username,
+          global_name: result.user.global_name,
+          avatar: result.user.avatar,
+          bot: result.user.bot ?? false,
+        },
+        nick: result.nick,
+        roles: result.roles,
+        joined_at: result.joined_at,
+        premium_since: result.premium_since,
+        deaf: result.deaf,
+        mute: result.mute,
+        pending: result.pending,
+        communication_disabled_until: result.communication_disabled_until,
+      };
+    },
+  });
+
+// ============================================================================
+// Get Current User
+// ============================================================================
+
+export const createGetCurrentUserTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_GET_BOT_USER",
+    description: "Get information about the bot's own user account",
+    annotations: { readOnlyHint: true },
+    inputSchema: z.object({}).strict(),
+    outputSchema: z
+      .object({
+        id: z.string(),
+        username: z.string(),
+        avatar: z.string().nullable(),
+        bot: z.boolean(),
+      })
+      .strict(),
+    execute: async () => {
+      const result = await discordAPI<{
+        id: string;
+        username: string;
+        avatar: string | null;
+        bot?: boolean;
+      }>(env, `/users/@me`);
+
+      return {
+        id: result.id,
+        username: result.username,
+        avatar: result.avatar,
+        bot: result.bot ?? true,
+      };
+    },
+  });
+
+// ============================================================================
+// Ban Member (supports single or multiple users)
+// ============================================================================
+
+export const createBanMemberTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_BAN_MEMBER",
+    description:
+      "Ban one or more members from a Discord server. Supports batch operations with rate limit handling.",
+    annotations: { destructiveHint: true, openWorldHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID"),
+        user_id: z.string().optional().describe("Single user ID to ban"),
+        user_ids: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Array of user IDs to ban (processed with rate limit handling)",
+          ),
+        delete_message_days: z
+          .number()
+          .min(0)
+          .max(7)
+          .optional()
+          .describe("Days of messages to delete (0-7)"),
+        reason: z.string().optional().describe("Reason for ban (audit log)"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        banned_count: z.number(),
+        failed_count: z.number(),
+        errors: z
+          .array(z.object({ user_id: z.string(), error: z.string() }))
+          .optional(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        guild_id: string;
+        user_id?: string;
+        user_ids?: string[];
+        delete_message_days?: number;
+        reason?: string;
+      };
+
+      const usersToBan: string[] = [];
+      if (input.user_id) usersToBan.push(input.user_id);
+      if (input.user_ids) usersToBan.push(...input.user_ids);
+
+      if (usersToBan.length === 0) {
+        throw new Error("Either user_id or user_ids must be provided");
+      }
+
+      const body: Record<string, unknown> = {};
+      if (input.delete_message_days !== undefined) {
+        body.delete_message_seconds = input.delete_message_days * 86400;
+      }
+
+      // Single user - simple ban
+      if (usersToBan.length === 1) {
+        await discordAPI(
+          env,
+          `/guilds/${input.guild_id}/bans/${usersToBan[0]}`,
+          { method: "PUT", body, reason: input.reason },
+        );
+        return { success: true, banned_count: 1, failed_count: 0 };
+      }
+
+      // Multiple users - batch ban
+
+      const { results, errors } = await discordAPIBatch(
+        env,
+        usersToBan,
+        async (userId) => {
+          await discordAPI(env, `/guilds/${input.guild_id}/bans/${userId}`, {
+            method: "PUT",
+            body,
+            reason: input.reason,
+          });
+          return userId;
+        },
+        {
+          delayMs: 300,
+          onProgress: (completed, total) => {
+            if (completed % 5 === 0 || completed === total) {
+            }
+          },
+          onError: () => "skip",
+        },
+      );
+
+      return {
+        success: errors.length === 0,
+        banned_count: results.length,
+        failed_count: errors.length,
+        errors:
+          errors.length > 0
+            ? errors.map((e) => ({ user_id: e.item, error: e.error }))
+            : undefined,
+      };
+    },
+  });
+
+// ============================================================================
+// Get Guild Roles
+// ============================================================================
+
+export const createGetGuildRolesTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_GET_ROLES",
+    description: "Get all roles from a Discord server",
+    annotations: { readOnlyHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        roles: z.array(
+          z.object({
+            id: z.string(),
+            name: z.string(),
+            color: z.number(),
+            position: z.number(),
+            permissions: z.string(),
+            mentionable: z.boolean(),
+            managed: z.boolean(),
+          }),
+        ),
+        count: z.number(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as { guild_id: string };
+
+      const roles = await discordAPI<
+        Array<{
+          id: string;
+          name: string;
+          color: number;
+          position: number;
+          permissions: string;
+          mentionable: boolean;
+          managed: boolean;
+        }>
+      >(env, `/guilds/${input.guild_id}/roles`);
+
+      return {
+        roles: roles.map((r) => ({
+          id: r.id,
+          name: r.name,
+          color: r.color,
+          position: r.position,
+          permissions: r.permissions,
+          mentionable: r.mentionable,
+          managed: r.managed,
+        })),
+        count: roles.length,
+      };
+    },
+  });
+
+// ============================================================================
+// Create Role
+// ============================================================================
+
+export const createCreateRoleTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_CREATE_ROLE",
+    description: "Create a new role in a Discord server",
+    annotations: { destructiveHint: false, openWorldHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID"),
+        name: z.string().describe("Role name"),
+        color: z.number().optional().describe("Role color (integer)"),
+        hoist: z
+          .boolean()
+          .optional()
+          .describe("Display role members separately"),
+        mentionable: z.boolean().optional().describe("Allow anyone to mention"),
+        reason: z.string().optional().describe("Reason (audit log)"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        id: z.string(),
+        name: z.string(),
+        color: z.number(),
+        position: z.number(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        guild_id: string;
+        name: string;
+        color?: number;
+        hoist?: boolean;
+        mentionable?: boolean;
+        reason?: string;
+      };
+
+      const body: Record<string, unknown> = { name: input.name };
+      if (input.color !== undefined) body.color = input.color;
+      if (input.hoist !== undefined) body.hoist = input.hoist;
+      if (input.mentionable !== undefined) body.mentionable = input.mentionable;
+
+      const result = await discordAPI<{
+        id: string;
+        name: string;
+        color: number;
+        position: number;
+      }>(env, `/guilds/${input.guild_id}/roles`, {
+        method: "POST",
+        body,
+        reason: input.reason,
+      });
+
+      return result;
+    },
+  });
+
+// ============================================================================
+// Edit Role
+// ============================================================================
+
+export const createEditRoleTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_EDIT_ROLE",
+    description: "Edit an existing role in a Discord server",
+    annotations: { destructiveHint: true, openWorldHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID"),
+        role_id: z.string().describe("The role ID to edit"),
+        name: z.string().optional().describe("New role name"),
+        color: z.number().optional().describe("New role color"),
+        hoist: z.boolean().optional().describe("Display separately"),
+        mentionable: z.boolean().optional().describe("Allow mentions"),
+        reason: z.string().optional().describe("Reason (audit log)"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        id: z.string(),
+        name: z.string(),
+        color: z.number(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        guild_id: string;
+        role_id: string;
+        name?: string;
+        color?: number;
+        hoist?: boolean;
+        mentionable?: boolean;
+        reason?: string;
+      };
+
+      const body: Record<string, unknown> = {};
+      if (input.name !== undefined) body.name = input.name;
+      if (input.color !== undefined) body.color = input.color;
+      if (input.hoist !== undefined) body.hoist = input.hoist;
+      if (input.mentionable !== undefined) body.mentionable = input.mentionable;
+
+      const result = await discordAPI<{
+        id: string;
+        name: string;
+        color: number;
+      }>(env, `/guilds/${input.guild_id}/roles/${input.role_id}`, {
+        method: "PATCH",
+        body,
+        reason: input.reason,
+      });
+
+      return result;
+    },
+  });
+
+// ============================================================================
+// Delete Role (supports multiple roles)
+// ============================================================================
+
+export const createDeleteRoleTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_DELETE_ROLE",
+    description:
+      "Delete one or more roles from a Discord server. Supports batch operations.",
+    annotations: { destructiveHint: true, openWorldHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID"),
+        role_id: z.string().optional().describe("Single role ID to delete"),
+        role_ids: z
+          .array(z.string())
+          .optional()
+          .describe("Array of role IDs to delete"),
+        reason: z.string().optional().describe("Reason (audit log)"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        deleted_count: z.number(),
+        failed_count: z.number(),
+        errors: z
+          .array(z.object({ role_id: z.string(), error: z.string() }))
+          .optional(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        guild_id: string;
+        role_id?: string;
+        role_ids?: string[];
+        reason?: string;
+      };
+
+      const roles: string[] = [];
+      if (input.role_id) roles.push(input.role_id);
+      if (input.role_ids) roles.push(...input.role_ids);
+
+      if (roles.length === 0) {
+        throw new Error("Either role_id or role_ids must be provided");
+      }
+
+      // Single role - simple delete
+      if (roles.length === 1) {
+        await discordAPI(env, `/guilds/${input.guild_id}/roles/${roles[0]}`, {
+          method: "DELETE",
+          reason: input.reason,
+        });
+        return { success: true, deleted_count: 1, failed_count: 0 };
+      }
+
+      // Multiple roles - batch delete
+
+      const { results, errors } = await discordAPIBatch(
+        env,
+        roles,
+        async (roleId) => {
+          await discordAPI(env, `/guilds/${input.guild_id}/roles/${roleId}`, {
+            method: "DELETE",
+            reason: input.reason,
+          });
+          return roleId;
+        },
+        {
+          delayMs: 300,
+          onProgress: (completed, total) => {
+            if (completed % 5 === 0 || completed === total) {
+            }
+          },
+          onError: () => "skip",
+        },
+      );
+
+      return {
+        success: errors.length === 0,
+        deleted_count: results.length,
+        failed_count: errors.length,
+        errors:
+          errors.length > 0
+            ? errors.map((e) => ({ role_id: e.item, error: e.error }))
+            : undefined,
+      };
+    },
+  });
+
+// ============================================================================
+// Add Role to Member (supports multiple users)
+// ============================================================================
+
+export const createAddRoleToMemberTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_ADD_ROLE",
+    description:
+      "Add a role to one or more guild members. Supports batch operations with rate limit handling.",
+    annotations: { destructiveHint: false, openWorldHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID"),
+        user_id: z.string().optional().describe("Single user ID"),
+        user_ids: z
+          .array(z.string())
+          .optional()
+          .describe("Array of user IDs to add the role to"),
+        role_id: z.string().describe("The role ID to add"),
+        reason: z.string().optional().describe("Reason for audit log"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        added_count: z.number(),
+        failed_count: z.number(),
+        message: z.string(),
+        errors: z
+          .array(z.object({ user_id: z.string(), error: z.string() }))
+          .optional(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        guild_id: string;
+        user_id?: string;
+        user_ids?: string[];
+        role_id: string;
+        reason?: string;
+      };
+
+      const users: string[] = [];
+      if (input.user_id) users.push(input.user_id);
+      if (input.user_ids) users.push(...input.user_ids);
+
+      if (users.length === 0) {
+        throw new Error("Either user_id or user_ids must be provided");
+      }
+
+      // Single user - simple add
+      if (users.length === 1) {
+        await discordAPI(
+          env,
+          `/guilds/${input.guild_id}/members/${users[0]}/roles/${input.role_id}`,
+          { method: "PUT", reason: input.reason },
+        );
+        return {
+          success: true,
+          added_count: 1,
+          failed_count: 0,
+          message: `Role ${input.role_id} added to user ${users[0]}`,
+        };
+      }
+
+      // Multiple users - batch add
+
+      const { results, errors } = await discordAPIBatch(
+        env,
+        users,
+        async (userId) => {
+          await discordAPI(
+            env,
+            `/guilds/${input.guild_id}/members/${userId}/roles/${input.role_id}`,
+            { method: "PUT", reason: input.reason },
+          );
+          return userId;
+        },
+        {
+          delayMs: 200,
+          onProgress: (completed, total) => {
+            if (completed % 10 === 0 || completed === total) {
+            }
+          },
+          onError: () => "skip",
+        },
+      );
+
+      return {
+        success: errors.length === 0,
+        added_count: results.length,
+        failed_count: errors.length,
+        message: `Role added to ${results.length} of ${users.length} users`,
+        errors:
+          errors.length > 0
+            ? errors.map((e) => ({ user_id: e.item, error: e.error }))
+            : undefined,
+      };
+    },
+  });
+
+// ============================================================================
+// Remove Role from Member (supports multiple users)
+// ============================================================================
+
+export const createRemoveRoleFromMemberTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_REMOVE_ROLE",
+    description:
+      "Remove a role from one or more guild members. Supports batch operations with rate limit handling.",
+    annotations: { destructiveHint: true, openWorldHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID"),
+        user_id: z.string().optional().describe("Single user ID"),
+        user_ids: z
+          .array(z.string())
+          .optional()
+          .describe("Array of user IDs to remove the role from"),
+        role_id: z.string().describe("The role ID to remove"),
+        reason: z.string().optional().describe("Reason for audit log"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        removed_count: z.number(),
+        failed_count: z.number(),
+        message: z.string(),
+        errors: z
+          .array(z.object({ user_id: z.string(), error: z.string() }))
+          .optional(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        guild_id: string;
+        user_id?: string;
+        user_ids?: string[];
+        role_id: string;
+        reason?: string;
+      };
+
+      const users: string[] = [];
+      if (input.user_id) users.push(input.user_id);
+      if (input.user_ids) users.push(...input.user_ids);
+
+      if (users.length === 0) {
+        throw new Error("Either user_id or user_ids must be provided");
+      }
+
+      // Single user - simple remove
+      if (users.length === 1) {
+        await discordAPI(
+          env,
+          `/guilds/${input.guild_id}/members/${users[0]}/roles/${input.role_id}`,
+          { method: "DELETE", reason: input.reason },
+        );
+        return {
+          success: true,
+          removed_count: 1,
+          failed_count: 0,
+          message: `Role ${input.role_id} removed from user ${users[0]}`,
+        };
+      }
+
+      // Multiple users - batch remove
+
+      const { results, errors } = await discordAPIBatch(
+        env,
+        users,
+        async (userId) => {
+          await discordAPI(
+            env,
+            `/guilds/${input.guild_id}/members/${userId}/roles/${input.role_id}`,
+            { method: "DELETE", reason: input.reason },
+          );
+          return userId;
+        },
+        {
+          delayMs: 200,
+          onProgress: (completed, total) => {
+            if (completed % 10 === 0 || completed === total) {
+            }
+          },
+          onError: () => "skip",
+        },
+      );
+
+      return {
+        success: errors.length === 0,
+        removed_count: results.length,
+        failed_count: errors.length,
+        message: `Role removed from ${results.length} of ${users.length} users`,
+        errors:
+          errors.length > 0
+            ? errors.map((e) => ({ user_id: e.item, error: e.error }))
+            : undefined,
+      };
+    },
+  });
+
+// ============================================================================
+// Edit Member (nickname, roles, mute, deaf, etc.)
+// ============================================================================
+
+export const createEditMemberTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_EDIT_MEMBER",
+    description:
+      "Edit a guild member's attributes (nickname, roles, mute, deaf, etc.)",
+    annotations: { destructiveHint: true, openWorldHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID"),
+        user_id: z.string().describe("The user ID of the member"),
+        nick: z
+          .string()
+          .nullable()
+          .optional()
+          .describe("New nickname (null to reset)"),
+        roles: z
+          .array(z.string())
+          .optional()
+          .describe("Array of role IDs to set (replaces all roles)"),
+        mute: z.boolean().optional().describe("Mute in voice channels"),
+        deaf: z.boolean().optional().describe("Deafen in voice channels"),
+        channel_id: z
+          .string()
+          .nullable()
+          .optional()
+          .describe("Move to voice channel (null to disconnect)"),
+        communication_disabled_until: z
+          .string()
+          .nullable()
+          .optional()
+          .describe("Timeout until ISO8601 timestamp (null to remove)"),
+        reason: z.string().optional().describe("Reason for audit log"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        message: z.string(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        guild_id: string;
+        user_id: string;
+        nick?: string | null;
+        roles?: string[];
+        mute?: boolean;
+        deaf?: boolean;
+        channel_id?: string | null;
+        communication_disabled_until?: string | null;
+        reason?: string;
+      };
+
+      const body: Record<string, unknown> = {};
+      if (input.nick !== undefined) body.nick = input.nick;
+      if (input.roles !== undefined) body.roles = input.roles;
+      if (input.mute !== undefined) body.mute = input.mute;
+      if (input.deaf !== undefined) body.deaf = input.deaf;
+      if (input.channel_id !== undefined) body.channel_id = input.channel_id;
+      if (input.communication_disabled_until !== undefined) {
+        body.communication_disabled_until = input.communication_disabled_until;
+      }
+
+      await discordAPI(
+        env,
+        `/guilds/${input.guild_id}/members/${input.user_id}`,
+        {
+          method: "PATCH",
+          body,
+          reason: input.reason,
+        },
+      );
+
+      return {
+        success: true,
+        message: `Member ${input.user_id} updated successfully`,
+      };
+    },
+  });
+
+// ============================================================================
+// Kick Member (supports multiple users)
+// ============================================================================
+
+export const createKickMemberTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_KICK_MEMBER",
+    description:
+      "Kick one or more members from a Discord server (they can rejoin). Supports batch operations.",
+    annotations: { destructiveHint: true, openWorldHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID"),
+        user_id: z.string().optional().describe("Single user ID to kick"),
+        user_ids: z
+          .array(z.string())
+          .optional()
+          .describe("Array of user IDs to kick"),
+        reason: z.string().optional().describe("Reason for audit log"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        kicked_count: z.number(),
+        failed_count: z.number(),
+        message: z.string(),
+        errors: z
+          .array(z.object({ user_id: z.string(), error: z.string() }))
+          .optional(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        guild_id: string;
+        user_id?: string;
+        user_ids?: string[];
+        reason?: string;
+      };
+
+      const users: string[] = [];
+      if (input.user_id) users.push(input.user_id);
+      if (input.user_ids) users.push(...input.user_ids);
+
+      if (users.length === 0) {
+        throw new Error("Either user_id or user_ids must be provided");
+      }
+
+      // Single user - simple kick
+      if (users.length === 1) {
+        await discordAPI(env, `/guilds/${input.guild_id}/members/${users[0]}`, {
+          method: "DELETE",
+          reason: input.reason,
+        });
+        return {
+          success: true,
+          kicked_count: 1,
+          failed_count: 0,
+          message: `User ${users[0]} kicked from guild ${input.guild_id}`,
+        };
+      }
+
+      // Multiple users - batch kick
+
+      const { results, errors } = await discordAPIBatch(
+        env,
+        users,
+        async (userId) => {
+          await discordAPI(env, `/guilds/${input.guild_id}/members/${userId}`, {
+            method: "DELETE",
+            reason: input.reason,
+          });
+          return userId;
+        },
+        {
+          delayMs: 300,
+          onProgress: (completed, total) => {
+            if (completed % 5 === 0 || completed === total) {
+            }
+          },
+          onError: () => "skip",
+        },
+      );
+
+      return {
+        success: errors.length === 0,
+        kicked_count: results.length,
+        failed_count: errors.length,
+        message: `Kicked ${results.length} of ${users.length} users`,
+        errors:
+          errors.length > 0
+            ? errors.map((e) => ({ user_id: e.item, error: e.error }))
+            : undefined,
+      };
+    },
+  });
+
+// ============================================================================
+// Timeout Member (supports multiple users)
+// ============================================================================
+
+export const createTimeoutMemberTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_TIMEOUT_MEMBER",
+    description:
+      "Timeout one or more members (prevent them from interacting) for a specified duration. Supports batch operations.",
+    annotations: { destructiveHint: true, openWorldHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID"),
+        user_id: z.string().optional().describe("Single user ID to timeout"),
+        user_ids: z
+          .array(z.string())
+          .optional()
+          .describe("Array of user IDs to timeout"),
+        duration_minutes: z
+          .number()
+          .min(1)
+          .max(40320)
+          .describe("Duration in minutes (max 28 days = 40320)"),
+        reason: z.string().optional().describe("Reason for audit log"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        timed_out_count: z.number(),
+        failed_count: z.number(),
+        message: z.string(),
+        timeout_until: z.string(),
+        errors: z
+          .array(z.object({ user_id: z.string(), error: z.string() }))
+          .optional(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        guild_id: string;
+        user_id?: string;
+        user_ids?: string[];
+        duration_minutes: number;
+        reason?: string;
+      };
+
+      const users: string[] = [];
+      if (input.user_id) users.push(input.user_id);
+      if (input.user_ids) users.push(...input.user_ids);
+
+      if (users.length === 0) {
+        throw new Error("Either user_id or user_ids must be provided");
+      }
+
+      const timeoutUntil = new Date(
+        Date.now() + input.duration_minutes * 60 * 1000,
+      ).toISOString();
+
+      // Single user - simple timeout
+      if (users.length === 1) {
+        await discordAPI(env, `/guilds/${input.guild_id}/members/${users[0]}`, {
+          method: "PATCH",
+          body: { communication_disabled_until: timeoutUntil },
+          reason: input.reason,
+        });
+        return {
+          success: true,
+          timed_out_count: 1,
+          failed_count: 0,
+          message: `User ${users[0]} timed out for ${input.duration_minutes} minutes`,
+          timeout_until: timeoutUntil,
+        };
+      }
+
+      // Multiple users - batch timeout
+
+      const { results, errors } = await discordAPIBatch(
+        env,
+        users,
+        async (userId) => {
+          await discordAPI(env, `/guilds/${input.guild_id}/members/${userId}`, {
+            method: "PATCH",
+            body: { communication_disabled_until: timeoutUntil },
+            reason: input.reason,
+          });
+          return userId;
+        },
+        {
+          delayMs: 200,
+          onProgress: (completed, total) => {
+            if (completed % 10 === 0 || completed === total) {
+            }
+          },
+          onError: () => "skip",
+        },
+      );
+
+      return {
+        success: errors.length === 0,
+        timed_out_count: results.length,
+        failed_count: errors.length,
+        message: `Timed out ${results.length} of ${users.length} users for ${input.duration_minutes} minutes`,
+        timeout_until: timeoutUntil,
+        errors:
+          errors.length > 0
+            ? errors.map((e) => ({ user_id: e.item, error: e.error }))
+            : undefined,
+      };
+    },
+  });
+
+// ============================================================================
+// Remove Timeout (supports multiple users)
+// ============================================================================
+
+export const createRemoveTimeoutTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_REMOVE_TIMEOUT",
+    description:
+      "Remove timeout from one or more members (allow them to interact again). Supports batch operations.",
+    annotations: { destructiveHint: false, openWorldHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID"),
+        user_id: z
+          .string()
+          .optional()
+          .describe("Single user ID to remove timeout from"),
+        user_ids: z
+          .array(z.string())
+          .optional()
+          .describe("Array of user IDs to remove timeout from"),
+        reason: z.string().optional().describe("Reason for audit log"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        removed_count: z.number(),
+        failed_count: z.number(),
+        message: z.string(),
+        errors: z
+          .array(z.object({ user_id: z.string(), error: z.string() }))
+          .optional(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        guild_id: string;
+        user_id?: string;
+        user_ids?: string[];
+        reason?: string;
+      };
+
+      const users: string[] = [];
+      if (input.user_id) users.push(input.user_id);
+      if (input.user_ids) users.push(...input.user_ids);
+
+      if (users.length === 0) {
+        throw new Error("Either user_id or user_ids must be provided");
+      }
+
+      // Single user - simple remove
+      if (users.length === 1) {
+        await discordAPI(env, `/guilds/${input.guild_id}/members/${users[0]}`, {
+          method: "PATCH",
+          body: { communication_disabled_until: null },
+          reason: input.reason,
+        });
+        return {
+          success: true,
+          removed_count: 1,
+          failed_count: 0,
+          message: `Timeout removed from user ${users[0]}`,
+        };
+      }
+
+      // Multiple users - batch remove
+
+      const { results, errors } = await discordAPIBatch(
+        env,
+        users,
+        async (userId) => {
+          await discordAPI(env, `/guilds/${input.guild_id}/members/${userId}`, {
+            method: "PATCH",
+            body: { communication_disabled_until: null },
+            reason: input.reason,
+          });
+          return userId;
+        },
+        {
+          delayMs: 200,
+          onProgress: (completed, total) => {
+            if (completed % 10 === 0 || completed === total) {
+            }
+          },
+          onError: () => "skip",
+        },
+      );
+
+      return {
+        success: errors.length === 0,
+        removed_count: results.length,
+        failed_count: errors.length,
+        message: `Timeout removed from ${results.length} of ${users.length} users`,
+        errors:
+          errors.length > 0
+            ? errors.map((e) => ({ user_id: e.item, error: e.error }))
+            : undefined,
+      };
+    },
+  });
+
+// ============================================================================
+// Unban Member
+// ============================================================================
+
+export const createUnbanMemberTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_UNBAN_MEMBER",
+    description: "Remove a ban for a user from a guild.",
+    annotations: { destructiveHint: false, openWorldHint: true },
+    inputSchema: z
+      .object({
+        guild_id: z.string().describe("The guild ID."),
+        user_id: z.string().describe("The user ID to unban."),
+        reason: z.string().optional().describe("Audit log reason."),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        message: z.string(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        guild_id: string;
+        user_id: string;
+        reason?: string;
+      };
+
+      try {
+        await discordAPI<unknown>(
+          env,
+          `/guilds/${input.guild_id}/bans/${input.user_id}`,
+          {
+            method: "DELETE",
+            reason: input.reason,
+          },
+        );
+        return {
+          success: true,
+          message: `Unbanned user ${input.user_id} from guild ${input.guild_id}.`,
+        };
+      } catch (err) {
+        return {
+          success: false,
+          message: `Failed to unban: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    },
+  });
+
+// ============================================================================
+// Export
+// ============================================================================
+
+export const discordGuildTools = [
+  createGetGuildTool,
+  createListBotGuildsTool,
+  createGetGuildMembersTool,
+  createSearchMembersTool,
+  createGetUserTool,
+  createGetMemberTool,
+  createGetCurrentUserTool,
+  createEditMemberTool,
+  createAddRoleToMemberTool,
+  createRemoveRoleFromMemberTool,
+  createKickMemberTool,
+  createBanMemberTool,
+  createUnbanMemberTool,
+  createTimeoutMemberTool,
+  createRemoveTimeoutTool,
+  createGetGuildRolesTool,
+  createCreateRoleTool,
+  createEditRoleTool,
+  createDeleteRoleTool,
+];

--- a/discord/server/tools/index.ts
+++ b/discord/server/tools/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Tool aggregator. Each tool factory is wrapped with updateEnv() so that
+ * MESH_REQUEST_CONTEXT (auth, state, connectionId) stays fresh across calls.
+ *
+ * Phase 1: config + bot status. Later phases append messages, channels,
+ * guilds, members, roles, moderation, webhooks, and interactions.
+ */
+
+import { updateEnv } from "../bot/manager.ts";
+import type { Env } from "../types/env.ts";
+import type { ToolFactory, ToolCollection } from "../types/tools.ts";
+import { configTools } from "./config/index.ts";
+import { botTools } from "./bot/index.ts";
+import { interactionTools } from "./interactions/index.ts";
+import { discordMessageTools } from "./messages/index.ts";
+import { discordChannelTools } from "./channels/index.ts";
+import { discordGuildTools } from "./guilds/index.ts";
+import { discordWebhookTools } from "./webhooks/index.ts";
+import { triggers } from "../triggers/store.ts";
+
+function wrapWithEnvUpdate(toolFactory: ToolFactory<Env>): ToolFactory<Env> {
+  return (env: Env) => {
+    updateEnv(env);
+    return toolFactory(env);
+  };
+}
+
+const wrappedConfig = configTools.map(wrapWithEnvUpdate);
+const wrappedBot = botTools.map(wrapWithEnvUpdate);
+const wrappedInteractions = interactionTools.map(wrapWithEnvUpdate);
+const wrappedMessages = discordMessageTools.map(wrapWithEnvUpdate);
+const wrappedChannels = discordChannelTools.map(wrapWithEnvUpdate);
+const wrappedGuilds = discordGuildTools.map(wrapWithEnvUpdate);
+const wrappedWebhooks = discordWebhookTools.map(wrapWithEnvUpdate);
+
+export const tools: ToolCollection<Env> = [
+  ...wrappedConfig,
+  ...wrappedBot,
+  ...wrappedInteractions,
+  ...wrappedMessages,
+  ...wrappedChannels,
+  ...wrappedGuilds,
+  ...wrappedWebhooks,
+  () => triggers.tools(),
+];

--- a/discord/server/tools/interactions/_fetch.ts
+++ b/discord/server/tools/interactions/_fetch.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared fetch wrapper for the Discord interaction REST endpoints.
+ * Used by FOLLOWUP, UPDATE, and SHOW_MODAL tools.
+ *
+ * Webhook URLs (`/webhooks/{app_id}/{token}/...`) are auth'd by the
+ * interaction token itself — no bot token needed.
+ */
+
+interface FetchInteractionResult {
+  success: boolean;
+  message: string;
+  message_id?: string;
+  response_text?: string;
+  status?: number;
+}
+
+export async function fetchInteractionAPI(
+  url: string,
+  method: "POST" | "PATCH",
+  body: Record<string, unknown>,
+): Promise<FetchInteractionResult> {
+  try {
+    const response = await fetch(url, {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      return {
+        success: false,
+        message: `Discord API ${response.status}: ${text}`,
+        response_text: text,
+        status: response.status,
+      };
+    }
+
+    // Some endpoints return 204; others return the message JSON.
+    if (response.status === 204) {
+      return { success: true, message: "OK" };
+    }
+
+    const data = (await response.json()) as { id?: string };
+    return {
+      success: true,
+      message: "OK",
+      message_id: data.id,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      message: `Network error: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}

--- a/discord/server/tools/interactions/index.ts
+++ b/discord/server/tools/interactions/index.ts
@@ -1,0 +1,9 @@
+import { createInteractionFollowupTool } from "./respond.ts";
+import { createInteractionUpdateTool } from "./update.ts";
+import { createInteractionShowModalTool } from "./modal.ts";
+
+export const interactionTools = [
+  createInteractionFollowupTool,
+  createInteractionUpdateTool,
+  createInteractionShowModalTool,
+];

--- a/discord/server/tools/interactions/modal.ts
+++ b/discord/server/tools/interactions/modal.ts
@@ -1,0 +1,91 @@
+import { createPrivateTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import type { Env } from "../../types/env.ts";
+import { fetchInteractionAPI } from "./_fetch.ts";
+
+/**
+ * Show a modal as the response to an interaction.
+ *
+ * IMPORTANT CAVEAT: modals can ONLY be the FIRST response to an interaction.
+ * If the MCP already auto-deferred (default for ALL interactions), this call
+ * will fail. To use modals reliably, set StateSchema.AUTO_DEFER_MODE = "off"
+ * for this connection. Then your agent has 3s to call SHOW_MODAL after
+ * receiving an interaction trigger.
+ *
+ * Modals are best driven by no-defer slash commands: register the command
+ * externally via Discord Developer Portal, and configure your agent to
+ * react to discord.interaction.slash_command and call SHOW_MODAL.
+ */
+export const createInteractionShowModalTool = (_env: Env) =>
+  createPrivateTool({
+    id: "DISCORD_INTERACTION_SHOW_MODAL",
+    description:
+      "Show a Discord modal in response to an interaction. Pass interaction_id + interaction_token from the trigger payload. CAVEAT: only works if the MCP did not auto-defer this interaction. Set AUTO_DEFER_MODE='off' on the connection to use modals; your agent then has 3s to respond. Best used with externally-registered slash commands.",
+    annotations: { destructiveHint: false },
+    inputSchema: z
+      .object({
+        interaction_id: z
+          .string()
+          .describe("interaction_id from the trigger payload."),
+        interaction_token: z
+          .string()
+          .describe("interaction_token from the trigger payload."),
+        custom_id: z
+          .string()
+          .max(100)
+          .describe(
+            "Custom ID for the modal — appears in the discord.interaction.modal_submit trigger payload when the user submits.",
+          ),
+        title: z.string().max(45).describe("Modal title shown in the dialog."),
+        components: z
+          .array(z.record(z.string(), z.unknown()))
+          .min(1)
+          .max(5)
+          .describe(
+            "Action rows containing text input components (component type 4). Each row holds one text input. Up to 5 rows. See https://discord.com/developers/docs/interactions/message-components#text-inputs.",
+          ),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        message: z.string(),
+      })
+      .strict(),
+    execute: async (params: any) => {
+      const ctx = params.context as {
+        interaction_id: string;
+        interaction_token: string;
+        custom_id: string;
+        title: string;
+        components: Record<string, unknown>[];
+      };
+
+      const url = `https://discord.com/api/v10/interactions/${encodeURIComponent(ctx.interaction_id)}/${encodeURIComponent(ctx.interaction_token)}/callback`;
+
+      const body = {
+        type: 9, // MODAL response type
+        data: {
+          custom_id: ctx.custom_id,
+          title: ctx.title,
+          components: ctx.components,
+        },
+      };
+
+      const result = await fetchInteractionAPI(url, "POST", body);
+      if (!result.success) {
+        // 400 INTERACTION_ALREADY_ACKNOWLEDGED is the most common failure —
+        // the MCP auto-deferred. Surface a hint instead of the raw API error.
+        const text = result.response_text ?? "";
+        if (text.includes("acknowledged") || text.includes("40060")) {
+          return {
+            success: false,
+            message:
+              "Interaction already acknowledged — modals can only be the FIRST response. Set AUTO_DEFER_MODE='off' on this connection to enable modals, or trigger the modal from a slash command (registered externally) where the agent can respond within 3 seconds.",
+          };
+        }
+        return { success: false, message: result.message };
+      }
+      return { success: true, message: "Modal shown." };
+    },
+  });

--- a/discord/server/tools/interactions/respond.ts
+++ b/discord/server/tools/interactions/respond.ts
@@ -1,0 +1,130 @@
+import { createPrivateTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import type { Env } from "../../types/env.ts";
+import * as interactionStore from "../../triggers/interaction-store.ts";
+import { fetchInteractionAPI } from "./_fetch.ts";
+
+/**
+ * Send the real reply to a Discord interaction the MCP previously auto-deferred.
+ *
+ * Use this in response to any interaction trigger
+ * (discord.interaction.button, .select, .modal_submit, .slash_command).
+ *
+ * Webhook URL is auth'd by the interaction_token itself — no bot token
+ * needed. Token is valid for 15 minutes from when the interaction fired.
+ */
+export const createInteractionFollowupTool = (_env: Env) =>
+  createPrivateTool({
+    id: "DISCORD_INTERACTION_FOLLOWUP",
+    description:
+      "Respond to a deferred Discord interaction. Pass `interaction_token` and `application_id` from the trigger payload. By default, edits the deferred message (replaces the 'thinking' indicator); set is_followup=true to send an additional message instead. Token is valid for 15 minutes after the interaction fired.",
+    annotations: { destructiveHint: false },
+    inputSchema: z
+      .object({
+        interaction_token: z
+          .string()
+          .describe(
+            "The interaction_token from the trigger payload. Auths the response.",
+          ),
+        application_id: z
+          .string()
+          .describe(
+            "The application_id (Discord App ID) from the trigger payload.",
+          ),
+        content: z
+          .string()
+          .max(2000)
+          .optional()
+          .describe("Plain text content of the response."),
+        embeds: z
+          .array(z.record(z.string(), z.unknown()))
+          .optional()
+          .describe(
+            "Discord embed objects (https://discord.com/developers/docs/resources/message#embed-object).",
+          ),
+        components: z
+          .array(z.record(z.string(), z.unknown()))
+          .optional()
+          .describe(
+            "Discord component rows (action rows of buttons/selects). Pass exactly the JSON shape Discord expects.",
+          ),
+        ephemeral: z
+          .boolean()
+          .optional()
+          .describe(
+            "Only honored when is_followup=true. The deferred message's ephemeral flag is fixed at defer time and cannot be changed.",
+          ),
+        is_followup: z
+          .boolean()
+          .default(false)
+          .describe(
+            "false (default): edit the original deferred message. true: send a new follow-up message.",
+          ),
+        interaction_id: z
+          .string()
+          .optional()
+          .describe(
+            "Optional: pass for idempotency on this pod. If two Mesh connections share the same bot, only the first FOLLOWUP for a given interaction_id will be sent; subsequent calls return already_responded.",
+          ),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        message: z.string(),
+        message_id: z.string().optional(),
+        already_responded: z.boolean().optional(),
+      })
+      .strict(),
+    execute: async (params: any) => {
+      const ctx = params.context as {
+        interaction_token: string;
+        application_id: string;
+        content?: string;
+        embeds?: Record<string, unknown>[];
+        components?: Record<string, unknown>[];
+        ephemeral?: boolean;
+        is_followup?: boolean;
+        interaction_id?: string;
+      };
+
+      // Idempotency: if we have the interaction_id, refuse a second response
+      // from this pod. Discord would just return 404/400 anyway, but this
+      // saves a round-trip and prevents the "two connections answer the same
+      // interaction" double-fire on shared bot tokens.
+      if (ctx.interaction_id) {
+        const ok = interactionStore.markResponded(ctx.interaction_id);
+        if (!ok) {
+          return {
+            success: false,
+            message:
+              "Already responded to this interaction (deduped against another connection that shares this bot).",
+            already_responded: true,
+          };
+        }
+      }
+
+      const url = ctx.is_followup
+        ? `https://discord.com/api/v10/webhooks/${encodeURIComponent(ctx.application_id)}/${encodeURIComponent(ctx.interaction_token)}`
+        : `https://discord.com/api/v10/webhooks/${encodeURIComponent(ctx.application_id)}/${encodeURIComponent(ctx.interaction_token)}/messages/@original`;
+      const method = ctx.is_followup ? "POST" : "PATCH";
+
+      const body: Record<string, unknown> = {};
+      if (ctx.content !== undefined) body.content = ctx.content;
+      if (ctx.embeds !== undefined) body.embeds = ctx.embeds;
+      if (ctx.components !== undefined) body.components = ctx.components;
+      if (ctx.is_followup && ctx.ephemeral) body.flags = 64;
+
+      const result = await fetchInteractionAPI(url, method, body);
+      if (!result.success) {
+        return { success: false, message: result.message };
+      }
+      return {
+        success: true,
+        message: ctx.is_followup
+          ? "Follow-up sent."
+          : "Original deferred message updated.",
+        message_id: result.message_id,
+      };
+    },
+  });

--- a/discord/server/tools/interactions/update.ts
+++ b/discord/server/tools/interactions/update.ts
@@ -1,0 +1,94 @@
+import { createPrivateTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import type { Env } from "../../types/env.ts";
+import * as interactionStore from "../../triggers/interaction-store.ts";
+import { fetchInteractionAPI } from "./_fetch.ts";
+
+/**
+ * Replace the message that contained the component the user just interacted
+ * with. Most common use case: disable the button after click.
+ *
+ * Only valid for component interactions (button/select). After auto-defer
+ * with deferUpdate(), this tool effectively unsets the deferral and
+ * replaces the message in one shot via PATCH /messages/@original.
+ */
+export const createInteractionUpdateTool = (_env: Env) =>
+  createPrivateTool({
+    id: "DISCORD_INTERACTION_UPDATE",
+    description:
+      "Update the message that contained the button/select the user just clicked (replace content, embeds, or components). Use this to disable a button after click or swap select-menu options. Pass the new components array — typically the original buttons with `disabled: true`. Only valid for button/select interactions. Token is valid for 15 minutes.",
+    annotations: { destructiveHint: false },
+    inputSchema: z
+      .object({
+        interaction_token: z.string(),
+        application_id: z.string(),
+        content: z
+          .string()
+          .max(2000)
+          .nullable()
+          .optional()
+          .describe(
+            "New content. Pass null to clear, omit to leave unchanged (Discord behavior).",
+          ),
+        embeds: z
+          .array(z.record(z.string(), z.unknown()))
+          .nullable()
+          .optional()
+          .describe("New embeds. Pass [] or null to clear."),
+        components: z
+          .array(z.record(z.string(), z.unknown()))
+          .nullable()
+          .optional()
+          .describe(
+            "New components. Pass [] or null to remove all components.",
+          ),
+        interaction_id: z
+          .string()
+          .optional()
+          .describe(
+            "Optional: idempotency key against same-bot multi-connection fan-out.",
+          ),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        message: z.string(),
+        already_responded: z.boolean().optional(),
+      })
+      .strict(),
+    execute: async (params: any) => {
+      const ctx = params.context as {
+        interaction_token: string;
+        application_id: string;
+        content?: string | null;
+        embeds?: Record<string, unknown>[] | null;
+        components?: Record<string, unknown>[] | null;
+        interaction_id?: string;
+      };
+
+      if (ctx.interaction_id) {
+        const ok = interactionStore.markResponded(ctx.interaction_id);
+        if (!ok) {
+          return {
+            success: false,
+            message: "Already responded to this interaction.",
+            already_responded: true,
+          };
+        }
+      }
+
+      const url = `https://discord.com/api/v10/webhooks/${encodeURIComponent(ctx.application_id)}/${encodeURIComponent(ctx.interaction_token)}/messages/@original`;
+
+      const body: Record<string, unknown> = {};
+      if (ctx.content !== undefined) body.content = ctx.content;
+      if (ctx.embeds !== undefined) body.embeds = ctx.embeds;
+      if (ctx.components !== undefined) body.components = ctx.components;
+
+      const result = await fetchInteractionAPI(url, "PATCH", body);
+      if (!result.success) {
+        return { success: false, message: result.message };
+      }
+      return { success: true, message: "Original message updated." };
+    },
+  });

--- a/discord/server/tools/messages/index.ts
+++ b/discord/server/tools/messages/index.ts
@@ -1,0 +1,1121 @@
+/**
+ * Discord Message Tools
+ *
+ * Tools for sending, editing, deleting, and managing messages.
+ */
+
+import { createTool } from "@decocms/runtime/tools";
+import z from "zod";
+import type { Env } from "../../types/env.ts";
+import {
+  discordAPI,
+  discordAPIBatch,
+  encodeEmoji,
+} from "../../discord-rest/api.ts";
+
+/**
+ * Validate that a required string parameter was provided.
+ * The MCP SDK doesn't always enforce Zod schemas at runtime,
+ * so the LLM may omit required fields — catch that early.
+ */
+function requireString(value: unknown, name: string): asserts value is string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(
+      `Missing required parameter: ${name}. Check the current context for the correct value.`,
+    );
+  }
+}
+
+// ============================================================================
+// Send Message
+// ============================================================================
+
+export const createSendMessageTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_SEND_MESSAGE",
+    description: "Send a message to a Discord channel",
+    annotations: { destructiveHint: false, openWorldHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z
+          .string()
+          .describe(
+            "The channel ID to send the message to (use channel_id from Current Context)",
+          ),
+        content: z
+          .string()
+          .optional()
+          .describe("The message content (up to 2000 characters)"),
+        embeds: z
+          .array(
+            z.object({
+              title: z.string().optional(),
+              description: z.string().optional(),
+              url: z.string().optional(),
+              color: z.number().optional(),
+              footer: z.object({ text: z.string() }).optional(),
+              thumbnail: z.object({ url: z.string() }).optional(),
+              image: z.object({ url: z.string() }).optional(),
+              fields: z
+                .array(
+                  z.object({
+                    name: z.string(),
+                    value: z.string(),
+                    inline: z.boolean().optional(),
+                  }),
+                )
+                .optional(),
+            }),
+          )
+          .optional()
+          .describe("Array of embed objects"),
+        reply_to: z.string().optional().describe("Message ID to reply to"),
+        tts: z.boolean().optional().describe("Whether this is a TTS message"),
+        components: z
+          .array(z.record(z.string(), z.unknown()))
+          .optional()
+          .describe(
+            "Discord component rows (action rows of buttons/selects). Pass exactly the JSON shape Discord expects — see https://discord.com/developers/docs/interactions/message-components. Each row is `{ type: 1, components: [{type, ...}] }` (type 2 = button, type 3 = string select, etc.). When a user clicks a button or submits a select, the MCP fires a discord.interaction.button / .select trigger with the component's custom_id.",
+          ),
+        flags: z
+          .number()
+          .optional()
+          .describe(
+            "Bitfield of message flags (e.g. 4 = SUPPRESS_EMBEDS, 4096 = SUPPRESS_NOTIFICATIONS).",
+          ),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        id: z.string(),
+        channel_id: z.string(),
+        content: z.string(),
+        timestamp: z.string(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        channel_id: string;
+        content?: string;
+        embeds?: unknown[];
+        reply_to?: string;
+        tts?: boolean;
+        components?: unknown[];
+        flags?: number;
+      };
+      requireString(input.channel_id, "channel_id");
+
+      const body: Record<string, unknown> = {};
+      if (input.content) body.content = input.content;
+      if (input.embeds) body.embeds = input.embeds;
+      if (input.components) body.components = input.components;
+      if (input.tts) body.tts = input.tts;
+      if (input.flags !== undefined) body.flags = input.flags;
+      if (input.reply_to) {
+        body.message_reference = { message_id: input.reply_to };
+      }
+
+      const result = await discordAPI<{
+        id: string;
+        channel_id: string;
+        content: string;
+        timestamp: string;
+      }>(env, `/channels/${input.channel_id}/messages`, {
+        method: "POST",
+        body,
+      });
+
+      return {
+        id: result.id,
+        channel_id: result.channel_id,
+        content: result.content,
+        timestamp: result.timestamp,
+      };
+    },
+  });
+
+// ============================================================================
+// Edit Message
+// ============================================================================
+
+export const createEditMessageTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_EDIT_MESSAGE",
+    description: "Edit a message in a Discord channel",
+    annotations: { destructiveHint: true, openWorldHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z
+          .string()
+          .describe("The channel ID (use channel_id from Current Context)"),
+        message_id: z.string().describe("The message ID to edit"),
+        content: z.string().optional().describe("The new message content"),
+        embeds: z
+          .array(z.object({}).passthrough())
+          .optional()
+          .describe("New embeds"),
+        components: z
+          .array(z.record(z.string(), z.unknown()))
+          .optional()
+          .describe(
+            "New component rows. Pass [] to clear all components, or a new array to replace them (e.g., disable a button by re-sending it with `disabled: true`).",
+          ),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        id: z.string(),
+        content: z.string(),
+        edited_timestamp: z.string().nullable(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        channel_id: string;
+        message_id: string;
+        content?: string;
+        embeds?: unknown[];
+        components?: unknown[];
+      };
+      requireString(input.channel_id, "channel_id");
+
+      const body: Record<string, unknown> = {};
+      if (input.content !== undefined) body.content = input.content;
+      if (input.embeds) body.embeds = input.embeds;
+      if (input.components !== undefined) body.components = input.components;
+
+      const result = await discordAPI<{
+        id: string;
+        content: string;
+        edited_timestamp: string | null;
+      }>(env, `/channels/${input.channel_id}/messages/${input.message_id}`, {
+        method: "PATCH",
+        body,
+      });
+
+      return {
+        id: result.id,
+        content: result.content,
+        edited_timestamp: result.edited_timestamp,
+      };
+    },
+  });
+
+// ============================================================================
+// Delete Message (supports single or multiple IDs)
+// ============================================================================
+
+export const createDeleteMessageTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_DELETE_MESSAGE",
+    description:
+      "Delete one or more messages from a Discord channel. For multiple messages, they are deleted sequentially with automatic rate limit handling.",
+    annotations: { destructiveHint: true, openWorldHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z
+          .string()
+          .describe("The channel ID (use channel_id from Current Context)"),
+        message_id: z
+          .string()
+          .optional()
+          .describe("Single message ID to delete"),
+        message_ids: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Array of message IDs to delete (processed sequentially with rate limit handling)",
+          ),
+        reason: z
+          .string()
+          .optional()
+          .describe("Reason for deletion (audit log)"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        deleted_count: z.number(),
+        failed_count: z.number(),
+        errors: z
+          .array(z.object({ message_id: z.string(), error: z.string() }))
+          .optional(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        channel_id: string;
+        message_id?: string;
+        message_ids?: string[];
+        reason?: string;
+      };
+      requireString(input.channel_id, "channel_id");
+
+      // Build list of IDs to delete
+      const idsToDelete: string[] = [];
+      if (input.message_id) {
+        idsToDelete.push(input.message_id);
+      }
+      if (input.message_ids) {
+        idsToDelete.push(...input.message_ids);
+      }
+
+      if (idsToDelete.length === 0) {
+        throw new Error("Either message_id or message_ids must be provided");
+      }
+
+      // Single message - simple delete
+      if (idsToDelete.length === 1) {
+        await discordAPI(
+          env,
+          `/channels/${input.channel_id}/messages/${idsToDelete[0]}`,
+          { method: "DELETE", reason: input.reason },
+        );
+        return { success: true, deleted_count: 1, failed_count: 0 };
+      }
+
+      // Multiple messages - batch delete with rate limit handling
+
+      const { results, errors } = await discordAPIBatch(
+        env,
+        idsToDelete,
+        async (messageId) => {
+          await discordAPI(
+            env,
+            `/channels/${input.channel_id}/messages/${messageId}`,
+            { method: "DELETE", reason: input.reason },
+          );
+          return messageId;
+        },
+        {
+          delayMs: 200, // 200ms between deletes to stay under rate limit
+          onProgress: (completed, total) => {
+            if (completed % 10 === 0 || completed === total) {
+            }
+          },
+          onError: () => "skip", // Continue on errors
+        },
+      );
+
+      return {
+        success: errors.length === 0,
+        deleted_count: results.length,
+        failed_count: errors.length,
+        errors:
+          errors.length > 0
+            ? errors.map((e) => ({
+                message_id: e.item,
+                error: e.error,
+              }))
+            : undefined,
+      };
+    },
+  });
+
+// ============================================================================
+// Bulk Delete Messages (Discord's native bulk endpoint)
+// ============================================================================
+
+export const createBulkDeleteMessagesTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_BULK_DELETE_MESSAGES",
+    description:
+      "Delete multiple messages at once using Discord's bulk delete endpoint. " +
+      "IMPORTANT: Only works for messages less than 14 days old. " +
+      "Can delete 2-100 messages per call. For older messages, use DISCORD_DELETE_MESSAGE with message_ids array.",
+    annotations: { destructiveHint: true, openWorldHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z
+          .string()
+          .describe("The channel ID (use channel_id from Current Context)"),
+        message_ids: z
+          .array(z.string())
+          .min(2)
+          .max(100)
+          .describe(
+            "Array of message IDs to delete (2-100, must be < 14 days old)",
+          ),
+        reason: z
+          .string()
+          .optional()
+          .describe("Reason for deletion (audit log)"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        deleted_count: z.number(),
+        message: z.string(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        channel_id: string;
+        message_ids: string[];
+        reason?: string;
+      };
+      requireString(input.channel_id, "channel_id");
+
+      if (input.message_ids.length < 2) {
+        throw new Error(
+          "Bulk delete requires at least 2 message IDs. Use DISCORD_DELETE_MESSAGE for single messages.",
+        );
+      }
+
+      if (input.message_ids.length > 100) {
+        throw new Error(
+          "Bulk delete supports maximum 100 messages per call. Split into multiple calls.",
+        );
+      }
+
+      try {
+        await discordAPI(
+          env,
+          `/channels/${input.channel_id}/messages/bulk-delete`,
+          {
+            method: "POST",
+            body: { messages: input.message_ids },
+            reason: input.reason,
+          },
+        );
+
+        return {
+          success: true,
+          deleted_count: input.message_ids.length,
+          message: `Successfully deleted ${input.message_ids.length} messages`,
+        };
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+
+        // Check if it's the "too old" error
+        if (
+          errorMsg.includes("10008") ||
+          errorMsg.includes("older than 2 weeks")
+        ) {
+          throw new Error(
+            "Some messages are older than 14 days. Use DISCORD_DELETE_MESSAGE with message_ids array for older messages.",
+          );
+        }
+
+        throw error;
+      }
+    },
+  });
+
+// ============================================================================
+// Purge Channel Messages (intelligent purge)
+// ============================================================================
+
+export const createPurgeChannelMessagesTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_PURGE_MESSAGES",
+    description:
+      "Intelligently purge messages from a channel. Automatically uses bulk delete for recent messages (<14 days) " +
+      "and individual delete for older messages. Can filter by user, bot messages, or content.",
+    annotations: { destructiveHint: true, openWorldHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z
+          .string()
+          .describe("The channel ID (use channel_id from Current Context)"),
+        limit: z
+          .number()
+          .min(1)
+          .max(1000)
+          .default(100)
+          .describe("Maximum number of messages to delete (1-1000)"),
+        user_id: z
+          .string()
+          .optional()
+          .describe("Only delete messages from this user"),
+        bots_only: z
+          .boolean()
+          .optional()
+          .describe("Only delete messages from bots"),
+        humans_only: z
+          .boolean()
+          .optional()
+          .describe("Only delete messages from humans (non-bots)"),
+        contains: z
+          .string()
+          .optional()
+          .describe("Only delete messages containing this text"),
+        before_id: z
+          .string()
+          .optional()
+          .describe("Only delete messages before this message ID"),
+        reason: z
+          .string()
+          .optional()
+          .describe("Reason for deletion (audit log)"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        deleted_count: z.number(),
+        scanned_count: z.number(),
+        bulk_deleted: z.number(),
+        individual_deleted: z.number(),
+        failed_count: z.number(),
+        message: z.string(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        channel_id: string;
+        limit: number;
+        user_id?: string;
+        bots_only?: boolean;
+        humans_only?: boolean;
+        contains?: string;
+        before_id?: string;
+        reason?: string;
+      };
+      requireString(input.channel_id, "channel_id");
+
+      // 14 days ago timestamp (Discord's bulk delete limit)
+      const fourteenDaysAgo = Date.now() - 14 * 24 * 60 * 60 * 1000;
+
+      // Fetch messages
+      const params = new URLSearchParams();
+      params.set("limit", String(Math.min(input.limit, 100)));
+      if (input.before_id) params.set("before", input.before_id);
+
+      let allMessages: Array<{
+        id: string;
+        content: string;
+        author: { id: string; bot?: boolean };
+        timestamp: string;
+      }> = [];
+
+      let lastId = input.before_id;
+      let fetched = 0;
+
+      // Fetch messages in batches
+      while (fetched < input.limit) {
+        const batchSize = Math.min(100, input.limit - fetched);
+        const fetchParams = new URLSearchParams();
+        fetchParams.set("limit", String(batchSize));
+        if (lastId) fetchParams.set("before", lastId);
+
+        const messages = await discordAPI<
+          Array<{
+            id: string;
+            content: string;
+            author: { id: string; bot?: boolean };
+            timestamp: string;
+          }>
+        >(
+          env,
+          `/channels/${input.channel_id}/messages?${fetchParams.toString()}`,
+        );
+
+        if (messages.length === 0) break;
+
+        allMessages.push(...messages);
+        lastId = messages[messages.length - 1].id;
+        fetched += messages.length;
+
+        // Small delay between fetches
+        if (messages.length === batchSize && fetched < input.limit) {
+          await new Promise((r) => setTimeout(r, 100));
+        }
+      }
+
+      // Filter messages
+      let filteredMessages = allMessages;
+
+      if (input.user_id) {
+        filteredMessages = filteredMessages.filter(
+          (m) => m.author.id === input.user_id,
+        );
+      }
+      if (input.bots_only) {
+        filteredMessages = filteredMessages.filter(
+          (m) => m.author.bot === true,
+        );
+      }
+      if (input.humans_only) {
+        filteredMessages = filteredMessages.filter((m) => !m.author.bot);
+      }
+      if (input.contains) {
+        const searchText = input.contains.toLowerCase();
+        filteredMessages = filteredMessages.filter((m) =>
+          m.content.toLowerCase().includes(searchText),
+        );
+      }
+
+      if (filteredMessages.length === 0) {
+        return {
+          success: true,
+          deleted_count: 0,
+          scanned_count: allMessages.length,
+          bulk_deleted: 0,
+          individual_deleted: 0,
+          failed_count: 0,
+          message: "No messages matched the filter criteria",
+        };
+      }
+
+      // Separate into recent (can bulk delete) and old (need individual delete)
+      const recentMessages = filteredMessages.filter((m) => {
+        const timestamp = new Date(m.timestamp).getTime();
+        return timestamp > fourteenDaysAgo;
+      });
+      const oldMessages = filteredMessages.filter((m) => {
+        const timestamp = new Date(m.timestamp).getTime();
+        return timestamp <= fourteenDaysAgo;
+      });
+
+      let bulkDeleted = 0;
+      let individualDeleted = 0;
+      let failedCount = 0;
+
+      // Bulk delete recent messages (in chunks of 100)
+      if (recentMessages.length >= 2) {
+        const recentIds = recentMessages.map((m) => m.id);
+
+        for (let i = 0; i < recentIds.length; i += 100) {
+          const chunk = recentIds.slice(i, Math.min(i + 100, recentIds.length));
+
+          if (chunk.length >= 2) {
+            try {
+              await discordAPI(
+                env,
+                `/channels/${input.channel_id}/messages/bulk-delete`,
+                {
+                  method: "POST",
+                  body: { messages: chunk },
+                  reason: input.reason,
+                },
+              );
+              bulkDeleted += chunk.length;
+            } catch (error) {
+              // Fall back to individual delete
+              for (const id of chunk) {
+                try {
+                  await discordAPI(
+                    env,
+                    `/channels/${input.channel_id}/messages/${id}`,
+                    { method: "DELETE", reason: input.reason },
+                  );
+                  individualDeleted++;
+                  await new Promise((r) => setTimeout(r, 200));
+                } catch {
+                  failedCount++;
+                }
+              }
+            }
+
+            // Small delay between bulk operations
+            await new Promise((r) => setTimeout(r, 500));
+          } else if (chunk.length === 1) {
+            // Single message - individual delete
+            try {
+              await discordAPI(
+                env,
+                `/channels/${input.channel_id}/messages/${chunk[0]}`,
+                { method: "DELETE", reason: input.reason },
+              );
+              individualDeleted++;
+            } catch {
+              failedCount++;
+            }
+          }
+        }
+      } else if (recentMessages.length === 1) {
+        // Single recent message
+        try {
+          await discordAPI(
+            env,
+            `/channels/${input.channel_id}/messages/${recentMessages[0].id}`,
+            { method: "DELETE", reason: input.reason },
+          );
+          individualDeleted++;
+        } catch {
+          failedCount++;
+        }
+      }
+
+      // Individual delete for old messages
+      if (oldMessages.length > 0) {
+        const { results, errors } = await discordAPIBatch(
+          env,
+          oldMessages,
+          async (msg) => {
+            await discordAPI(
+              env,
+              `/channels/${input.channel_id}/messages/${msg.id}`,
+              { method: "DELETE", reason: input.reason },
+            );
+            return msg.id;
+          },
+          {
+            delayMs: 200,
+            onProgress: (completed, total) => {
+              if (completed % 20 === 0 || completed === total) {
+              }
+            },
+            onError: () => "skip",
+          },
+        );
+
+        individualDeleted += results.length;
+        failedCount += errors.length;
+      }
+
+      const totalDeleted = bulkDeleted + individualDeleted;
+
+      return {
+        success: failedCount === 0,
+        deleted_count: totalDeleted,
+        scanned_count: allMessages.length,
+        bulk_deleted: bulkDeleted,
+        individual_deleted: individualDeleted,
+        failed_count: failedCount,
+        message: `Deleted ${totalDeleted} of ${filteredMessages.length} messages matching criteria`,
+      };
+    },
+  });
+
+// ============================================================================
+// Get Message
+// ============================================================================
+
+export const createGetMessageTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_GET_MESSAGE",
+    description: "Get a specific message from a Discord channel",
+    annotations: { readOnlyHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z
+          .string()
+          .describe("The channel ID (use channel_id from Current Context)"),
+        message_id: z.string().describe("The message ID"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        id: z.string(),
+        channel_id: z.string(),
+        content: z.string(),
+        author: z.object({
+          id: z.string(),
+          username: z.string(),
+          bot: z.boolean().optional(),
+        }),
+        timestamp: z.string(),
+        edited_timestamp: z.string().nullable(),
+        attachments: z.array(z.object({}).passthrough()),
+        embeds: z.array(z.object({}).passthrough()),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as { channel_id: string; message_id: string };
+      requireString(input.channel_id, "channel_id");
+
+      const result = await discordAPI<{
+        id: string;
+        channel_id: string;
+        content: string;
+        author: { id: string; username: string; bot?: boolean };
+        timestamp: string;
+        edited_timestamp: string | null;
+        attachments: Record<string, unknown>[];
+        embeds: Record<string, unknown>[];
+      }>(env, `/channels/${input.channel_id}/messages/${input.message_id}`);
+
+      return result;
+    },
+  });
+
+// ============================================================================
+// Get Channel Messages
+// ============================================================================
+
+export const createGetChannelMessagesTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_GET_CHANNEL_MESSAGES",
+    description: "Get messages from a Discord channel",
+    annotations: { readOnlyHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z
+          .string()
+          .describe("The channel ID (use channel_id from Current Context)"),
+        limit: z
+          .number()
+          .min(1)
+          .max(100)
+          .default(50)
+          .describe("Number of messages (1-100)"),
+        before: z
+          .string()
+          .optional()
+          .describe("Get messages before this message ID"),
+        after: z
+          .string()
+          .optional()
+          .describe("Get messages after this message ID"),
+        around: z
+          .string()
+          .optional()
+          .describe("Get messages around this message ID"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        formatted_output: z
+          .string()
+          .describe(
+            "Pre-formatted message list ready to display. ALWAYS show this to the user as-is.",
+          ),
+        messages: z.array(
+          z.object({
+            id: z.string(),
+            content: z.string(),
+            author: z.object({
+              id: z.string(),
+              username: z.string(),
+            }),
+            timestamp: z.string(),
+          }),
+        ),
+        count: z.number(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        channel_id: string;
+        limit: number;
+        before?: string;
+        after?: string;
+        around?: string;
+      };
+      requireString(input.channel_id, "channel_id");
+
+      const params = new URLSearchParams();
+      params.set("limit", String(input.limit));
+      if (input.before) params.set("before", input.before);
+      if (input.after) params.set("after", input.after);
+      if (input.around) params.set("around", input.around);
+
+      const messages = await discordAPI<
+        Array<{
+          id: string;
+          content: string;
+          author: { id: string; username: string };
+          timestamp: string;
+        }>
+      >(env, `/channels/${input.channel_id}/messages?${params.toString()}`);
+
+      const mapped = messages.map((m) => ({
+        id: m.id,
+        content: m.content,
+        author: { id: m.author.id, username: m.author.username },
+        timestamp: m.timestamp,
+      }));
+
+      // Pre-format for display so the LLM doesn't need to reformat
+      const formatted = mapped
+        .slice()
+        .reverse()
+        .map((m, i) => {
+          const date = new Date(m.timestamp);
+          const ts = date.toLocaleString("pt-BR", {
+            timeZone: "America/Sao_Paulo",
+          });
+          const text = m.content || "*[sem conteúdo de texto]*";
+          return `${i + 1}. **${m.author.username}** (${ts}): ${text}`;
+        })
+        .join("\n");
+
+      return {
+        formatted_output: formatted || "Nenhuma mensagem encontrada.",
+        messages: mapped,
+        count: mapped.length,
+      };
+    },
+  });
+
+// ============================================================================
+// Pin/Unpin Message
+// ============================================================================
+
+export const createPinMessageTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_PIN_MESSAGE",
+    description: "Pin a message in a Discord channel",
+    annotations: { destructiveHint: false, openWorldHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z
+          .string()
+          .describe("The channel ID (use channel_id from Current Context)"),
+        message_id: z.string().describe("The message ID to pin"),
+        reason: z
+          .string()
+          .optional()
+          .describe("Reason for pinning (audit log)"),
+      })
+      .strict(),
+    outputSchema: z.object({ success: z.boolean() }).strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        channel_id: string;
+        message_id: string;
+        reason?: string;
+      };
+      requireString(input.channel_id, "channel_id");
+
+      await discordAPI(
+        env,
+        `/channels/${input.channel_id}/pins/${input.message_id}`,
+        { method: "PUT", reason: input.reason },
+      );
+
+      return { success: true };
+    },
+  });
+
+export const createUnpinMessageTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_UNPIN_MESSAGE",
+    description: "Unpin a message in a Discord channel",
+    annotations: { destructiveHint: false, openWorldHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z
+          .string()
+          .describe("The channel ID (use channel_id from Current Context)"),
+        message_id: z.string().describe("The message ID to unpin"),
+        reason: z
+          .string()
+          .optional()
+          .describe("Reason for unpinning (audit log)"),
+      })
+      .strict(),
+    outputSchema: z.object({ success: z.boolean() }).strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        channel_id: string;
+        message_id: string;
+        reason?: string;
+      };
+      requireString(input.channel_id, "channel_id");
+
+      await discordAPI(
+        env,
+        `/channels/${input.channel_id}/pins/${input.message_id}`,
+        { method: "DELETE", reason: input.reason },
+      );
+
+      return { success: true };
+    },
+  });
+
+export const createGetPinnedMessagesTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_GET_PINNED_MESSAGES",
+    description: "Get all pinned messages from a Discord channel",
+    annotations: { readOnlyHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z
+          .string()
+          .describe("The channel ID (use channel_id from Current Context)"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        messages: z.array(
+          z.object({
+            id: z.string(),
+            content: z.string(),
+            author: z.object({ id: z.string(), username: z.string() }),
+            timestamp: z.string(),
+          }),
+        ),
+        count: z.number(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as { channel_id: string };
+      requireString(input.channel_id, "channel_id");
+
+      const messages = await discordAPI<
+        Array<{
+          id: string;
+          content: string;
+          author: { id: string; username: string };
+          timestamp: string;
+        }>
+      >(env, `/channels/${input.channel_id}/pins`);
+
+      return {
+        messages: messages.map((m) => ({
+          id: m.id,
+          content: m.content,
+          author: { id: m.author.id, username: m.author.username },
+          timestamp: m.timestamp,
+        })),
+        count: messages.length,
+      };
+    },
+  });
+
+// ============================================================================
+// Reactions
+// ============================================================================
+
+export const createAddReactionTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_ADD_REACTION",
+    description: "Add an emoji reaction to a Discord message",
+    annotations: { destructiveHint: false, openWorldHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z
+          .string()
+          .describe("The channel ID (use channel_id from Current Context)"),
+        message_id: z.string().describe("The message ID"),
+        emoji: z
+          .string()
+          .describe(
+            "The emoji (Unicode emoji or custom emoji in format name:id)",
+          ),
+      })
+      .strict(),
+    outputSchema: z.object({ success: z.boolean() }).strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        channel_id: string;
+        message_id: string;
+        emoji: string;
+      };
+      requireString(input.channel_id, "channel_id");
+
+      await discordAPI(
+        env,
+        `/channels/${input.channel_id}/messages/${input.message_id}/reactions/${encodeEmoji(input.emoji)}/@me`,
+        { method: "PUT" },
+      );
+
+      return { success: true };
+    },
+  });
+
+export const createRemoveReactionTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_REMOVE_REACTION",
+    description: "Remove bot's reaction from a message",
+    annotations: { destructiveHint: false, openWorldHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z
+          .string()
+          .describe("The channel ID (use channel_id from Current Context)"),
+        message_id: z.string().describe("The message ID"),
+        emoji: z.string().describe("The emoji to remove"),
+      })
+      .strict(),
+    outputSchema: z.object({ success: z.boolean() }).strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        channel_id: string;
+        message_id: string;
+        emoji: string;
+      };
+      requireString(input.channel_id, "channel_id");
+
+      await discordAPI(
+        env,
+        `/channels/${input.channel_id}/messages/${input.message_id}/reactions/${encodeEmoji(input.emoji)}/@me`,
+        { method: "DELETE" },
+      );
+
+      return { success: true };
+    },
+  });
+
+export const createGetReactionsTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_GET_REACTIONS",
+    description: "Get users who reacted to a message with a specific emoji",
+    annotations: { readOnlyHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z
+          .string()
+          .describe("The channel ID (use channel_id from Current Context)"),
+        message_id: z.string().describe("The message ID"),
+        emoji: z.string().describe("The emoji"),
+        limit: z
+          .number()
+          .min(1)
+          .max(100)
+          .default(25)
+          .describe("Max users to return"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        users: z.array(
+          z.object({
+            id: z.string(),
+            username: z.string(),
+            bot: z.boolean().optional(),
+          }),
+        ),
+        count: z.number(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        channel_id: string;
+        message_id: string;
+        emoji: string;
+        limit: number;
+      };
+      requireString(input.channel_id, "channel_id");
+
+      const users = await discordAPI<
+        Array<{ id: string; username: string; bot?: boolean }>
+      >(
+        env,
+        `/channels/${input.channel_id}/messages/${input.message_id}/reactions/${encodeEmoji(input.emoji)}?limit=${input.limit}`,
+      );
+
+      return {
+        users,
+        count: users.length,
+      };
+    },
+  });
+
+// ============================================================================
+// Search User Mentions
+// ============================================================================
+
+// ============================================================================
+// Export all message tools
+// ============================================================================
+
+export const discordMessageTools = [
+  createSendMessageTool,
+  createEditMessageTool,
+  createDeleteMessageTool,
+  createBulkDeleteMessagesTool,
+  createPurgeChannelMessagesTool,
+  createGetMessageTool,
+  createGetChannelMessagesTool,
+  createPinMessageTool,
+  createUnpinMessageTool,
+  createGetPinnedMessagesTool,
+  createAddReactionTool,
+  createRemoveReactionTool,
+  createGetReactionsTool,
+];

--- a/discord/server/tools/webhooks/index.ts
+++ b/discord/server/tools/webhooks/index.ts
@@ -1,0 +1,300 @@
+/**
+ * Discord Webhook Tools
+ *
+ * Tools for managing and executing webhooks.
+ */
+
+import { createTool } from "@decocms/runtime/tools";
+import z from "zod";
+import type { Env } from "../../types/env.ts";
+import { discordAPI } from "../../discord-rest/api.ts";
+
+// ============================================================================
+// Create Webhook
+// ============================================================================
+
+export const createCreateWebhookTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_CREATE_WEBHOOK",
+    description: "Create a webhook in a Discord channel",
+    annotations: { destructiveHint: false, openWorldHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z.string().describe("The channel ID"),
+        name: z.string().describe("Webhook name (1-80 characters)"),
+        avatar: z
+          .string()
+          .optional()
+          .describe("Avatar image URL (will be converted to base64)"),
+        reason: z.string().optional().describe("Reason (audit log)"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        id: z.string(),
+        token: z.string(),
+        name: z.string(),
+        channel_id: z.string(),
+        url: z.string(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        channel_id: string;
+        name: string;
+        avatar?: string;
+        reason?: string;
+      };
+
+      const body: Record<string, unknown> = { name: input.name };
+
+      // Note: Avatar needs to be base64 data URI - skipping for simplicity
+      // If avatar URL is provided, it would need to be fetched and converted
+
+      const result = await discordAPI<{
+        id: string;
+        token: string;
+        name: string;
+        channel_id: string;
+      }>(env, `/channels/${input.channel_id}/webhooks`, {
+        method: "POST",
+        body,
+        reason: input.reason,
+      });
+
+      return {
+        id: result.id,
+        token: result.token,
+        name: result.name,
+        channel_id: result.channel_id,
+        url: `https://discord.com/api/webhooks/${result.id}/${result.token}`,
+      };
+    },
+  });
+
+// ============================================================================
+// List Webhooks
+// ============================================================================
+
+export const createListWebhooksTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_LIST_WEBHOOKS",
+    description: "List webhooks from a Discord channel or guild",
+    annotations: { readOnlyHint: true },
+    inputSchema: z
+      .object({
+        channel_id: z
+          .string()
+          .optional()
+          .describe("Channel ID (list channel webhooks)"),
+        guild_id: z
+          .string()
+          .optional()
+          .describe("Guild ID (list all guild webhooks)"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        webhooks: z.array(
+          z.object({
+            id: z.string(),
+            name: z.string(),
+            channel_id: z.string(),
+            type: z.number(),
+            user: z
+              .object({
+                id: z.string(),
+                username: z.string(),
+              })
+              .optional(),
+          }),
+        ),
+        count: z.number(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        channel_id?: string;
+        guild_id?: string;
+      };
+
+      let endpoint: string;
+      if (input.channel_id) {
+        endpoint = `/channels/${input.channel_id}/webhooks`;
+      } else if (input.guild_id) {
+        endpoint = `/guilds/${input.guild_id}/webhooks`;
+      } else {
+        throw new Error("Either channel_id or guild_id is required");
+      }
+
+      const webhooks = await discordAPI<
+        Array<{
+          id: string;
+          name: string;
+          channel_id: string;
+          type: number;
+          user?: { id: string; username: string };
+        }>
+      >(env, endpoint);
+
+      return {
+        webhooks: webhooks.map((w) => ({
+          id: w.id,
+          name: w.name,
+          channel_id: w.channel_id,
+          type: w.type,
+          user: w.user,
+        })),
+        count: webhooks.length,
+      };
+    },
+  });
+
+// ============================================================================
+// Delete Webhook
+// ============================================================================
+
+export const createDeleteWebhookTool = (env: Env) =>
+  createTool({
+    id: "DISCORD_DELETE_WEBHOOK",
+    description: "Delete a Discord webhook",
+    annotations: { destructiveHint: true, openWorldHint: true },
+    inputSchema: z
+      .object({
+        webhook_id: z.string().describe("The webhook ID"),
+        webhook_token: z
+          .string()
+          .optional()
+          .describe("Webhook token (if deleting without bot auth)"),
+        reason: z.string().optional().describe("Reason (audit log)"),
+      })
+      .strict(),
+    outputSchema: z.object({ success: z.boolean() }).strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        webhook_id: string;
+        webhook_token?: string;
+        reason?: string;
+      };
+
+      const endpoint = input.webhook_token
+        ? `/webhooks/${input.webhook_id}/${input.webhook_token}`
+        : `/webhooks/${input.webhook_id}`;
+
+      await discordAPI(env, endpoint, {
+        method: "DELETE",
+        reason: input.reason,
+      });
+
+      return { success: true };
+    },
+  });
+
+// ============================================================================
+// Execute Webhook
+// ============================================================================
+
+export const createExecuteWebhookTool = () =>
+  createTool({
+    id: "DISCORD_EXECUTE_WEBHOOK",
+    description: "Send a message through a Discord webhook",
+    annotations: { destructiveHint: false, openWorldHint: true },
+    inputSchema: z
+      .object({
+        webhook_id: z.string().describe("The webhook ID"),
+        webhook_token: z.string().describe("The webhook token"),
+        content: z.string().optional().describe("Message content"),
+        username: z.string().optional().describe("Override webhook username"),
+        avatar_url: z.string().optional().describe("Override webhook avatar"),
+        embeds: z
+          .array(
+            z.object({
+              title: z.string().optional(),
+              description: z.string().optional(),
+              url: z.string().optional(),
+              color: z.number().optional(),
+              footer: z.object({ text: z.string() }).optional(),
+              fields: z
+                .array(
+                  z.object({
+                    name: z.string(),
+                    value: z.string(),
+                    inline: z.boolean().optional(),
+                  }),
+                )
+                .optional(),
+            }),
+          )
+          .optional()
+          .describe("Embed objects"),
+        thread_id: z.string().optional().describe("Send to a thread"),
+        wait: z
+          .boolean()
+          .default(false)
+          .describe("Wait for message and return it"),
+      })
+      .strict(),
+    outputSchema: z
+      .object({
+        success: z.boolean(),
+        message_id: z.string().optional(),
+      })
+      .strict(),
+    execute: async ({ context }: { context: unknown }) => {
+      const input = context as {
+        webhook_id: string;
+        webhook_token: string;
+        content?: string;
+        username?: string;
+        avatar_url?: string;
+        embeds?: unknown[];
+        thread_id?: string;
+        wait: boolean;
+      };
+
+      const body: Record<string, unknown> = {};
+      if (input.content) body.content = input.content;
+      if (input.username) body.username = input.username;
+      if (input.avatar_url) body.avatar_url = input.avatar_url;
+      if (input.embeds) body.embeds = input.embeds;
+
+      const params = new URLSearchParams();
+      if (input.wait) params.set("wait", "true");
+      if (input.thread_id) params.set("thread_id", input.thread_id);
+
+      const paramStr = params.toString();
+      const endpoint = `/webhooks/${input.webhook_id}/${input.webhook_token}${paramStr ? `?${paramStr}` : ""}`;
+
+      // Execute webhook doesn't use bot authorization
+      const response = await fetch(`https://discord.com/api/v10${endpoint}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "");
+        throw new Error(
+          `Discord API error (${response.status}): ${errorText || response.statusText}`,
+        );
+      }
+
+      if (input.wait && response.status !== 204) {
+        const result = (await response.json()) as { id: string };
+        return { success: true, message_id: result.id };
+      }
+
+      return { success: true };
+    },
+  });
+
+// ============================================================================
+// Export
+// ============================================================================
+
+export const discordWebhookTools = [
+  createCreateWebhookTool,
+  createListWebhooksTool,
+  createDeleteWebhookTool,
+  createExecuteWebhookTool,
+];

--- a/discord/server/triggers/definitions.ts
+++ b/discord/server/triggers/definitions.ts
@@ -1,0 +1,279 @@
+/**
+ * Trigger catalog — every event the MCP can emit.
+ *
+ * This file is the source of truth for what an agent can subscribe to.
+ * 22 default + 4 interactions (Phase 3) + 3 opt-in (presence/typing/voice,
+ * guarded by StateSchema flags in events.ts).
+ *
+ * Filter shapes intentionally mirror the payload fields so an agent can
+ * narrow on the same names that arrive in the trigger body.
+ */
+
+import { z } from "zod";
+
+const guildOnly = z.object({
+  guild_id: z
+    .string()
+    .optional()
+    .describe("Filter by guild ID. Empty = all guilds."),
+});
+
+const guildAndChannel = z.object({
+  guild_id: z
+    .string()
+    .optional()
+    .describe("Filter by guild ID. Empty = all guilds."),
+  channel_id: z
+    .string()
+    .optional()
+    .describe("Filter by channel ID. Empty = all channels."),
+});
+
+const messageFilter = z.object({
+  guild_id: z
+    .string()
+    .optional()
+    .describe(
+      "Filter by guild ID. Empty = all guilds (and DMs if is_dm allows).",
+    ),
+  channel_id: z.string().optional().describe("Filter by channel ID."),
+  is_dm: z
+    .boolean()
+    .optional()
+    .describe(
+      "true = only DMs, false = only guild messages, undefined = both. DMs are scoped to the originating connection only.",
+    ),
+  dm_user_id: z.string().optional().describe("Filter DMs by author user ID."),
+  author_bot: z
+    .boolean()
+    .optional()
+    .describe("Filter by author type. false = humans only, true = bots only."),
+});
+
+const reactionFilter = z.object({
+  guild_id: z.string().optional(),
+  channel_id: z.string().optional(),
+  message_id: z.string().optional(),
+  emoji: z
+    .string()
+    .optional()
+    .describe("Match by emoji name (e.g. '👍') or unicode."),
+  is_dm: z.boolean().optional(),
+});
+
+const interactionFilter = z.object({
+  guild_id: z.string().optional(),
+  channel_id: z.string().optional(),
+  custom_id: z.string().optional().describe("Exact custom_id match."),
+  custom_id_prefix: z
+    .string()
+    .optional()
+    .describe(
+      "Match interactions whose custom_id starts with this prefix (e.g. 'order:' to match order:approve, order:reject).",
+    ),
+});
+
+export const triggerDefinitions = [
+  // ============================================================================
+  // Messages
+  // ============================================================================
+  {
+    type: "discord.message.created",
+    description:
+      "A message was sent in a guild channel or as a DM to the bot. Includes the bot's own messages — filter `author_bot: false` to exclude bots.",
+    params: messageFilter,
+  },
+  {
+    type: "discord.message.updated",
+    description: "A message was edited.",
+    params: messageFilter,
+  },
+  {
+    type: "discord.message.deleted",
+    description: "A message was deleted.",
+    params: messageFilter,
+  },
+  {
+    type: "discord.message.bulk_deleted",
+    description:
+      "Multiple messages were deleted at once (admin bulk delete). Single payload with all deleted message IDs.",
+    params: guildAndChannel,
+  },
+
+  // ============================================================================
+  // Reactions
+  // ============================================================================
+  {
+    type: "discord.reaction.added",
+    description: "A reaction was added to a message.",
+    params: reactionFilter,
+  },
+  {
+    type: "discord.reaction.removed",
+    description: "A reaction was removed from a message.",
+    params: reactionFilter,
+  },
+
+  // ============================================================================
+  // Members
+  // ============================================================================
+  {
+    type: "discord.member.joined",
+    description: "A user joined a guild.",
+    params: guildOnly,
+  },
+  {
+    type: "discord.member.left",
+    description: "A user left or was kicked from a guild.",
+    params: guildOnly,
+  },
+  {
+    type: "discord.member.updated",
+    description:
+      "A member's profile changed inside a guild — nickname, avatar, timeout, pending status, communication disabled until.",
+    params: guildOnly,
+  },
+  {
+    type: "discord.member.role.added",
+    description: "A role was added to a guild member.",
+    params: z.object({
+      guild_id: z.string().optional(),
+      role_id: z.string().optional().describe("Filter by role ID."),
+    }),
+  },
+  {
+    type: "discord.member.role.removed",
+    description: "A role was removed from a guild member.",
+    params: z.object({
+      guild_id: z.string().optional(),
+      role_id: z.string().optional(),
+    }),
+  },
+
+  // ============================================================================
+  // Threads
+  // ============================================================================
+  {
+    type: "discord.thread.created",
+    description: "A thread or forum post was created.",
+    params: guildAndChannel,
+  },
+  {
+    type: "discord.thread.updated",
+    description: "A thread was archived, unarchived, locked, renamed, etc.",
+    params: guildAndChannel,
+  },
+  {
+    type: "discord.thread.deleted",
+    description: "A thread was deleted.",
+    params: guildAndChannel,
+  },
+
+  // ============================================================================
+  // Channels
+  // ============================================================================
+  {
+    type: "discord.channel.created",
+    description: "A channel was created in a guild.",
+    params: guildOnly,
+  },
+  {
+    type: "discord.channel.updated",
+    description:
+      "A channel was modified — name, topic, position, permission overwrites.",
+    params: guildOnly,
+  },
+  {
+    type: "discord.channel.deleted",
+    description: "A channel was deleted from a guild.",
+    params: guildOnly,
+  },
+
+  // ============================================================================
+  // Roles
+  // ============================================================================
+  {
+    type: "discord.role.created",
+    description: "A role was created in a guild.",
+    params: guildOnly,
+  },
+  {
+    type: "discord.role.updated",
+    description: "A role was modified — name, color, permissions, position.",
+    params: guildOnly,
+  },
+  {
+    type: "discord.role.deleted",
+    description: "A role was deleted from a guild.",
+    params: guildOnly,
+  },
+
+  // ============================================================================
+  // Guild lifecycle
+  // ============================================================================
+  {
+    type: "discord.guild.joined",
+    description: "The bot was added to a new guild.",
+    params: z.object({}),
+  },
+  {
+    type: "discord.guild.left",
+    description:
+      "The bot was removed from a guild (kicked, banned, or guild deleted).",
+    params: z.object({}),
+  },
+
+  // ============================================================================
+  // Interactions (Phase 3 will populate the events.ts handler)
+  // ============================================================================
+  {
+    type: "discord.interaction.button",
+    description:
+      "A user clicked a button. The MCP auto-defers within 100ms; the agent has 15 minutes to call DISCORD_INTERACTION_FOLLOWUP using the interaction_token from this payload.",
+    params: interactionFilter,
+  },
+  {
+    type: "discord.interaction.select",
+    description:
+      "A user submitted a select-menu choice. Auto-deferred. Use DISCORD_INTERACTION_FOLLOWUP to respond.",
+    params: interactionFilter,
+  },
+  {
+    type: "discord.interaction.modal_submit",
+    description:
+      "A user submitted a modal form. Auto-deferred. Use DISCORD_INTERACTION_FOLLOWUP to respond.",
+    params: interactionFilter,
+  },
+  {
+    type: "discord.interaction.slash_command",
+    description:
+      "A user invoked a slash command. The MCP does not register slash commands itself — register externally via the Discord Developer Portal. Auto-deferred (unless AUTO_DEFER_MODE='off'). Use DISCORD_INTERACTION_FOLLOWUP to respond.",
+    params: z.object({
+      guild_id: z.string().optional(),
+      channel_id: z.string().optional(),
+      command_name: z.string().optional().describe("Filter by command name."),
+    }),
+  },
+
+  // ============================================================================
+  // Opt-in (high-volume) — handler emits only when the corresponding flag is on
+  // ============================================================================
+  {
+    type: "discord.presence.updated",
+    description:
+      "[OPT-IN] A user's presence changed (online/offline/activity). Requires ENABLE_PRESENCE_EVENTS=true and the GuildPresences privileged intent.",
+    params: guildOnly,
+  },
+  {
+    type: "discord.typing.started",
+    description:
+      "[OPT-IN] A user started typing. Requires ENABLE_TYPING_EVENTS=true. High frequency.",
+    params: guildAndChannel,
+  },
+  {
+    type: "discord.voice.state.updated",
+    description:
+      "[OPT-IN] A user joined/left a voice channel or muted/deafened. Requires ENABLE_VOICE_EVENTS=true.",
+    params: guildOnly,
+  },
+];

--- a/discord/server/triggers/interaction-store.ts
+++ b/discord/server/triggers/interaction-store.ts
@@ -1,0 +1,82 @@
+/**
+ * In-memory store for active Discord interactions.
+ *
+ * Discord interactions have a 15-minute lifetime — after auto-defer, the
+ * agent calls DISCORD_INTERACTION_FOLLOWUP with the interaction_token.
+ * We track each one here so we can:
+ *   - Detect already_responded (idempotency for same-bot multi-connection
+ *     fan-out — see plan §"Multi-tenant / mesma bot_token").
+ *   - Sweep expired tokens.
+ *
+ * Note: Discord's webhook URLs are auth'd by interaction_token itself, so
+ * any pod that has the token can answer — this store is defense-in-depth,
+ * not a hard gate. We never block follow-ups from foreign pods; we only
+ * use the local store for idempotency on this pod.
+ */
+
+const TOKEN_TTL_MS = 15 * 60 * 1000;
+const SWEEP_INTERVAL_MS = 60 * 1000;
+
+export interface InteractionRecord {
+  interaction_id: string;
+  token: string;
+  application_id: string;
+  type: number; // discord.js InteractionType
+  expires_at: number;
+  already_responded: boolean;
+  custom_id?: string;
+  channel_id?: string;
+  guild_id?: string;
+}
+
+const store = new Map<string, InteractionRecord>();
+
+export function set(
+  record: Omit<InteractionRecord, "expires_at" | "already_responded">,
+): void {
+  store.set(record.interaction_id, {
+    ...record,
+    expires_at: Date.now() + TOKEN_TTL_MS,
+    already_responded: false,
+  });
+}
+
+export function get(interaction_id: string): InteractionRecord | undefined {
+  return store.get(interaction_id);
+}
+
+/**
+ * Mark a record as responded. Returns true on first call, false if it was
+ * already marked — used by the FOLLOWUP/UPDATE tools for idempotency when
+ * the same bot is connected via two Mesh connections.
+ */
+export function markResponded(interaction_id: string): boolean {
+  const record = store.get(interaction_id);
+  if (!record) return true; // Unknown id — let the call through; Discord will reject if expired.
+  if (record.already_responded) return false;
+  record.already_responded = true;
+  return true;
+}
+
+export function size(): number {
+  return store.size;
+}
+
+let sweepInterval: ReturnType<typeof setInterval> | null = null;
+
+export function startSweeper(): void {
+  if (sweepInterval) return;
+  sweepInterval = setInterval(() => {
+    const now = Date.now();
+    for (const [id, record] of store) {
+      if (record.expires_at < now) store.delete(id);
+    }
+  }, SWEEP_INTERVAL_MS);
+}
+
+export function stopSweeper(): void {
+  if (sweepInterval) {
+    clearInterval(sweepInterval);
+    sweepInterval = null;
+  }
+}

--- a/discord/server/triggers/publisher.ts
+++ b/discord/server/triggers/publisher.ts
@@ -1,0 +1,742 @@
+/**
+ * Multi-tenant trigger fan-out.
+ *
+ * Privacy contract:
+ *   - Guild events: notify any connection whose bot is a member of the guild
+ *     (or any connection without a running bot, since we can't check
+ *     membership without a client — those connections may have triggers
+ *     configured for offline use).
+ *   - DM events: notify ONLY the connection that owns the bot which received
+ *     the DM. Cross-tenant DM leakage is a non-starter.
+ *
+ * Each helper builds a payload that mirrors the trigger's filter params so
+ * the runtime can match subscriptions efficiently.
+ */
+
+import type {
+  Message,
+  GuildMember,
+  MessageReaction,
+  User,
+  ThreadChannel,
+  AnyThreadChannel,
+  GuildChannel,
+  CategoryChannel,
+  Role,
+  Guild,
+  PartialGuildMember,
+  PartialMessage,
+  Presence,
+  Typing,
+  VoiceState,
+  ReadonlyCollection,
+  Snowflake,
+  ButtonInteraction,
+  AnySelectMenuInteraction,
+  ModalSubmitInteraction,
+  ChatInputCommandInteraction,
+} from "discord.js";
+import type { Env } from "../types/env.ts";
+import { triggers } from "./store.ts";
+import { getAllInstances } from "../bot/instance.ts";
+
+type TriggerType = Parameters<(typeof triggers)["notify"]>[1];
+
+function notifyAllConnections(
+  type: TriggerType,
+  data: Record<string, unknown>,
+  sourceConnectionId?: string,
+): void {
+  const instances = getAllInstances();
+  const guildId = data.guild_id as string | undefined;
+
+  for (const instance of instances) {
+    if (guildId) {
+      // Guild event: skip connections whose bot is online but not in this guild.
+      if (
+        instance.client?.isReady() &&
+        !instance.client.guilds.cache.has(guildId)
+      ) {
+        continue;
+      }
+    } else {
+      // DM (or non-guild) event: only notify the originating connection.
+      if (sourceConnectionId && instance.connectionId !== sourceConnectionId) {
+        continue;
+      }
+    }
+
+    triggers.notify(instance.connectionId, type, data);
+  }
+}
+
+function isoOrUndefined(d: Date | null | undefined): string | undefined {
+  return d ? d.toISOString() : undefined;
+}
+
+// ============================================================================
+// Messages
+// ============================================================================
+
+export function publishMessageCreated(env: Env, message: Message): void {
+  const connId = env.MESH_REQUEST_CONTEXT?.connectionId;
+  const isDM = !message.guild;
+  notifyAllConnections(
+    "discord.message.created",
+    {
+      event: "discord.message.created",
+      subject: message.id,
+      message_id: message.id,
+      guild_id: message.guild?.id,
+      guild_name: message.guild?.name,
+      channel_id: message.channelId,
+      channel_name:
+        message.channel && "name" in message.channel
+          ? message.channel.name
+          : undefined,
+      parent_id:
+        message.channel && "parentId" in message.channel
+          ? message.channel.parentId
+          : undefined,
+      author_id: message.author.id,
+      author_username: message.author.username,
+      author_global_name: message.author.globalName,
+      author_bot: message.author.bot,
+      content: message.content,
+      attachments: message.attachments.map((a) => ({
+        id: a.id,
+        url: a.url,
+        name: a.name,
+        size: a.size,
+        content_type: a.contentType,
+      })),
+      attachment_count: message.attachments.size,
+      embeds: message.embeds.length,
+      mention_everyone: message.mentions.everyone,
+      mention_user_ids: message.mentions.users.map((u) => u.id),
+      mention_role_ids: message.mentions.roles.map((r) => r.id),
+      is_dm: isDM,
+      dm_user_id: isDM ? message.author.id : undefined,
+      timestamp: message.createdAt.toISOString(),
+      referenced_message_id: message.reference?.messageId,
+    },
+    connId,
+  );
+}
+
+export function publishMessageUpdated(
+  env: Env,
+  oldMessage: Message | PartialMessage,
+  newMessage: Message,
+): void {
+  const connId = env.MESH_REQUEST_CONTEXT?.connectionId;
+  const isDM = !newMessage.guild;
+  notifyAllConnections(
+    "discord.message.updated",
+    {
+      event: "discord.message.updated",
+      subject: newMessage.id,
+      message_id: newMessage.id,
+      guild_id: newMessage.guild?.id,
+      channel_id: newMessage.channelId,
+      author_id: newMessage.author.id,
+      author_username: newMessage.author.username,
+      author_bot: newMessage.author.bot,
+      old_content: oldMessage.partial ? undefined : oldMessage.content,
+      new_content: newMessage.content,
+      content_changed:
+        !oldMessage.partial && oldMessage.content !== newMessage.content,
+      is_dm: isDM,
+      dm_user_id: isDM ? newMessage.author.id : undefined,
+      edited_at: isoOrUndefined(newMessage.editedAt),
+    },
+    connId,
+  );
+}
+
+export function publishMessageDeleted(
+  env: Env,
+  message: Message | PartialMessage,
+): void {
+  const connId = env.MESH_REQUEST_CONTEXT?.connectionId;
+  const isDM = !message.guild;
+  notifyAllConnections(
+    "discord.message.deleted",
+    {
+      event: "discord.message.deleted",
+      subject: message.id,
+      message_id: message.id,
+      guild_id: message.guild?.id,
+      channel_id: message.channelId,
+      author_id: message.author?.id,
+      author_username: message.author?.username,
+      author_bot: message.author?.bot,
+      content: message.partial ? undefined : message.content,
+      is_dm: isDM,
+      dm_user_id: isDM ? message.author?.id : undefined,
+      deleted_at: new Date().toISOString(),
+    },
+    connId,
+  );
+}
+
+export function publishMessageBulkDeleted(
+  env: Env,
+  messages: ReadonlyCollection<Snowflake, Message | PartialMessage>,
+): void {
+  const connId = env.MESH_REQUEST_CONTEXT?.connectionId;
+  const first = messages.first();
+  if (!first) return;
+  notifyAllConnections(
+    "discord.message.bulk_deleted",
+    {
+      event: "discord.message.bulk_deleted",
+      subject: first.channelId,
+      guild_id: first.guild?.id,
+      channel_id: first.channelId,
+      message_ids: Array.from(messages.keys()),
+      message_count: messages.size,
+      deleted_at: new Date().toISOString(),
+    },
+    connId,
+  );
+}
+
+// ============================================================================
+// Reactions
+// ============================================================================
+
+function emojiKey(reaction: MessageReaction): string {
+  return reaction.emoji.id
+    ? `<:${reaction.emoji.name}:${reaction.emoji.id}>`
+    : (reaction.emoji.name ?? "?");
+}
+
+export function publishReactionAdded(
+  env: Env,
+  reaction: MessageReaction,
+  user: User,
+): void {
+  const connId = env.MESH_REQUEST_CONTEXT?.connectionId;
+  const isDM = !reaction.message.guild;
+  notifyAllConnections(
+    "discord.reaction.added",
+    {
+      event: "discord.reaction.added",
+      subject: reaction.message.id,
+      message_id: reaction.message.id,
+      guild_id: reaction.message.guild?.id,
+      channel_id: reaction.message.channelId,
+      user_id: user.id,
+      username: user.username,
+      emoji: emojiKey(reaction),
+      emoji_id: reaction.emoji.id,
+      emoji_name: reaction.emoji.name,
+      is_dm: isDM,
+      added_at: new Date().toISOString(),
+    },
+    connId,
+  );
+}
+
+export function publishReactionRemoved(
+  env: Env,
+  reaction: MessageReaction,
+  user: User,
+): void {
+  const connId = env.MESH_REQUEST_CONTEXT?.connectionId;
+  const isDM = !reaction.message.guild;
+  notifyAllConnections(
+    "discord.reaction.removed",
+    {
+      event: "discord.reaction.removed",
+      subject: reaction.message.id,
+      message_id: reaction.message.id,
+      guild_id: reaction.message.guild?.id,
+      channel_id: reaction.message.channelId,
+      user_id: user.id,
+      username: user.username,
+      emoji: emojiKey(reaction),
+      emoji_id: reaction.emoji.id,
+      emoji_name: reaction.emoji.name,
+      is_dm: isDM,
+      removed_at: new Date().toISOString(),
+    },
+    connId,
+  );
+}
+
+// ============================================================================
+// Members
+// ============================================================================
+
+export function publishMemberJoined(_env: Env, member: GuildMember): void {
+  notifyAllConnections("discord.member.joined", {
+    event: "discord.member.joined",
+    subject: member.id,
+    user_id: member.id,
+    username: member.user.username,
+    display_name: member.displayName,
+    guild_id: member.guild.id,
+    guild_name: member.guild.name,
+    is_bot: member.user.bot,
+    joined_at: isoOrUndefined(member.joinedAt),
+    account_created_at: member.user.createdAt.toISOString(),
+  });
+}
+
+export function publishMemberLeft(
+  _env: Env,
+  member: GuildMember | PartialGuildMember,
+): void {
+  notifyAllConnections("discord.member.left", {
+    event: "discord.member.left",
+    subject: member.id,
+    user_id: member.id,
+    username: member.user?.username,
+    guild_id: member.guild.id,
+    guild_name: member.guild.name,
+    left_at: new Date().toISOString(),
+  });
+}
+
+export function publishMemberUpdated(
+  _env: Env,
+  oldMember: GuildMember | PartialGuildMember,
+  newMember: GuildMember,
+): void {
+  notifyAllConnections("discord.member.updated", {
+    event: "discord.member.updated",
+    subject: newMember.id,
+    user_id: newMember.id,
+    username: newMember.user.username,
+    guild_id: newMember.guild.id,
+    old_nickname: oldMember.nickname ?? undefined,
+    new_nickname: newMember.nickname ?? undefined,
+    nickname_changed: oldMember.nickname !== newMember.nickname,
+    timed_out_until: isoOrUndefined(newMember.communicationDisabledUntil),
+    pending: newMember.pending,
+    updated_at: new Date().toISOString(),
+  });
+}
+
+export function publishMemberRoleAdded(
+  _env: Env,
+  member: GuildMember,
+  roleId: string,
+  roleName: string,
+): void {
+  notifyAllConnections("discord.member.role.added", {
+    event: "discord.member.role.added",
+    subject: member.id,
+    user_id: member.id,
+    username: member.user.username,
+    guild_id: member.guild.id,
+    role_id: roleId,
+    role_name: roleName,
+    added_at: new Date().toISOString(),
+  });
+}
+
+export function publishMemberRoleRemoved(
+  _env: Env,
+  member: GuildMember,
+  roleId: string,
+  roleName: string,
+): void {
+  notifyAllConnections("discord.member.role.removed", {
+    event: "discord.member.role.removed",
+    subject: member.id,
+    user_id: member.id,
+    username: member.user.username,
+    guild_id: member.guild.id,
+    role_id: roleId,
+    role_name: roleName,
+    removed_at: new Date().toISOString(),
+  });
+}
+
+// ============================================================================
+// Threads
+// ============================================================================
+
+export function publishThreadCreated(
+  _env: Env,
+  thread: ThreadChannel | AnyThreadChannel,
+): void {
+  notifyAllConnections("discord.thread.created", {
+    event: "discord.thread.created",
+    subject: thread.id,
+    thread_id: thread.id,
+    thread_name: thread.name,
+    guild_id: thread.guild?.id,
+    channel_id: thread.parentId,
+    channel_name: thread.parent?.name,
+    owner_id: thread.ownerId,
+    type: thread.type,
+    archived: thread.archived,
+    locked: thread.locked,
+    message_count: thread.messageCount,
+    member_count: thread.memberCount,
+    created_at: isoOrUndefined(thread.createdAt),
+  });
+}
+
+export function publishThreadUpdated(
+  _env: Env,
+  oldThread: ThreadChannel | AnyThreadChannel,
+  newThread: ThreadChannel | AnyThreadChannel,
+): void {
+  notifyAllConnections("discord.thread.updated", {
+    event: "discord.thread.updated",
+    subject: newThread.id,
+    thread_id: newThread.id,
+    thread_name: newThread.name,
+    guild_id: newThread.guild?.id,
+    channel_id: newThread.parentId,
+    old_name: oldThread.name,
+    new_name: newThread.name,
+    name_changed: oldThread.name !== newThread.name,
+    old_archived: oldThread.archived,
+    new_archived: newThread.archived,
+    old_locked: oldThread.locked,
+    new_locked: newThread.locked,
+    updated_at: new Date().toISOString(),
+  });
+}
+
+export function publishThreadDeleted(
+  _env: Env,
+  thread: ThreadChannel | AnyThreadChannel,
+): void {
+  notifyAllConnections("discord.thread.deleted", {
+    event: "discord.thread.deleted",
+    subject: thread.id,
+    thread_id: thread.id,
+    thread_name: thread.name,
+    guild_id: thread.guild?.id,
+    channel_id: thread.parentId,
+    deleted_at: new Date().toISOString(),
+  });
+}
+
+// ============================================================================
+// Channels
+// ============================================================================
+
+export function publishChannelCreated(_env: Env, channel: GuildChannel): void {
+  const categoryName =
+    "parent" in channel ? (channel.parent as CategoryChannel)?.name : undefined;
+  notifyAllConnections("discord.channel.created", {
+    event: "discord.channel.created",
+    subject: channel.id,
+    channel_id: channel.id,
+    channel_name: channel.name,
+    guild_id: channel.guild?.id,
+    type: channel.type,
+    parent_id: "parentId" in channel ? channel.parentId : undefined,
+    category_name: categoryName,
+    position: channel.position,
+    created_at: isoOrUndefined(channel.createdAt),
+  });
+}
+
+export function publishChannelUpdated(
+  _env: Env,
+  oldChannel: GuildChannel,
+  newChannel: GuildChannel,
+): void {
+  notifyAllConnections("discord.channel.updated", {
+    event: "discord.channel.updated",
+    subject: newChannel.id,
+    channel_id: newChannel.id,
+    channel_name: newChannel.name,
+    guild_id: newChannel.guild?.id,
+    type: newChannel.type,
+    old_name: oldChannel.name,
+    new_name: newChannel.name,
+    name_changed: oldChannel.name !== newChannel.name,
+    old_position: oldChannel.position,
+    new_position: newChannel.position,
+    updated_at: new Date().toISOString(),
+  });
+}
+
+export function publishChannelDeleted(_env: Env, channel: GuildChannel): void {
+  notifyAllConnections("discord.channel.deleted", {
+    event: "discord.channel.deleted",
+    subject: channel.id,
+    channel_id: channel.id,
+    channel_name: channel.name,
+    guild_id: channel.guild?.id,
+    type: channel.type,
+    deleted_at: new Date().toISOString(),
+  });
+}
+
+// ============================================================================
+// Roles
+// ============================================================================
+
+export function publishRoleCreated(_env: Env, role: Role): void {
+  notifyAllConnections("discord.role.created", {
+    event: "discord.role.created",
+    subject: role.id,
+    role_id: role.id,
+    role_name: role.name,
+    guild_id: role.guild.id,
+    color: role.color,
+    permissions: role.permissions.bitfield.toString(),
+    position: role.position,
+    hoist: role.hoist,
+    mentionable: role.mentionable,
+    created_at: isoOrUndefined(role.createdAt),
+  });
+}
+
+export function publishRoleUpdated(
+  _env: Env,
+  oldRole: Role,
+  newRole: Role,
+): void {
+  notifyAllConnections("discord.role.updated", {
+    event: "discord.role.updated",
+    subject: newRole.id,
+    role_id: newRole.id,
+    guild_id: newRole.guild.id,
+    old_name: oldRole.name,
+    new_name: newRole.name,
+    old_color: oldRole.color,
+    new_color: newRole.color,
+    old_permissions: oldRole.permissions.bitfield.toString(),
+    new_permissions: newRole.permissions.bitfield.toString(),
+    permissions_changed:
+      oldRole.permissions.bitfield !== newRole.permissions.bitfield,
+    updated_at: new Date().toISOString(),
+  });
+}
+
+export function publishRoleDeleted(_env: Env, role: Role): void {
+  notifyAllConnections("discord.role.deleted", {
+    event: "discord.role.deleted",
+    subject: role.id,
+    role_id: role.id,
+    role_name: role.name,
+    guild_id: role.guild.id,
+    deleted_at: new Date().toISOString(),
+  });
+}
+
+// ============================================================================
+// Guild lifecycle
+// ============================================================================
+
+export function publishGuildJoined(_env: Env, guild: Guild): void {
+  notifyAllConnections("discord.guild.joined", {
+    event: "discord.guild.joined",
+    subject: guild.id,
+    guild_id: guild.id,
+    guild_name: guild.name,
+    member_count: guild.memberCount,
+    owner_id: guild.ownerId,
+    joined_at: new Date().toISOString(),
+  });
+}
+
+export function publishGuildLeft(_env: Env, guild: Guild): void {
+  notifyAllConnections("discord.guild.left", {
+    event: "discord.guild.left",
+    subject: guild.id,
+    guild_id: guild.id,
+    guild_name: guild.name,
+    left_at: new Date().toISOString(),
+  });
+}
+
+// ============================================================================
+// Interactions (button / select / modal / slash command)
+// ============================================================================
+
+function interactionExpiresAt(): string {
+  return new Date(Date.now() + 15 * 60 * 1000).toISOString();
+}
+
+export function publishInteractionButton(
+  env: Env,
+  interaction: ButtonInteraction,
+): void {
+  const connId = env.MESH_REQUEST_CONTEXT?.connectionId;
+  notifyAllConnections(
+    "discord.interaction.button",
+    {
+      event: "discord.interaction.button",
+      subject: interaction.id,
+      interaction_id: interaction.id,
+      interaction_token: interaction.token,
+      application_id: interaction.applicationId,
+      expires_at: interactionExpiresAt(),
+      custom_id: interaction.customId,
+      message_id: interaction.message.id,
+      channel_id: interaction.channelId,
+      guild_id: interaction.guildId ?? undefined,
+      user_id: interaction.user.id,
+      username: interaction.user.username,
+      timestamp: new Date().toISOString(),
+    },
+    connId,
+  );
+}
+
+export function publishInteractionSelect(
+  env: Env,
+  interaction: AnySelectMenuInteraction,
+): void {
+  const connId = env.MESH_REQUEST_CONTEXT?.connectionId;
+  notifyAllConnections(
+    "discord.interaction.select",
+    {
+      event: "discord.interaction.select",
+      subject: interaction.id,
+      interaction_id: interaction.id,
+      interaction_token: interaction.token,
+      application_id: interaction.applicationId,
+      expires_at: interactionExpiresAt(),
+      custom_id: interaction.customId,
+      selected_values: interaction.values,
+      message_id: interaction.message.id,
+      channel_id: interaction.channelId,
+      guild_id: interaction.guildId ?? undefined,
+      user_id: interaction.user.id,
+      username: interaction.user.username,
+      timestamp: new Date().toISOString(),
+    },
+    connId,
+  );
+}
+
+export function publishInteractionModalSubmit(
+  env: Env,
+  interaction: ModalSubmitInteraction,
+): void {
+  const connId = env.MESH_REQUEST_CONTEXT?.connectionId;
+  const fields: Record<string, string> = {};
+  for (const [key, field] of interaction.fields.fields) {
+    // ModalData has subtype TextInputModalData with `.value`. Other modal field
+    // types may not, so guard with `in`.
+    if (
+      "value" in field &&
+      typeof (field as { value: unknown }).value === "string"
+    ) {
+      fields[key] = (field as { value: string }).value;
+    }
+  }
+  notifyAllConnections(
+    "discord.interaction.modal_submit",
+    {
+      event: "discord.interaction.modal_submit",
+      subject: interaction.id,
+      interaction_id: interaction.id,
+      interaction_token: interaction.token,
+      application_id: interaction.applicationId,
+      expires_at: interactionExpiresAt(),
+      custom_id: interaction.customId,
+      field_values: fields,
+      channel_id: interaction.channelId ?? undefined,
+      guild_id: interaction.guildId ?? undefined,
+      user_id: interaction.user.id,
+      username: interaction.user.username,
+      timestamp: new Date().toISOString(),
+    },
+    connId,
+  );
+}
+
+export function publishInteractionSlashCommand(
+  env: Env,
+  interaction: ChatInputCommandInteraction,
+): void {
+  const connId = env.MESH_REQUEST_CONTEXT?.connectionId;
+  // Flatten options into a simple object the agent can consume.
+  const options: Record<string, unknown> = {};
+  for (const opt of interaction.options.data) {
+    options[opt.name] = opt.value ?? opt.options ?? null;
+  }
+  notifyAllConnections(
+    "discord.interaction.slash_command",
+    {
+      event: "discord.interaction.slash_command",
+      subject: interaction.id,
+      interaction_id: interaction.id,
+      interaction_token: interaction.token,
+      application_id: interaction.applicationId,
+      expires_at: interactionExpiresAt(),
+      command_name: interaction.commandName,
+      options,
+      channel_id: interaction.channelId,
+      guild_id: interaction.guildId ?? undefined,
+      user_id: interaction.user.id,
+      username: interaction.user.username,
+      timestamp: new Date().toISOString(),
+    },
+    connId,
+  );
+}
+
+// ============================================================================
+// Opt-in: presence, typing, voice
+// ============================================================================
+
+export function publishPresenceUpdated(_env: Env, newPresence: Presence): void {
+  if (!newPresence.userId || !newPresence.guild) return;
+  notifyAllConnections("discord.presence.updated", {
+    event: "discord.presence.updated",
+    subject: newPresence.userId,
+    user_id: newPresence.userId,
+    guild_id: newPresence.guild.id,
+    status: newPresence.status,
+    activities: newPresence.activities.map((a) => ({
+      type: a.type,
+      name: a.name,
+      state: a.state,
+      details: a.details,
+    })),
+    updated_at: new Date().toISOString(),
+  });
+}
+
+export function publishTypingStarted(_env: Env, typing: Typing): void {
+  notifyAllConnections("discord.typing.started", {
+    event: "discord.typing.started",
+    subject: typing.user.id,
+    user_id: typing.user.id,
+    guild_id: typing.guild?.id,
+    channel_id: typing.channel.id,
+    started_at: new Date(typing.startedTimestamp).toISOString(),
+  });
+}
+
+export function publishVoiceStateUpdated(
+  _env: Env,
+  oldState: VoiceState,
+  newState: VoiceState,
+): void {
+  notifyAllConnections("discord.voice.state.updated", {
+    event: "discord.voice.state.updated",
+    subject: newState.id,
+    user_id: newState.id,
+    guild_id: newState.guild.id,
+    old_channel_id: oldState.channelId,
+    new_channel_id: newState.channelId,
+    joined: !oldState.channelId && !!newState.channelId,
+    left: !!oldState.channelId && !newState.channelId,
+    moved:
+      !!oldState.channelId &&
+      !!newState.channelId &&
+      oldState.channelId !== newState.channelId,
+    self_mute: newState.selfMute,
+    self_deaf: newState.selfDeaf,
+    server_mute: newState.serverMute,
+    server_deaf: newState.serverDeaf,
+    updated_at: new Date().toISOString(),
+  });
+}

--- a/discord/server/triggers/store.ts
+++ b/discord/server/triggers/store.ts
@@ -1,0 +1,47 @@
+/**
+ * Supabase-backed storage for the @decocms/runtime/triggers system.
+ *
+ * Trigger definitions live in ./definitions.ts; this module wires storage and
+ * exports the singleton `triggers` instance everywhere else imports.
+ */
+
+import { createTriggers, type TriggerStorage } from "@decocms/runtime/triggers";
+import {
+  saveTriggerCredentials,
+  loadTriggerCredentials,
+  deleteTriggerCredentials,
+} from "../lib/supabase.ts";
+import { triggerDefinitions } from "./definitions.ts";
+
+class SupabaseTriggerStorage implements TriggerStorage {
+  async get(connectionId: string) {
+    try {
+      return await loadTriggerCredentials(connectionId);
+    } catch {
+      return null;
+    }
+  }
+
+  async set(connectionId: string, state: any) {
+    try {
+      await saveTriggerCredentials(connectionId, state);
+    } catch {
+      // swallow: trigger registration is best-effort
+    }
+  }
+
+  async delete(connectionId: string) {
+    try {
+      await deleteTriggerCredentials(connectionId);
+    } catch {
+      // swallow
+    }
+  }
+}
+
+const storage = new SupabaseTriggerStorage();
+
+export const triggers = createTriggers({
+  definitions: triggerDefinitions,
+  storage,
+});

--- a/discord/server/types/env.ts
+++ b/discord/server/types/env.ts
@@ -1,0 +1,59 @@
+import type { Registry } from "@decocms/mcps-shared/registry";
+import { BindingOf, type DefaultEnv } from "@decocms/runtime";
+import z from "zod";
+
+export const StateSchema = z.object({
+  CONNECTION: BindingOf("@deco/connection"),
+
+  DISCORD_PUBLIC_KEY: z
+    .string()
+    .optional()
+    .describe(
+      "Discord Application Public Key (Developer Portal > General Information). Only required if you intend to use the HTTP webhook fallback for slash commands.",
+    ),
+
+  DISCORD_APPLICATION_ID: z
+    .string()
+    .optional()
+    .describe(
+      "Discord Application ID (Developer Portal). Required for interaction follow-ups (the agent passes this back when responding to button/select/modal events).",
+    ),
+
+  AUTHORIZED_GUILDS: z
+    .string()
+    .optional()
+    .describe(
+      "Comma-separated guild IDs allowed to interact with this bot. Empty = all guilds.",
+    ),
+
+  AUTO_DEFER_MODE: z
+    .enum(["ephemeral", "visible", "off"])
+    .default("ephemeral")
+    .describe(
+      "Default acknowledgement mode for Discord interactions. 'ephemeral' (default): user sees a private 'thinking' indicator while the agent is processing. 'visible': everyone sees it. 'off': skip auto-defer (only safe if your agent always replies in <3s, e.g. for slash commands that show a modal).",
+    ),
+
+  ENABLE_PRESENCE_EVENTS: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Emit discord.presence.updated triggers. HIGH VOLUME: requires GuildPresences privileged intent and Discord verification when the bot is in 100+ guilds.",
+    ),
+
+  ENABLE_TYPING_EVENTS: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Emit discord.typing.started triggers. High frequency — only enable if your agent reacts to typing.",
+    ),
+
+  ENABLE_VOICE_EVENTS: z
+    .boolean()
+    .default(false)
+    .describe(
+      "Emit discord.voice.state.updated triggers (mute/deafen/join/leave voice).",
+    ),
+});
+
+export type Env = DefaultEnv<typeof StateSchema, Registry>;
+export type { Registry };

--- a/discord/server/types/tools.ts
+++ b/discord/server/types/tools.ts
@@ -1,0 +1,3 @@
+export type ToolFactory<TEnv> = (env: TEnv) => unknown;
+
+export type ToolCollection<TEnv> = ToolFactory<TEnv>[];

--- a/discord/tsconfig.json
+++ b/discord/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": [
+      "ES2023"
+    ],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "allowJs": true,
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "types": [
+      "@types/node"
+    ]
+  },
+  "include": [
+    "server"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "datajud",
     "deco-llm",
     "deco-news-weekly-digest",
+    "discord",
     "discord-read",
     "dropbox",
     "farmrio-reorder-collection-db",


### PR DESCRIPTION
## Summary
- New MCP at `discord/` (kubernetes-bun) that listens to Discord gateway events and emits them as Studio triggers (26 default + 3 opt-in interactions/voice/presence/typing)
- Auto-defers interactions in <100ms so the agent has 15 min to respond via `DISCORD_INTERACTION_FOLLOWUP` / `_UPDATE` / `SHOW_MODAL`
- Replaces embedded LLM logic from `discord-read` — agent in Studio decides everything; this MCP only listens, emits, and exposes management tools (messages with `components`, channels, guilds, members, roles, moderation, webhooks)
- Multi-tenant safe with bot tokens persisted in `discord2_connections` (Supabase) and bots auto-starting at pod boot; DM events scoped to the originating connection only

## Test plan
- [ ] Apply migrations: `discord/migrations/001_discord2_connections.sql` and `002_discord2_trigger_credentials.sql`
- [ ] Configure a connection via DISCORD_SAVE_CONFIG with a real bot token
- [ ] Send a message with a button via DISCORD_SEND_MESSAGE \`components\`, click it, and verify the agent receives \`discord.interaction.button\` and replies via DISCORD_INTERACTION_FOLLOWUP
- [ ] Restart the pod and verify the bot reconnects automatically (no manual start)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new event‑driven Discord MCP at `discord/` that turns Gateway events into Studio triggers and exposes tools for the agent to manage Discord. This replaces `discord-read`’s embedded logic with a trigger + tool flow and auto-starts bots per connection.

- **New Features**
  - Publishes Discord Gateway events as triggers (core events by default; presence/typing/voice are opt‑in).
  - Auto‑defers interactions in under 100 ms; agent replies via `DISCORD_INTERACTION_FOLLOWUP`, `DISCORD_INTERACTION_UPDATE`, or `DISCORD_INTERACTION_SHOW_MODAL` within 15 minutes.
  - Multi‑tenant safe: bot tokens stored in Supabase (`discord2_connections`); bots auto‑start on pod boot; DM events scoped to the originating connection; interaction idempotency across same‑bot multi‑connections.
  - Tools for messages, interactions, channels, guilds/members/roles/moderation, and webhooks.
  - New `deploy.json` target for `kubernetes-bun` with `/health` and a lightweight gateway client; cached config reads and retry‑aware REST calls.

- **Migration**
  - Apply Supabase migrations: `discord/migrations/001_discord2_connections.sql` and `discord/migrations/002_discord2_trigger_credentials.sql`.
  - Configure a connection with `DISCORD_SAVE_CONFIG` (provide a bot token; optionally `AUTHORIZED_GUILDS` and `DISCORD_APPLICATION_ID` for interactions).
  - Verify by sending a message with `components`, clicking it to receive a `discord.interaction.*` trigger, and responding via `DISCORD_INTERACTION_FOLLOWUP`.

<sup>Written for commit a53ddbef60c5c6ba92cbf8aa47dc56c083a5b366. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

