### PR TITLE
chore(vtex): bump @decocms/runtime to ^1.6.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1007,7 +1007,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@decocms/bindings": "^1.4.0",
-        "@decocms/runtime": "^1.6.1",
+        "@decocms/runtime": "^1.6.2",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "zod": "^4.0.0",
       },
@@ -4285,7 +4285,7 @@
 
     "vtex/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
-    "vtex/@decocms/runtime": ["@decocms/runtime@1.6.1", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-JY0n3fjuKe6S+uwohrNn32DcSu2WQTgrrGkZCbsLqubOb6/XIy5Gcsw8CGv3sw9fIPc+OBlWfvLorZ8PJu9DbQ=="],
+    "vtex/@decocms/runtime": ["@decocms/runtime@1.6.2", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-Z38pLHDoJOfiZVOfQgnfyK24vVV/m8MOm8dXB0dvkIM6yp31JNmW88t3d5hw6P5FYr9TvpvKxQE9uWEeCeN8QQ=="],
 
     "vtex/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 

--- a/vtex/package.json
+++ b/vtex/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@decocms/bindings": "^1.4.0",
-    "@decocms/runtime": "^1.6.1",
+    "@decocms/runtime": "^1.6.2",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "zod": "^4.0.0"
   },


### PR DESCRIPTION
## Summary
Picks up the actual cache fix from decocms/studio#3300. The 1.6.1 patch's lookup key (\`ListToolsRequestSchema.shape.method.value\`) was \`undefined\` under zod 4, so the cache wrapper never installed. 1.6.2 hardcodes the MCP method name \`"tools/list"\`, which should finally drop warm \`tools/list\` latency from ~5s to ms-scale.

## Test plan
- [x] \`bun run check\` clean
- [x] \`bunx wrangler deploy --dry-run\` clean
- [ ] After merge: curl \`tools/list\` 5x in a row and confirm runs 2-5 are <500ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@decocms/runtime` to ^1.6.2 to pick up the `tools/list` caching fix that failed under `zod` 4. This restores the cache wrapper and should drop warm `tools/list` latency from ~5s to milliseconds.

<sup>Written for commit 8011caea95d0d4e6a6aa6f7510a9759cae1ceb7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

