### PR TITLE
chore(vtex): bump @decocms/runtime to ^1.6.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1007,7 +1007,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@decocms/bindings": "^1.4.0",
-        "@decocms/runtime": "^1.6.0",
+        "@decocms/runtime": "^1.6.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "zod": "^4.0.0",
       },
@@ -4285,7 +4285,7 @@
 
     "vtex/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
-    "vtex/@decocms/runtime": ["@decocms/runtime@1.6.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-iVRp3yUvPd5x1nQ+WbsTOHA3KKBRMq6kGnJLoV1oyjIFm1uyxK69IihnYp1B49sQxlWAfPAJco3AZ8TuvF3T6A=="],
+    "vtex/@decocms/runtime": ["@decocms/runtime@1.6.1", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-JY0n3fjuKe6S+uwohrNn32DcSu2WQTgrrGkZCbsLqubOb6/XIy5Gcsw8CGv3sw9fIPc+OBlWfvLorZ8PJu9DbQ=="],
 
     "vtex/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 

--- a/vtex/package.json
+++ b/vtex/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@decocms/bindings": "^1.4.0",
-    "@decocms/runtime": "^1.6.0",
+    "@decocms/runtime": "^1.6.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "zod": "^4.0.0"
   },


### PR DESCRIPTION
## Summary
Picks up the cached \`tools/list\` payload from decocms/studio#3299. After deploy, warm \`tools/list\` should drop from ~5s to ms-scale for vtex's 708-tool surface (first request still pays the cache-miss cost).

## Test plan
- [x] \`bun run check\` clean
- [x] \`bunx wrangler deploy --dry-run\` clean (5.8MB / 905KB gzip, unchanged)
- [ ] After merge: hit \`https://vtex-mcp.decocms.com/mcp\` with \`tools/list\` repeatedly and confirm the 2nd+ requests are fast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@decocms/runtime` to ^1.6.1 to enable cached `tools/list` responses, reducing warm latency from ~5s to milliseconds across VTEX’s 708-tool surface. First request remains a cache miss; subsequent requests are fast.

- **Dependencies**
  - Updated `@decocms/runtime` to `^1.6.1` in `vtex/package.json` and `bun.lock`.

<sup>Written for commit 707556e82d08be3676f38a713c320abf3cbebc63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

