### PR TITLE
fix(vtex): read MESH_REQUEST_CONTEXT per-request, not from cached factory env

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1006,8 +1006,9 @@
       "name": "vtex",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/bindings": "^1.3.1",
-        "@decocms/runtime": "1.3.1",
+        "@decocms/bindings": "^1.4.0",
+        "@decocms/runtime": "^1.6.2",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -1015,7 +1016,6 @@
         "@decocms/mcps-shared": "1.0.0",
         "@hey-api/client-fetch": "^0.8.0",
         "@hey-api/openapi-ts": "0.92.4",
-        "@modelcontextprotocol/sdk": "1.20.2",
         "@types/bun": "^1.2.14",
         "deco-cli": "^0.28.0",
         "typescript": "^5.7.2",
@@ -4365,7 +4365,9 @@
 
     "vtex/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
-    "vtex/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.20.2", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-6rqTdFt67AAAzln3NOKsXRmv5ZzPkgbfaebKBqUbts7vK1GZudqnrun5a8d3M/h955cam9RHZ6Jb4Y1XhnmFPg=="],
+    "vtex/@decocms/runtime": ["@decocms/runtime@1.6.2", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-Z38pLHDoJOfiZVOfQgnfyK24vVV/m8MOm8dXB0dvkIM6yp31JNmW88t3d5hw6P5FYr9TvpvKxQE9uWEeCeN8QQ=="],
+
+    "vtex/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
     "vtex/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -4915,11 +4917,7 @@
 
     "vtex-docs/ai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "vtex/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
-
-    "vtex/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
-
-    "vtex/@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "vtex/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
     "whatsapp-management/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
@@ -5490,10 +5488,6 @@
     "vtex-docs/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "vtex-docs/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "vtex/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
-
-    "vtex/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "whatsapp-management/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 

--- a/vtex/package.json
+++ b/vtex/package.json
@@ -18,8 +18,9 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@decocms/bindings": "^1.3.1",
-    "@decocms/runtime": "1.3.1",
+    "@decocms/bindings": "^1.4.0",
+    "@decocms/runtime": "^1.6.2",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "zod": "^4.0.0"
   },
   "devDependencies": {
@@ -27,7 +28,6 @@
     "@decocms/mcps-shared": "1.0.0",
     "@hey-api/client-fetch": "^0.8.0",
     "@hey-api/openapi-ts": "0.92.4",
-    "@modelcontextprotocol/sdk": "1.20.2",
     "@types/bun": "^1.2.14",
     "deco-cli": "^0.28.0",
     "typescript": "^5.7.2"

--- a/vtex/server/lib/tool-adapter.ts
+++ b/vtex/server/lib/tool-adapter.ts
@@ -291,28 +291,22 @@ export interface ToolFromOperationConfig {
 export function createToolFromOperation(config: ToolFromOperationConfig) {
   const flatInput = flattenRequestSchema(config.requestSchema);
 
-  return (env: Env) =>
+  // The factory's `env` is captured ONCE when the runtime resolves tool
+  // registrations on the first request, then cached for the process lifetime
+  // (see @decocms/runtime tools.ts: `let cached: Registrations | null`).
+  // Reading `env.MESH_REQUEST_CONTEXT` from this closure pins every tool call
+  // to the FIRST request's context — so an unauthenticated tools/list at pod
+  // start would poison every subsequent state read with `state: {}`.
+  // Read per-request env from `runtimeContext` instead — the runtime fills
+  // it from AsyncLocalStorage on every execute call.
+  return (_env: Env) =>
     createTool({
       id: config.id,
       description: config.description,
       annotations: config.annotations,
       inputSchema: flatInput,
-      execute: async ({ context }) => {
-        const meshCtx = env.MESH_REQUEST_CONTEXT;
-        console.log(
-          `[VTEX] tool=${config.id} mesh-context-shape:`,
-          JSON.stringify({
-            hasMeshContext: Boolean(meshCtx),
-            hasToken: Boolean(meshCtx?.token),
-            hasConnectionId: Boolean(meshCtx?.connectionId),
-            hasMeshUrl: Boolean(meshCtx?.meshUrl),
-            stateKeys: meshCtx?.state ? Object.keys(meshCtx.state) : [],
-            stateAccountNamePresent: Boolean(
-              (meshCtx?.state as { accountName?: unknown } | undefined)
-                ?.accountName,
-            ),
-          }),
-        );
+      execute: async ({ context, runtimeContext }) => {
+        const meshCtx = (runtimeContext.env as Env).MESH_REQUEST_CONTEXT;
         const creds = resolveCredentials(meshCtx?.state);
         assertValidCredentials(creds, config.id);
         const factory = config.clientFactory ?? createVtexClient;

--- a/vtex/server/tools/custom/reorder-collection.ts
+++ b/vtex/server/tools/custom/reorder-collection.ts
@@ -267,14 +267,18 @@ async function uploadCollectionFile(params: {
   }
 }
 
-export const reorderCollection = (env: Env) =>
+// Read per-request env from `runtimeContext` — see comment in
+// lib/tool-adapter.ts for why the factory's captured env is unsafe to read
+// inside execute (cached registrations + fresh per-request bindings).
+export const reorderCollection = (_env: Env) =>
   createTool({
     id: "VTEX_REORDER_COLLECTION",
     description:
       "Overwrite collection contents by removing current SKUs and importing a new ordered SKU list via spreadsheet file.",
     inputSchema: reorderCollectionInputSchema,
     outputSchema: reorderCollectionOutputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context, runtimeContext }) => {
+      const env = runtimeContext.env as Env;
       const reorderPromise = (async () => {
         const credentials = resolveCredentials(env.MESH_REQUEST_CONTEXT?.state);
         assertValidCredentials(credentials, "VTEX_REORDER_COLLECTION");

--- a/vtex/server/tools/custom/search-collections.ts
+++ b/vtex/server/tools/custom/search-collections.ts
@@ -2,7 +2,10 @@ import { createTool } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../../types/env.ts";
 
-export const searchCollections = (env: Env) =>
+// Read per-request env from `runtimeContext` — see comment in
+// lib/tool-adapter.ts for why the factory's captured env is unsafe to read
+// inside execute (cached registrations + fresh per-request bindings).
+export const searchCollections = (_env: Env) =>
   createTool({
     id: "VTEX_SEARCH_COLLECTIONS",
     description: "Search collections by name or other terms.",
@@ -10,7 +13,8 @@ export const searchCollections = (env: Env) =>
     inputSchema: z.object({
       searchTerms: z.string().describe("Search terms to find collections"),
     }),
-    execute: async ({ context }) => {
+    execute: async ({ context, runtimeContext }) => {
+      const env = runtimeContext.env as Env;
       const credentials = env.MESH_REQUEST_CONTEXT.state;
       const { accountName, appKey, appToken } = credentials;
 

--- a/vtex/server/tools/custom/update-product-specifications.ts
+++ b/vtex/server/tools/custom/update-product-specifications.ts
@@ -39,14 +39,18 @@ const outputSchema = z.object({
   productId: z.number().int().positive(),
 });
 
-export const updateProductSpecifications = (env: Env) =>
+// Read per-request env from `runtimeContext` — see comment in
+// lib/tool-adapter.ts for why the factory's captured env is unsafe to read
+// inside execute (cached registrations + fresh per-request bindings).
+export const updateProductSpecifications = (_env: Env) =>
   createTool({
     id: "VTEX_UPDATE_PRODUCT_SPECIFICATIONS",
     description:
       "Replace all specifications for a product. Pass the complete set — values not included are removed. Caller does GET → merge → POST for partial updates. Counterpart of VTEX_GET_PRODUCT_SPECIFICATIONS.",
     inputSchema,
     outputSchema,
-    execute: async ({ context }) => {
+    execute: async ({ context, runtimeContext }) => {
+      const env = runtimeContext.env as Env;
       const credentials = resolveCredentials(env.MESH_REQUEST_CONTEXT?.state);
       assertValidCredentials(credentials, "VTEX_UPDATE_PRODUCT_SPECIFICATIONS");
       const url = `https://${credentials.accountName}.vtexcommercestable.com.br/api/catalog_system/pvt/products/${context.productId}/specification`;


### PR DESCRIPTION
## Summary
Switch every vtex tool's `execute` to read `MESH_REQUEST_CONTEXT` from `runtimeContext.env` (per-request, filled by the runtime's AsyncLocalStorage) instead of from the `env` captured in the factory closure. Affects:

- `server/lib/tool-adapter.ts` — `createToolFromOperation` (used by all ~705 generated registry tools)
- `server/tools/custom/reorder-collection.ts` — `VTEX_REORDER_COLLECTION`
- `server/tools/custom/search-collections.ts` — `VTEX_SEARCH_COLLECTIONS`
- `server/tools/custom/update-product-specifications.ts` — `VTEX_UPDATE_PRODUCT_SPECIFICATIONS`

## Why this is the actual root cause

Studio is doing the right thing: I confirmed by introspecting the `farmrio` connection (`COLLECTION_CONNECTIONS_GET conn_9uNQJVyv_ECiRcDZl290Y`) that `configuration_state` is `{ accountName: \"lojafarm\", appKey, appToken }` — fully populated — and `buildRequestHeaders` mints a JWT with that state and forwards it as `x-mesh-token` to `https://sites-vtex.decocache.com/mcp`.

The bug was in vtex. `@decocms/runtime` caches tool registrations after the first request (`tools.ts`: `let cached: Registrations | null`) and creates a fresh `bindings` env per request (`index.ts`: `env: { ...process.env, ...env }`). Tools that capture `env` in the factory closure see only the FIRST request's env — every subsequent call uses that frozen snapshot. The runtime's own comment at `tools.ts:821` explicitly says: *\"Tool execution reads per-request context from State (AsyncLocalStorage), so reusing definitions is safe.\"* — implying tools must read from `runtimeContext.env`, not the captured factory env.

Symptom: when the pod's first request happened to carry a state-bearing JWT, every subsequent call appeared to work. When the first request was an unauthenticated `tools/list` (typical right after a Knative scale-up), every subsequent call saw `state: {}` and failed with *\"VTEX accountName is missing\"* — the exact intermittent behavior reported (\"worked for a little bit then back to error\").

Verified by direct port-forward to the pod with a fake `x-mesh-token` containing state — the captured-env code returned `hasToken: false` regardless of what the request actually carried.

## Test plan
- [x] `bun run check` — clean
- [x] `bun test` — 77 pass, 0 fail (mock runtimeContext.env propagates correctly through all paths)
- [x] `bun run build` — bundles cleanly
- [ ] After deploy, confirm the diagnostic log in `client-factory.ts` flips from `stateKeys: []` to `stateKeys: [\"accountName\", \"appKey\", \"appToken\"]` and `VTEX_GET_COLLECTION_PRODUCTS` returns real data
- [ ] Verify across pod scale events — the bug was timing-dependent, so the fix should be insensitive to which request hits a fresh pod first

Once verified, follow-up PR can strip the diagnostic logging added in #423.

## Note about #430
The runtime bump in #430 (1.3.1 → ^1.6.2) didn't fix anything by itself — both runtime versions had the cached-registrations behavior — but it doesn't hurt and cleans up some unrelated divergence from the recent rollback, so I'm leaving it merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix VTEX tools to read `MESH_REQUEST_CONTEXT` from per-request `runtimeContext.env` instead of the cached factory env. This removes state leakage across requests and fixes intermittent “VTEX accountName is missing” errors after cold starts or unauthenticated first calls.

- **Bug Fixes**
  - Read `MESH_REQUEST_CONTEXT` from `runtimeContext.env` in `createToolFromOperation` and custom tools: `VTEX_REORDER_COLLECTION`, `VTEX_SEARCH_COLLECTIONS`, `VTEX_UPDATE_PRODUCT_SPECIFICATIONS`.
  - Avoids using a cached env snapshot from tool registration; tools now receive the correct state on every call.

- **Dependencies**
  - Bump `@decocms/runtime` to `^1.6.2` and `@decocms/bindings` to `^1.4.0`.
  - Add `@modelcontextprotocol/sdk` to dependencies at `^1.27.1` (was in devDependencies).

<sup>Written for commit c05b08586bdb939f9943aa37530cfed8fff31f89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

