### PR TITLE
fix(vtex): bump @decocms/runtime to ^1.6.2 to restore state propagation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1006,8 +1006,9 @@
       "name": "vtex",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/bindings": "^1.3.1",
-        "@decocms/runtime": "1.3.1",
+        "@decocms/bindings": "^1.4.0",
+        "@decocms/runtime": "^1.6.2",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -1015,7 +1016,6 @@
         "@decocms/mcps-shared": "1.0.0",
         "@hey-api/client-fetch": "^0.8.0",
         "@hey-api/openapi-ts": "0.92.4",
-        "@modelcontextprotocol/sdk": "1.20.2",
         "@types/bun": "^1.2.14",
         "deco-cli": "^0.28.0",
         "typescript": "^5.7.2",
@@ -4365,7 +4365,9 @@
 
     "vtex/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
-    "vtex/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.20.2", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-6rqTdFt67AAAzln3NOKsXRmv5ZzPkgbfaebKBqUbts7vK1GZudqnrun5a8d3M/h955cam9RHZ6Jb4Y1XhnmFPg=="],
+    "vtex/@decocms/runtime": ["@decocms/runtime@1.6.2", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-Z38pLHDoJOfiZVOfQgnfyK24vVV/m8MOm8dXB0dvkIM6yp31JNmW88t3d5hw6P5FYr9TvpvKxQE9uWEeCeN8QQ=="],
+
+    "vtex/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
     "vtex/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -4915,11 +4917,7 @@
 
     "vtex-docs/ai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "vtex/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
-
-    "vtex/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
-
-    "vtex/@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "vtex/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
     "whatsapp-management/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
@@ -5490,10 +5488,6 @@
     "vtex-docs/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "vtex-docs/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "vtex/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
-
-    "vtex/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "whatsapp-management/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 

--- a/vtex/package.json
+++ b/vtex/package.json
@@ -18,8 +18,9 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@decocms/bindings": "^1.3.1",
-    "@decocms/runtime": "1.3.1",
+    "@decocms/bindings": "^1.4.0",
+    "@decocms/runtime": "^1.6.2",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "zod": "^4.0.0"
   },
   "devDependencies": {
@@ -27,7 +28,6 @@
     "@decocms/mcps-shared": "1.0.0",
     "@hey-api/client-fetch": "^0.8.0",
     "@hey-api/openapi-ts": "0.92.4",
-    "@modelcontextprotocol/sdk": "1.20.2",
     "@types/bun": "^1.2.14",
     "deco-cli": "^0.28.0",
     "typescript": "^5.7.2"


### PR DESCRIPTION
## Summary
- Bumps `@decocms/runtime` `1.3.1` → `^1.6.2`, `@decocms/bindings` `^1.3.1` → `^1.4.0`, and `@modelcontextprotocol/sdk` `1.20.2` → `^1.27.1` (now in `dependencies`, where 1.6.x expects it).
- Keeps the kubernetes-bun deploy, the `serve()` entrypoint, and the rest of the dev tooling untouched — this is purely a runtime version bump.

## Why
Every VTEX tool call has been failing since the rollback in #429 with:
> `VTEX accountName is missing (tool=…) — set MESH_REQUEST_CONTEXT.state.accountName or VTEX_ACCOUNT_NAME env var.`

The diagnostic logging added in #423 lets us see exactly what the deployed pod sees:
```
hasMeshContext: true, hasToken: true, hasConnectionId: true, hasMeshUrl: true,
stateKeys: [], stateAccountNamePresent: false
```
The MESH_REQUEST_CONTEXT envelope is reaching the pod fully populated, but `state` arrives as `{}`. The connection's saved `configSchema` values aren't being hydrated into `state` for the tool to read.

Vtex was on `^1.6.2` immediately before #429, where state propagation worked. The rollback dropped it three minor versions back to 1.3.1, which evidently doesn't speak the current mesh's state shape. The latency that motivated the rollback (`~5s/call tools/list`) was Cloudflare Workers' startup-CPU budget being blown by the 708-tool surface — that's not a problem on Bun, so we should be able to safely take the runtime upgrade without re-introducing it.

## Test plan
- [x] `bun run check` — clean
- [x] `bun test` — 77 pass, 0 fail (mock state propagates correctly through the tool adapter)
- [x] `bun run build` — bundles successfully (4.57 MB, 1268 modules)
- [ ] After deploy, confirm pod logs show `stateKeys: ["accountName","appKey","appToken"]` and a successful `VTEX_GET_COLLECTION_PRODUCTS` call.
- [ ] Watch warm `tools/list` latency — should stay sub-second on Bun even with the 1.6.2 cache wrapper.

If state arrives correctly after this deploy, follow-up PR can strip the diagnostic logs added in #423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores VTEX tool state propagation by upgrading `@decocms/runtime` to ^1.6.2, fixing the missing `accountName` error caused by 1.3.1. No changes to the deploy setup or entrypoint.

- **Bug Fixes**
  - `state` is hydrated from `MESH_REQUEST_CONTEXT` again, so VTEX tools can read `accountName` and execute.

- **Dependencies**
  - `@decocms/runtime`: 1.3.1 → ^1.6.2
  - `@decocms/bindings`: ^1.3.1 → ^1.4.0
  - `@modelcontextprotocol/sdk`: 1.20.2 (devDependency) → ^1.27.1 (dependency)

<sup>Written for commit 4b3497ff85d241bd8a7563caea0a565758c33d5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

