### PR TITLE
fix(google-gmail): lazy ensureGmailSetup on every authenticated tool call

### DIFF
--- a/google-gmail/server/lib/gmail-client.ts
+++ b/google-gmail/server/lib/gmail-client.ts
@@ -630,5 +630,10 @@ export class GmailClient {
   }
 }
 
-// Re-export getGoogleAccessToken from env.ts for convenience
+// Re-export getGoogleAccessToken from env.ts for convenience.
+// Tools should prefer `getAccessTokenWithSetup` from `./setup.ts` —
+// it threads the bearer token through the idempotent per-connection
+// setup so first-time use lazily registers the Pub/Sub watch even
+// when mesh never invoked configuration.onChange.
 export { getGoogleAccessToken as getAccessToken } from "./env.ts";
+export { getAccessTokenWithSetup } from "./setup.ts";

--- a/google-gmail/server/lib/setup.ts
+++ b/google-gmail/server/lib/setup.ts
@@ -1,0 +1,162 @@
+/**
+ * Idempotent per-connection setup. Runs the work that *should* happen
+ * inside `configuration.onChange` — fetch profile, write the email ↔
+ * connection mapping, claim the pending refresh_token, register the
+ * Pub/Sub watch, and anchor the historyId watermark.
+ *
+ * Why this lives outside onChange too: mesh only invokes
+ * ON_MCP_CONFIGURATION (which fires our onChange) when the user saves
+ * configuration state. With an empty StateSchema, that handler may
+ * never fire — the user authenticates, configures a trigger, and never
+ * touches a "save settings" button. Without onChange running, no
+ * users.watch is registered with Google and Pub/Sub never fires.
+ *
+ * So we also run this on every authenticated tool call, mirroring the
+ * github MCP's `ensureInstallationMappings` pattern. The cheap path is
+ * a single KV read once setup is complete.
+ */
+
+import { ENDPOINTS } from "../constants.ts";
+import {
+  getEmailForConnection,
+  removeConnectionMappings,
+  setEmailMapping,
+} from "./email-connection-map.ts";
+import {
+  claimPendingRefreshToken,
+  getRefreshTokenForConnection,
+  setLastHistoryId,
+  setRefreshTokenForConnection,
+} from "./oauth-store.ts";
+import type { Env } from "../types/env.ts";
+
+interface KVNamespaceLike {
+  get(key: string): Promise<string | null>;
+  put(
+    key: string,
+    value: string,
+    options?: { expirationTtl?: number },
+  ): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+export async function ensureGmailSetup(
+  env: Env,
+  accessToken: string,
+  connectionId: string,
+): Promise<void> {
+  const kv = env.EMAIL_MAP;
+  if (!kv) return;
+
+  // Fast path: setup already ran for this connection. We treat
+  // "we have an email mapping AND a refresh_token" as the cheap
+  // signal that everything else (watch, history anchor) is also
+  // fine. If a downstream piece is broken we'd see it in webhook
+  // logs and run setup again on demand.
+  const [existingEmail, existingRefresh] = await Promise.all([
+    getEmailForConnection(kv, connectionId),
+    getRefreshTokenForConnection(kv, connectionId),
+  ]);
+  if (existingEmail && existingRefresh) {
+    return;
+  }
+
+  try {
+    const profileRes = await fetch(ENDPOINTS.PROFILE, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (!profileRes.ok) {
+      console.error(
+        `[Gmail setup] profile fetch failed: ${profileRes.status} (connection=${connectionId})`,
+      );
+      return;
+    }
+    const profile = (await profileRes.json()) as {
+      emailAddress: string;
+      historyId: string;
+    };
+
+    if (!existingEmail || existingEmail !== profile.emailAddress) {
+      await removeConnectionMappings(kv, connectionId);
+      await setEmailMapping(kv, profile.emailAddress, connectionId);
+      console.log(
+        `[Gmail setup] Mapped ${profile.emailAddress} → ${connectionId}`,
+      );
+    }
+
+    if (!existingRefresh) {
+      const refreshToken = await claimPendingRefreshToken(kv, accessToken);
+      if (refreshToken) {
+        await setRefreshTokenForConnection(kv, connectionId, refreshToken);
+        console.log(
+          `[Gmail setup] Persisted refresh_token for connection=${connectionId}`,
+        );
+      } else {
+        console.warn(
+          `[Gmail setup] No pending refresh_token for connection=${connectionId} — webhook delivery will fail until the user reauthenticates`,
+        );
+      }
+    }
+
+    const pubsubTopic = process.env.GMAIL_PUBSUB_TOPIC || "";
+    if (!pubsubTopic) {
+      console.warn(
+        "[Gmail setup] GMAIL_PUBSUB_TOPIC not set — skipping users.watch (no webhook delivery)",
+      );
+      return;
+    }
+
+    const watchRes = await fetch(ENDPOINTS.WATCH, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        topicName: pubsubTopic,
+        labelIds: ["INBOX"],
+      }),
+    });
+    if (!watchRes.ok) {
+      const error = await watchRes.text();
+      console.error(
+        `[Gmail setup] users.watch failed: ${watchRes.status} - ${error} (connection=${connectionId})`,
+      );
+      return;
+    }
+
+    const watchData = (await watchRes.json()) as {
+      historyId: string;
+      expiration: string;
+    };
+    await setLastHistoryId(kv, connectionId, watchData.historyId);
+    console.log(
+      `[Gmail setup] Watch registered for ${profile.emailAddress}, expires ${watchData.expiration}`,
+    );
+  } catch (err) {
+    console.error(`[Gmail setup] error for connection=${connectionId}:`, err);
+  }
+}
+
+/**
+ * Convenience wrapper used by every tool: pulls accessToken +
+ * connectionId from MESH_REQUEST_CONTEXT, runs the idempotent setup,
+ * returns the accessToken so the tool can keep going. Throws the same
+ * "Not authenticated" error as the old getGoogleAccessToken if the
+ * Bearer is missing.
+ */
+export async function getAccessTokenWithSetup(env: Env): Promise<string> {
+  const authorization = env.MESH_REQUEST_CONTEXT?.authorization;
+  if (!authorization) {
+    throw new Error("Not authenticated. Please authorize with Gmail first.");
+  }
+  const accessToken = authorization.replace(/^Bearer\s+/i, "");
+  const connectionId = env.MESH_REQUEST_CONTEXT?.connectionId;
+  if (connectionId && env.EMAIL_MAP) {
+    await ensureGmailSetup(env, accessToken, connectionId);
+  }
+  return accessToken;
+}
+
+// Re-export the KV interface so callers don't need to import directly.
+export type { KVNamespaceLike };

