### PR TITLE
ci: diff against PR merge base, not current main tip

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,7 +36,7 @@ jobs:
             BASE="${{ github.event.before }}"
           fi
 
-          CHANGED=$(git diff --name-only "$BASE" HEAD | cut -d'/' -f1 | sort -u | tr '\n' ' ')
+          CHANGED=$(git diff --name-only "$BASE"...HEAD | cut -d'/' -f1 | sort -u | tr '\n' ' ')
           echo "mcps=$CHANGED" >> "$GITHUB_OUTPUT"
           echo "Changed folders: $CHANGED"
 


### PR DESCRIPTION
## Summary

The changed-MCPs detection in `checks.yml` used `git diff "$BASE" HEAD`, which compares the current tip of `main` against `HEAD`. So whenever `main` had moved ahead since the PR forked, every path touched on `main` showed up as "changed" too — and the `Run type check` / `Run tests` steps ran for MCPs that weren't actually modified by the PR.

Switching to `"$BASE"...HEAD` (three-dot) uses the merge base, restricting the list to what the PR actually changed.

Real example, this branch's parent PR (#403) on the previous CI run:

- two-dot (old): `.github bun.lock deploy.json discord discord-read dropbox github google-gmail package.json vtex`
- three-dot (new): `.github hyperdx scripts`

## Test plan

- [x] Verified locally that `git diff --name-only origin/main...HEAD` returns only the paths this PR touches
- [ ] CI on this PR runs only against `.github` (no MCP test/check runs, since no MCP source changed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI changed-MCP detection by diffing against the PR merge base (`git diff "$BASE"...HEAD`) instead of the current `main` tip. This prevents unrelated MCP jobs from running when `main` moves and runs checks only for paths changed by the PR.

<sup>Written for commit be1fe7ffaaecd43ee3757ea3b68b296d85545112. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

