### PR TITLE
fix(vtex): surface real cause of "typo in url or port" errors

### DIFF
--- a/vtex/server/lib/client-factory.ts
+++ b/vtex/server/lib/client-factory.ts
@@ -4,18 +4,76 @@ import type { VTEXCredentials } from "../types/env.ts";
 
 const REQUEST_TIMEOUT_MS = 30_000;
 
-export function resolveCredentials(
-  state: Partial<VTEXCredentials>,
-): VTEXCredentials {
-  return {
-    accountName: state.accountName || process.env.VTEX_ACCOUNT_NAME || "",
-    appKey: state.appKey || process.env.VTEX_APP_KEY || "",
-    appToken: state.appToken || process.env.VTEX_APP_TOKEN || "",
+export interface ResolvedCredentials extends VTEXCredentials {
+  /** Where each credential value came from — useful for diagnosing missing config. */
+  sources: {
+    accountName: "state" | "env" | "missing";
+    appKey: "state" | "env" | "missing";
+    appToken: "state" | "env" | "missing";
   };
+}
+
+function pickSource(
+  fromState: string | undefined,
+  fromEnv: string | undefined,
+): { value: string; source: "state" | "env" | "missing" } {
+  if (fromState) return { value: fromState, source: "state" };
+  if (fromEnv) return { value: fromEnv, source: "env" };
+  return { value: "", source: "missing" };
+}
+
+export function resolveCredentials(
+  state: Partial<VTEXCredentials> | undefined,
+): ResolvedCredentials {
+  const safeState = state ?? {};
+  const account = pickSource(
+    safeState.accountName,
+    process.env.VTEX_ACCOUNT_NAME,
+  );
+  const key = pickSource(safeState.appKey, process.env.VTEX_APP_KEY);
+  const token = pickSource(safeState.appToken, process.env.VTEX_APP_TOKEN);
+
+  if (account.source === "missing") {
+    const stateKeys = state ? Object.keys(state) : [];
+    console.warn(
+      "[VTEX] resolveCredentials: accountName is missing — neither MESH_REQUEST_CONTEXT.state.accountName nor process.env.VTEX_ACCOUNT_NAME is set.",
+      JSON.stringify({
+        receivedStateType: state === undefined ? "undefined" : typeof state,
+        receivedStateKeys: stateKeys,
+        receivedStateAccountName: safeState.accountName ?? null,
+        envVtexAccountNameSet: Boolean(process.env.VTEX_ACCOUNT_NAME),
+      }),
+    );
+  }
+
+  return {
+    accountName: account.value,
+    appKey: key.value || undefined,
+    appToken: token.value || undefined,
+    sources: {
+      accountName: account.source,
+      appKey: key.source,
+      appToken: token.source,
+    },
+  };
+}
+
+export function assertValidCredentials(
+  creds: ResolvedCredentials,
+  toolId?: string,
+): void {
+  if (!creds.accountName) {
+    const where = toolId ? ` (tool=${toolId})` : "";
+    throw new Error(
+      `VTEX accountName is missing${where} — set MESH_REQUEST_CONTEXT.state.accountName or VTEX_ACCOUNT_NAME env var. Without it the request URL would be "https://.vtexcommercestable.com.br" and the runtime would reject it with "Was there a typo in the url or port?".`,
+    );
+  }
 }
 
 function buildClient(baseUrl: string, credentials: VTEXCredentials): Client {
   const client = createClient(createConfig({ baseUrl }));
+
+  console.log("[VTEX] buildClient: baseUrl=", baseUrl);
 
   client.interceptors.request.use((request) => {
     if (credentials.appKey) {

--- a/vtex/server/lib/tool-adapter.ts
+++ b/vtex/server/lib/tool-adapter.ts
@@ -5,7 +5,11 @@ import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { Env } from "../types/env.ts";
 import type { VTEXCredentials } from "../types/env.ts";
-import { createVtexClient, resolveCredentials } from "./client-factory.ts";
+import {
+  assertValidCredentials,
+  createVtexClient,
+  resolveCredentials,
+} from "./client-factory.ts";
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Schema introspection helpers
@@ -294,7 +298,23 @@ export function createToolFromOperation(config: ToolFromOperationConfig) {
       annotations: config.annotations,
       inputSchema: flatInput,
       execute: async ({ context }) => {
-        const creds = resolveCredentials(env.MESH_REQUEST_CONTEXT.state);
+        const meshCtx = env.MESH_REQUEST_CONTEXT;
+        console.log(
+          `[VTEX] tool=${config.id} mesh-context-shape:`,
+          JSON.stringify({
+            hasMeshContext: Boolean(meshCtx),
+            hasToken: Boolean(meshCtx?.token),
+            hasConnectionId: Boolean(meshCtx?.connectionId),
+            hasMeshUrl: Boolean(meshCtx?.meshUrl),
+            stateKeys: meshCtx?.state ? Object.keys(meshCtx.state) : [],
+            stateAccountNamePresent: Boolean(
+              (meshCtx?.state as { accountName?: unknown } | undefined)
+                ?.accountName,
+            ),
+          }),
+        );
+        const creds = resolveCredentials(meshCtx?.state);
+        assertValidCredentials(creds, config.id);
         const factory = config.clientFactory ?? createVtexClient;
         const client = factory(creds);
         const structured = unflattenToStructured(
@@ -306,13 +326,20 @@ export function createToolFromOperation(config: ToolFromOperationConfig) {
         );
         if (result.error) {
           const err = result.error;
-          const message =
+          const baseMessage =
             err instanceof Error
               ? err.message
               : typeof err === "string"
                 ? err
                 : JSON.stringify(err);
-          throw new Error(message);
+          const ctx = [
+            `tool=${config.id}`,
+            `account=${creds.accountName || "<empty>"}`,
+            `accountSource=${creds.sources.accountName}`,
+            `appKeySource=${creds.sources.appKey}`,
+            `appTokenSource=${creds.sources.appToken}`,
+          ].join(" ");
+          throw new Error(`${baseMessage} [${ctx}]`);
         }
         const data = Array.isArray(result.data)
           ? { items: result.data }

--- a/vtex/server/tools/custom/reorder-collection.ts
+++ b/vtex/server/tools/custom/reorder-collection.ts
@@ -1,6 +1,9 @@
 import { createTool } from "@decocms/runtime/tools";
 import { z } from "zod";
-import { resolveCredentials } from "../../lib/client-factory.ts";
+import {
+  assertValidCredentials,
+  resolveCredentials,
+} from "../../lib/client-factory.ts";
 import type { Env } from "../../types/env.ts";
 
 /**
@@ -273,7 +276,8 @@ export const reorderCollection = (env: Env) =>
     outputSchema: reorderCollectionOutputSchema,
     execute: async ({ context }) => {
       const reorderPromise = (async () => {
-        const credentials = resolveCredentials(env.MESH_REQUEST_CONTEXT.state);
+        const credentials = resolveCredentials(env.MESH_REQUEST_CONTEXT?.state);
+        assertValidCredentials(credentials, "VTEX_REORDER_COLLECTION");
         const directSkuIds = context.skuIds ?? [];
         const productIds = context.productIds ?? [];
 

--- a/vtex/server/tools/custom/update-product-specifications.ts
+++ b/vtex/server/tools/custom/update-product-specifications.ts
@@ -1,6 +1,9 @@
 import { createTool } from "@decocms/runtime/tools";
 import { z } from "zod";
-import { resolveCredentials } from "../../lib/client-factory.ts";
+import {
+  assertValidCredentials,
+  resolveCredentials,
+} from "../../lib/client-factory.ts";
 import type { Env } from "../../types/env.ts";
 
 const inputSchema = z.object({
@@ -44,7 +47,8 @@ export const updateProductSpecifications = (env: Env) =>
     inputSchema,
     outputSchema,
     execute: async ({ context }) => {
-      const credentials = resolveCredentials(env.MESH_REQUEST_CONTEXT.state);
+      const credentials = resolveCredentials(env.MESH_REQUEST_CONTEXT?.state);
+      assertValidCredentials(credentials, "VTEX_UPDATE_PRODUCT_SPECIFICATIONS");
       const url = `https://${credentials.accountName}.vtexcommercestable.com.br/api/catalog_system/pvt/products/${context.productId}/specification`;
       console.log("[VTEX] POST", url);
 


### PR DESCRIPTION
## Summary

- When `state.accountName` arrived empty, the URL became `https://.vtexcommercestable.com.br` and Bun rejected it with the cryptic `"Was there a typo in the url or port?"` — across many tools.
- Adds a fail-fast `assertValidCredentials` check that throws a descriptive error naming the missing field, used in the generated-tool adapter and both custom tools (`reorder-collection`, `update-product-specifications`).
- Enriches SDK errors with credential-source context (`[tool=… account=… accountSource=state|env|missing …]`) and logs the resolved baseUrl + mesh-context shape on every tool call so the inconsistent state-propagation path can be diagnosed in production.

## Test plan

- [x] `bun run check` (vtex) — passes
- [x] `bun test` (vtex) — 77 pass, 0 fail
- [x] Reproduced locally: calling a tool without `VTEX_ACCOUNT_NAME` now returns the descriptive fail-fast error instead of the Bun "typo in url or port" message
- [x] Verified through deco.host UI tunnel: when `state` is properly injected, `[VTEX] tool=… mesh-context-shape: {hasToken:true, stateAccountNamePresent:true, …}` is logged and the call succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail-fast validation for VTEX tools to prevent invalid base URLs and replace Bun’s “Was there a typo in the url or port?” with a clear error when `accountName` is missing. Adds source-aware error context and lightweight logging to make config issues easy to diagnose.

- **Bug Fixes**
  - Added `assertValidCredentials` in the tool adapter and custom tools to throw a clear error when `accountName` is missing (avoids `https://.vtexcommercestable.com.br`).
  - Updated `resolveCredentials` to pull from `state` or env and return per-field `sources`; warns when `accountName` is missing.
  - Enriched thrown errors with `[tool=… account=… accountSource=…]` context.
  - Logged baseUrl creation and mesh-context shape on each call to trace state propagation.

<sup>Written for commit 2052d4e14cbf81184ede00e90b64ac9ca583ad6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