--- a/google-gmail/server/main.ts
+++ b/google-gmail/server/main.ts
@@ -14,19 +14,10 @@
 import { withRuntime } from "@decocms/runtime";
 import { createGoogleOAuth } from "@decocms/mcps-shared/google-oauth";
 
-import { ENDPOINTS, GOOGLE_SCOPES } from "./constants.ts";
-import {
-  removeConnectionMappings,
-  setEmailMapping,
-} from "./lib/email-connection-map.ts";
-import {
-  claimPendingRefreshToken,
-  setLastHistoryId,
-  setOAuthKV,
-  setRefreshTokenForConnection,
-  stashPendingRefreshToken,
-} from "./lib/oauth-store.ts";
+import { GOOGLE_SCOPES } from "./constants.ts";
+import { setOAuthKV, stashPendingRefreshToken } from "./lib/oauth-store.ts";
 import { renewAllWatches } from "./lib/scheduled.ts";
+import { ensureGmailSetup } from "./lib/setup.ts";
 import { setTriggerKV } from "./lib/trigger-store.ts";
 import { tools } from "./tools/index.ts";
 import { type Env, type Registry, StateSchema } from "./types/env.ts";
@@ -78,116 +69,20 @@ function getRuntime(): Runtime {
     oauth: buildOAuth(),
     configuration: {
       state: StateSchema,
+      // Mesh only invokes ON_MCP_CONFIGURATION (which fires this) when
+      // the user actually saves config state. With an empty StateSchema
+      // the user can authenticate and configure a trigger without ever
+      // touching that path, so onChange isn't a reliable setup hook on
+      // its own — every tool also runs the same idempotent setup via
+      // getAccessTokenWithSetup. Keeping onChange wired means setup
+      // *also* runs when the user does change config, which is cheaper
+      // than waiting for the first tool call.
       onChange: async (env) => {
         const token = env.MESH_REQUEST_CONTEXT?.authorization;
         const connectionId = env.MESH_REQUEST_CONTEXT?.connectionId;
         if (!token || !connectionId) return;
-
-        if (!env.EMAIL_MAP) {
-          console.warn(
-            "[Gmail onChange] EMAIL_MAP binding missing — skipping mapping/watch setup",
-          );
-          return;
-        }
-
         const accessToken = token.replace(/^Bearer\s+/i, "");
-
-        try {
-          const profileRes = await fetch(ENDPOINTS.PROFILE, {
-            headers: { Authorization: `Bearer ${accessToken}` },
-          });
-
-          if (!profileRes.ok) {
-            console.error(
-              `[Gmail onChange] Failed to fetch profile: ${profileRes.status}`,
-            );
-            return;
-          }
-
-          const profile = (await profileRes.json()) as {
-            emailAddress: string;
-            historyId: string;
-          };
-
-          // Drop any stale email→connection mapping owned by *this*
-          // connection before writing the new one (handles rebinding to
-          // a different mailbox).
-          await removeConnectionMappings(env.EMAIL_MAP, connectionId);
-          await setEmailMapping(
-            env.EMAIL_MAP,
-            profile.emailAddress,
-            connectionId,
-          );
-          console.log(
-            `[Gmail onChange] Mapped ${profile.emailAddress} → ${connectionId}`,
-          );
-
-          // Claim the refresh_token stashed at exchangeCode time and
-          // re-key it under the connectionId so webhook/cron contexts
-          // can pick it up.
-          const refreshToken = await claimPendingRefreshToken(
-            env.EMAIL_MAP,
-            accessToken,
-          );
-          if (refreshToken) {
-            await setRefreshTokenForConnection(
-              env.EMAIL_MAP,
-              connectionId,
-              refreshToken,
-            );
-            console.log(
-              `[Gmail onChange] Persisted refresh_token for connection=${connectionId}`,
-            );
-          } else {
-            console.warn(
-              `[Gmail onChange] No pending refresh_token for connection=${connectionId} — webhook delivery will fail until the user reauthenticates`,
-            );
-          }
-
-          const pubsubTopic = process.env.GMAIL_PUBSUB_TOPIC || "";
-          if (!pubsubTopic) {
-            console.warn(
-              "[Gmail onChange] GMAIL_PUBSUB_TOPIC not set — skipping users.watch (no webhook delivery)",
-            );
-            return;
-          }
-
-          const watchRes = await fetch(ENDPOINTS.WATCH, {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              topicName: pubsubTopic,
-              labelIds: ["INBOX"],
-            }),
-          });
-
-          if (watchRes.ok) {
-            const watchData = (await watchRes.json()) as {
-              historyId: string;
-              expiration: string;
-            };
-            // Anchor the historyId so the first webhook delivery has a
-            // valid startHistoryId to diff against.
-            await setLastHistoryId(
-              env.EMAIL_MAP,
-              connectionId,
-              watchData.historyId,
-            );
-            console.log(
-              `[Gmail onChange] Watch registered for ${profile.emailAddress}, expires ${watchData.expiration}`,
-            );
-          } else {
-            const error = await watchRes.text();
-            console.error(
-              `[Gmail onChange] users.watch failed: ${watchRes.status} - ${error}`,
-            );
-          }
-        } catch (error) {
-          console.error("[Gmail onChange] Error:", error);
-        }
+        await ensureGmailSetup(env, accessToken, connectionId);
       },
     },
     tools,

