### PR TITLE
debug(vtex): probe isolate reuse + per-request timing

### DIFF
--- a/vtex/server/main.ts
+++ b/vtex/server/main.ts
@@ -19,6 +19,33 @@ const runtime = withRuntime<Env, typeof StateSchema>({
   tools,
 });
 
+// DEBUG PROBE — temporary. If `requestCount` increments across requests, the
+// isolate is being reused and module-scope caches in @decocms/runtime should
+// stick. If it always reads `1`, Workers is spawning a fresh isolate per
+// request and the runtime's tools/list cache can never hit. Logs are printed
+// before and after the runtime fetch, with timing.
+const isolateBootedAt = Date.now();
+let requestCount = 0;
+
 export default {
-  fetch: runtime.fetch,
+  fetch: async (req: Request, env: Env, ctx: ExecutionContext) => {
+    const myReq = ++requestCount;
+    const t0 = Date.now();
+    console.log(
+      `[vtex-probe] req#${myReq} isolateAge=${t0 - isolateBootedAt}ms url=${new URL(req.url).pathname}`,
+    );
+    try {
+      const res = await runtime.fetch(req, env, ctx);
+      console.log(
+        `[vtex-probe] req#${myReq} done status=${res.status} ms=${Date.now() - t0}`,
+      );
+      return res;
+    } catch (err) {
+      console.log(
+        `[vtex-probe] req#${myReq} threw after ${Date.now() - t0}ms`,
+        err,
+      );
+      throw err;
+    }
+  },
 };


### PR DESCRIPTION
## Summary
Diagnostic — not for keeps. Wrap \`runtime.fetch\` in vtex's main.ts with a request counter and isolate-age log so we can see in \`wrangler tail\` whether Workers is reusing isolates across requests at GRU.

The runtime cache fix (decocms/studio#3300, vtex#427) is deployed but \`tools/list\` is still 4-7s on every call. Either:
- The cache wrapper isn't installing (we'd see no \`[runtime]\` logs from the wrapper)
- The cache installs but the closure resets per request (Workers spawning fresh isolates → \`req#1\` repeats)
- Something else dominates per-request CPU

This probe answers question 2.

## Test plan
- Merge → deploy
- Hit \`tools/list\` 5x in a row, check \`wrangler tail\` for \`[vtex-probe]\` lines
- If counter resets to 1 every call → isolate not reused → revisit caching strategy
- If counter increments → cache should be hitting; runtime needs further investigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a temporary debug probe that wraps `runtime.fetch` in `vtex/server/main.ts` to log a per-request counter, isolate age, and request timing. This helps confirm Workers isolate reuse and diagnose why `tools/list` stays slow despite the cache fix.

<sup>Written for commit 804a736aeba1e434f6b156672ed39dd4d9ef0b77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

