### PR TITLE
fix(google-workspace): request minimal effective OAuth scopes (10 not 26)

### DIFF
--- a/google-workspace/server/constants.ts
+++ b/google-workspace/server/constants.ts
@@ -47,9 +47,38 @@ export interface BackendSnapshot {
 }
 
 /**
- * Union of every scope advertised by every backend's PRM.
- * Sent to Google's authorization endpoint at consent time.
+ * Curated minimal set of OAuth scopes sent to Google's authorization endpoint.
+ *
+ * Each backend's PRM advertises every scope it accepts (e.g. Calendar lists 9
+ * variants like `calendar`, `calendar.readonly`, `calendar.events.owned`...).
+ * Google's scope hierarchy means the broadest scope per service implicitly
+ * grants the narrower ones — so we ask for only the broadest sensible scope
+ * each service actually needs to power its tool catalog. This:
+ *
+ *  - keeps the consent screen short (10 scopes vs 26)
+ *  - reduces the chance of "scope not configured in OAuth client" silent drops
+ *  - matches the principle of least privilege at consent time
+ *
+ * If Google adds a tool requiring a scope not listed here, extend the array
+ * for the relevant service. Re-running `generate-tools` does NOT touch this
+ * list — it's hand-curated against the tool catalog.
  */
-export const GOOGLE_WORKSPACE_SCOPES: string[] = Array.from(
-  new Set(Object.values(TOOL_SNAPSHOTS).flatMap((snap) => snap.scopes)),
-).sort();
+export const GOOGLE_WORKSPACE_SCOPES: string[] = [
+  // Calendar — full read/write covers all .readonly/.events.* sub-scopes.
+  "https://www.googleapis.com/auth/calendar",
+  // Chat — three orthogonal scopes. The .readonly variants are subsets.
+  "https://www.googleapis.com/auth/chat.spaces",
+  "https://www.googleapis.com/auth/chat.messages",
+  "https://www.googleapis.com/auth/chat.memberships",
+  // Drive — full access covers drive.readonly and drive.file.
+  "https://www.googleapis.com/auth/drive",
+  // Gmail — modify covers read+label, compose covers drafts. Together they
+  // satisfy every gmail_* tool we proxy. (mail.google.com/ is broader still
+  // but is a "restricted" scope requiring extra Google verification.)
+  "https://www.googleapis.com/auth/gmail.modify",
+  "https://www.googleapis.com/auth/gmail.compose",
+  // People — three orthogonal scopes for directory, contacts, self profile.
+  "https://www.googleapis.com/auth/contacts.readonly",
+  "https://www.googleapis.com/auth/directory.readonly",
+  "https://www.googleapis.com/auth/userinfo.profile",
+];


### PR DESCRIPTION
## Symptom

Live testing returned "The caller does not have permission" on Calendar / Gmail / Drive / People, while Chat worked partially ("Requested entity was not found" — meaning the API authorized the call but found no data).

## Root cause

The previous version asked for the **union** of every scope in each backend's PRM `scopes_supported` — 26 scopes total. Google's OAuth flow silently drops any requested scope that isn't pre-declared on the OAuth client's consent screen, so users were getting tokens covering only the subset that happened to be configured (chat-* in this case).

## Fix

Replace the auto-union with a hand-curated minimal-effective set. Google's scope hierarchy means the broadest scope per service implicitly grants the narrower ones, so this still satisfies every tool we proxy:

| Service | Scopes (10 total) |
|---|---|
| Calendar | `calendar` — covers all `.readonly` / `.events.*` variants |
| Chat | `chat.spaces`, `chat.messages`, `chat.memberships` (orthogonal) |
| Drive | `drive` — covers `.readonly` / `.file` |
| Gmail | `gmail.modify` + `gmail.compose` — read + label + drafts; avoids the restricted `mail.google.com/` |
| People | `contacts.readonly`, `directory.readonly`, `userinfo.profile` |

## Side benefits

- Shorter consent screen (10 vs 26 scopes) → lower friction for users
- Avoids `mail.google.com/`, which is "restricted" by Google and triggers their verification process
- Clear least-privilege story

## Still required (operational)

The OAuth client in Google Cloud Console must have these 10 scopes added to the consent screen. If any are missing, Google still drops them silently and the same symptom returns. To diagnose:

```bash
curl "https://oauth2.googleapis.com/tokeninfo?access_token=<TOKEN>" | jq .scope
```

The returned `scope` string is exactly what the user's token has. If it's missing entries from the list above, the consent screen needs those scopes added.

## Test plan

- [x] `bun scripts/check.ts google-workspace` — passes
- [ ] After deploy: re-authenticate with a test user and verify tokeninfo shows all 10 scopes
- [ ] Smoke test one tool per service:
  - `calendar_list_events { calendarId: "primary" }`
  - `gmail_search_threads { query: "is:unread newer_than:1d" }`
  - `drive_list_recent_files {}`
  - `chat_search_conversations { displayName: "..." }`
  - `people_get_user_profile {}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Request a minimal set of 10 Google Workspace OAuth scopes instead of the prior 26-scope union. This fixes “The caller does not have permission” errors and shortens the consent screen.

- **Bug Fixes**
  - Replace auto-union of PRM scopes with a curated set of broad scopes per service to avoid Google silently dropping undeclared scopes.
  - Coverage: Calendar, Drive (full); Gmail (modify + compose); Chat (spaces, messages, memberships); People (contacts.readonly, directory.readonly, userinfo.profile).
  - Avoids the restricted `mail.google.com/` scope.

- **Migration**
  - Add these 10 scopes to the OAuth consent screen in Google Cloud Console, then re-authenticate users.
  - Verify the new token includes all scopes via Google’s tokeninfo endpoint.

<sup>Written for commit 1a597b886667cb547c60d9b941f8e2e443024b7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