--- a/google-gmail/server/tools/drafts.ts
+++ b/google-gmail/server/tools/drafts.ts
@@ -7,7 +7,7 @@
 import { createPrivateTool } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../types/env.ts";
-import { GmailClient, getAccessToken } from "../lib/gmail-client.ts";
+import { GmailClient, getAccessTokenWithSetup } from "../lib/gmail-client.ts";
 
 // ============================================================================
 // Schema Definitions
@@ -59,7 +59,7 @@ export const createListDraftsTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       const result = await client.listDrafts({
@@ -95,7 +95,7 @@ export const createGetDraftTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       const draft = await client.getDraft(context.id, "full");
@@ -141,7 +141,7 @@ export const createCreateDraftTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       const draft = await client.createDraft({
@@ -190,7 +190,7 @@ export const createUpdateDraftTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       const draft = await client.updateDraft(context.id, {
@@ -233,7 +233,7 @@ export const createSendDraftTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       const result = await client.sendDraft(context.id);
@@ -264,7 +264,7 @@ export const createDeleteDraftTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       await client.deleteDraft(context.id);

--- a/google-gmail/server/tools/labels.ts
+++ b/google-gmail/server/tools/labels.ts
@@ -7,7 +7,7 @@
 import { createPrivateTool } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../types/env.ts";
-import { GmailClient, getAccessToken } from "../lib/gmail-client.ts";
+import { GmailClient, getAccessTokenWithSetup } from "../lib/gmail-client.ts";
 
 // ============================================================================
 // Schema Definitions
@@ -56,7 +56,7 @@ export const createListLabelsTool = (env: Env) =>
     }),
     execute: async ({ context: _context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       const labels = await client.listLabels();
@@ -89,7 +89,7 @@ export const createGetLabelTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       const label = await client.getLabel(context.id);
@@ -132,7 +132,7 @@ export const createCreateLabelTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       // Gmail API requires BOTH textColor and backgroundColor when setting colors
@@ -187,7 +187,7 @@ export const createUpdateLabelTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       // Gmail API requires BOTH textColor and backgroundColor when setting colors
@@ -232,7 +232,7 @@ export const createDeleteLabelTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       await client.deleteLabel(context.id);

--- a/google-gmail/server/tools/messages.ts
+++ b/google-gmail/server/tools/messages.ts
@@ -7,7 +7,7 @@
 import { createPrivateTool } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../types/env.ts";
-import { GmailClient, getAccessToken } from "../lib/gmail-client.ts";
+import { GmailClient, getAccessTokenWithSetup } from "../lib/gmail-client.ts";
 
 // ============================================================================
 // Schema Definitions
@@ -95,7 +95,7 @@ export const createListMessagesTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       const result = await client.listMessages({
@@ -159,7 +159,7 @@ export const createGetMessageTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       const rawMessage = await client.getMessage({
@@ -216,7 +216,7 @@ export const createSendMessageTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       const result = await client.sendMessage({
@@ -284,7 +284,7 @@ Search Examples:
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       // First, list message IDs matching the query
@@ -328,7 +328,7 @@ export const createTrashMessageTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       await client.trashMessage(context.id);
@@ -357,7 +357,7 @@ export const createUntrashMessageTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       await client.untrashMessage(context.id);
@@ -387,7 +387,7 @@ export const createDeleteMessageTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       await client.deleteMessage(context.id);
@@ -434,7 +434,7 @@ export const createModifyMessageTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       const result = await client.modifyMessage({
@@ -492,7 +492,7 @@ Supports up to 1000 email IDs per call.`,
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       await client.batchModifyMessages({

--- a/google-gmail/server/tools/threads.ts
+++ b/google-gmail/server/tools/threads.ts
@@ -7,7 +7,7 @@
 import { createPrivateTool } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../types/env.ts";
-import { GmailClient, getAccessToken } from "../lib/gmail-client.ts";
+import { GmailClient, getAccessTokenWithSetup } from "../lib/gmail-client.ts";
 
 // ============================================================================
 // Schema Definitions
@@ -82,7 +82,7 @@ export const createListThreadsTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       const result = await client.listThreads({
@@ -121,7 +121,7 @@ export const createGetThreadTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       const thread = await client.getThread({
@@ -174,7 +174,7 @@ export const createTrashThreadTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       await client.trashThread(context.id);
@@ -204,7 +204,7 @@ export const createUntrashThreadTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       await client.untrashThread(context.id);
@@ -244,7 +244,7 @@ export const createModifyThreadTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       await client.modifyThread({
@@ -278,7 +278,7 @@ export const createDeleteThreadTool = (env: Env) =>
     }),
     execute: async ({ context }) => {
       const client = new GmailClient({
-        accessToken: getAccessToken(env),
+        accessToken: await getAccessTokenWithSetup(env),
       });
 
       await client.deleteThread(context.id);


### PR DESCRIPTION
## Summary

Follow-up to #393. The trigger appeared to "succeed" (mesh wrote `triggers:<connId>` to KV) but no emails ever fired the workflow. Diagnosed via KV inspection — the connection was missing `email:`, `conn:`, `refresh:`, and `history:` keys, meaning `configuration.onChange` never ran.

## Root cause

Mesh only invokes `ON_MCP_CONFIGURATION` (which fires our `onChange`) when the user saves integration state. Gmail MCP's `StateSchema` is `z.object({})` — no fields to save — so a flow of *authenticate → create workflow → enable trigger* never goes through that handler. `TRIGGER_CONFIGURE` does fire (separate runtime tool), which is why `triggers:<connId>` was present, but the watch-setup logic was solely behind `onChange`.

Result: no `users.watch` registered with Google → Pub/Sub never publishes → trigger silently dead.

## Fix

Mirrors github MCP's `ensureInstallationMappings` pattern:

- Extract the watch-setup logic into `ensureGmailSetup(env, accessToken, connectionId)` in `server/lib/setup.ts`. Idempotent — fast path is one KV read once setup is complete.
- Add `getAccessTokenWithSetup(env)` that pulls the bearer + connectionId from `MESH_REQUEST_CONTEXT`, runs `ensureGmailSetup`, and returns the token. Tools migrate from `getAccessToken(env)` to `await getAccessTokenWithSetup(env)`.
- `onChange` now just calls `ensureGmailSetup` too, so configuration saves still eagerly bootstrap.

Net effect: any authenticated tool call (`gmail_list_messages`, etc.) now lazily registers the watch on first use.

## Recovery for existing broken connections

Users with the bad state from before this fix can recover by running **any** Gmail tool (e.g. ask the agent to list messages). The `pending_refresh:<hash>` KV entry has a 1h TTL, so users who authenticated within the last hour and haven't taken any action since will recover automatically. Beyond 1h: re-authenticate.

## Test plan

- [x] `bun run check` clean
- [x] `bun run build` (wrangler dry-run) succeeds
- [x] `oxfmt --check` clean
- [ ] Smoke: connect MCP, configure trigger, run any tool once → KV should populate `email:`, `conn:`, `refresh:`, `history:` for that connection
- [ ] Send email → workflow fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing Gmail webhook setup by running a lazy, idempotent per-connection setup on every authenticated tool call. Ensures `users.watch` is registered and triggers fire even when `configuration.onChange` never runs.

- **Bug Fixes**
  - Added `ensureGmailSetup(env, accessToken, connectionId)` to handle profile fetch, email↔connection mapping, refresh token claim, `users.watch`, and `historyId` anchoring (idempotent with a KV fast path).
  - Introduced `getAccessTokenWithSetup`, used by all tools, to run setup before API calls; `onChange` now delegates to the same setup.
  - Existing broken connections self-heal on first tool use; if the pending refresh TTL (1h) expired, the user must re-authenticate.

- **Refactors**
  - Extracted setup logic to `server/lib/setup.ts` and re-exported from `gmail-client`.
  - Replaced `getAccessToken` with `getAccessTokenWithSetup` across drafts, labels, messages, and threads tools.
  - Simplified `main.ts` by removing inline setup code and calling `ensureGmailSetup` instead.

<sup>Written for commit f8962660076ba40e7deec44b91a32c6113d7495d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

