### PR TITLE
fix(slack): collapse history into 1 system msg + use user name as thread_id

### DIFF
--- a/slack-mcp/server/llm.ts
+++ b/slack-mcp/server/llm.ts
@@ -76,25 +76,51 @@ async function getDirectHttpAgent(
 
   const { meshUrl, agentId } = config;
 
+  const url = `${meshUrl}/api/${orgPath}/decopilot/stream`;
+
   return {
     STREAM: async (params) => {
-      const url = `${meshUrl}/api/${orgPath}/decopilot/stream`;
-      console.log(`[LLM] Direct HTTP call to ${url}`);
+      const initialThreadId = params.thread_id;
 
-      const response = await fetch(url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-          Accept: "application/json, text/event-stream",
-        },
-        body: JSON.stringify({
-          messages: params.messages,
-          agent: { id: agentId },
-          stream: true,
-          toolApprovalLevel: params.toolApprovalLevel ?? "auto",
-        }),
-      });
+      const send = async (threadId: string | undefined) => {
+        console.log(
+          `[LLM] Direct HTTP call to ${url} (thread_id=${threadId ?? "none"})`,
+        );
+        return fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+            Accept: "application/json, text/event-stream",
+          },
+          body: JSON.stringify({
+            messages: params.messages,
+            agent: { id: agentId },
+            stream: true,
+            toolApprovalLevel: params.toolApprovalLevel ?? "auto",
+            ...(threadId ? { thread_id: threadId } : {}),
+          }),
+        });
+      };
+
+      let response = await send(initialThreadId);
+
+      // If the thread_id is not accessible (decopilot returns permission/forbidden),
+      // retry once with a temp thread_id derived from the original (name) + timestamp.
+      if (
+        !response.ok &&
+        initialThreadId &&
+        isThreadPermissionStatus(response.status)
+      ) {
+        const peek = await response.clone().text();
+        if (isThreadPermissionMessage(peek)) {
+          const tempThreadId = `${initialThreadId}-${Date.now()}`;
+          console.log(
+            `[LLM] thread_id=${initialThreadId} returned ${response.status} (permission). Retrying with temp thread_id=${tempThreadId}`,
+          );
+          response = await send(tempThreadId);
+        }
+      }
 
       if (!response.ok) {
         const errorText = await response.text();
@@ -106,6 +132,16 @@ async function getDirectHttpAgent(
       return sseResponseToAsyncIterable(response);
     },
   };
+}
+
+function isThreadPermissionStatus(status: number): boolean {
+  return status === 401 || status === 403 || status === 404;
+}
+
+function isThreadPermissionMessage(body: string): boolean {
+  return /permission|forbidden|unauthor|not[\s_-]?allowed|access denied|not[\s_-]?found/i.test(
+    body,
+  );
 }
 
 /**

--- a/slack-mcp/server/slack/handlers/context-builder.ts
+++ b/slack-mcp/server/slack/handlers/context-builder.ts
@@ -23,7 +23,7 @@ export interface ContextConfig {
 }
 
 export interface MessageWithImages {
-  role: "user" | "assistant";
+  role: "system" | "user" | "assistant";
   content: string;
   images?: Array<{
     type: "image" | "audio";
@@ -211,27 +211,24 @@ export function formatMessagesForLLM(
 ): MessageWithImages[] {
   const allMessages: MessageWithImages[] = [];
 
-  // Add context with explicit markers (if any)
+  // The decopilot endpoint enforces "exactly one non-system message" per call,
+  // so we collapse all prior conversation turns into a single system message
+  // and emit a single user message with the current request.
   if (contextMessages.length > 0) {
+    const history = contextMessages
+      .map((m) => `[${m.role}]: ${m.content}`)
+      .join("\n");
     allMessages.push({
-      role: "user",
+      role: "system",
       content:
-        "<previous_conversation>\n" +
-        "The messages below are the previous conversation history for context. " +
-        "Respond ONLY to <current_request>, use the context only to understand the conversation.\n" +
-        "</previous_conversation>",
-    });
-    allMessages.push(...contextMessages);
-    allMessages.push({
-      role: "user",
-      content: "<end_previous_conversation>",
+        "Previous conversation history (for context only — respond only to the user's current message):\n" +
+        history,
     });
   }
 
-  // Add current request with explicit marker
   allMessages.push({
     role: "user",
-    content: `<current_request>\n${currentContent}\n</current_request>`,
+    content: currentContent,
     images: media && media.length > 0 ? media : undefined,
   });
 

--- a/slack-mcp/server/slack/handlers/eventHandler.ts
+++ b/slack-mcp/server/slack/handlers/eventHandler.ts
@@ -336,6 +336,21 @@ async function processAttachedFiles(
 }
 
 /**
+ * Resolve a Slack user's display name (display_name → real_name → name → userId).
+ * Used as the stable decopilot thread_id so the agent has memory per person.
+ */
+async function resolveUserName(userId: string): Promise<string> {
+  try {
+    const info = await getUserInfo(userId);
+    return (
+      info?.profile?.display_name || info?.real_name || info?.name || userId
+    );
+  } catch {
+    return userId;
+  }
+}
+
+/**
  * Build messages for LLM with context
  */
 async function buildLLMMessages(
@@ -502,6 +517,7 @@ async function handleAppMention(
       replyTo,
       thinkingMessageTs: thinkingMsg?.ts,
       streamingEnabled: enableStreaming,
+      userName: await resolveUserName(user),
       slackEvent: { text: fullText, user, ts, thread_ts },
     });
   } catch (error) {
@@ -632,19 +648,12 @@ async function handleDirectMessage(
     await removeReaction(channel, ts, "eyes");
   }
 
-  // Resolve sender name
-  let senderText = text;
-  try {
-    const userInfo = await getUserInfo(user);
-    const senderName = userInfo
-      ? userInfo.profile?.display_name || userInfo.real_name || userInfo.name
-      : null;
-    if (senderName) {
-      senderText = `[Mensagem de ${senderName}]\n${text}`;
-    }
-  } catch (err) {
-    console.warn(`[EventHandler] Failed to resolve DM sender name:`, err);
-  }
+  // Resolve sender name (used both as a prefix for the LLM and as the thread_id)
+  const senderName = await resolveUserName(user);
+  const senderText =
+    senderName && senderName !== user
+      ? `[Mensagem de ${senderName}]\n${text}`
+      : text;
 
   const messages = await buildLLMMessages(
     channel,
@@ -673,6 +682,7 @@ async function handleDirectMessage(
       channel,
       thinkingMessageTs: thinkingMsg?.ts,
       streamingEnabled: enableStreaming,
+      userName: senderName,
       slackEvent: { text, user, ts, channel_type: "im" },
     });
   } catch (error) {
@@ -745,6 +755,7 @@ async function handleThreadReply(
       replyTo: threadTs,
       thinkingMessageTs: thinkingMsg?.ts,
       streamingEnabled: enableStreaming,
+      userName: await resolveUserName(user),
       slackEvent: { text, user, ts, thread_ts: threadTs },
     });
   } catch (error) {

--- a/slack-mcp/server/slack/handlers/llm-handler.ts
+++ b/slack-mcp/server/slack/handlers/llm-handler.ts
@@ -51,6 +51,13 @@ export interface LLMResponseOptions {
   thinkingMessageTs?: string;
   useBlocks?: boolean;
   streamingEnabled?: boolean;
+  /**
+   * Stable identifier for the decopilot thread.
+   * We use the Slack user's resolved name so the agent has memory per person.
+   * The HTTP layer auto-falls back to `<userName>-<timestamp>` when the
+   * decopilot rejects access to the thread.
+   */
+  userName?: string;
   /** Original Slack event context — used for trigger fallback when STREAM fails */
   slackEvent?: {
     text: string;
@@ -110,7 +117,7 @@ async function callWithStreaming(
   messages: MessageWithImages[],
   options: LLMResponseOptions,
 ): Promise<string> {
-  const { channel, thinkingMessageTs, useBlocks = true } = options;
+  const { channel, thinkingMessageTs, useBlocks = true, userName } = options;
 
   if (!thinkingMessageTs) {
     return callWithoutStreaming(connectionId, messages, options);
@@ -119,7 +126,7 @@ async function callWithStreaming(
   const animation = startThinkingAnimation(channel, thinkingMessageTs);
 
   try {
-    const stream = await streamAgentResponse(connectionId, messages);
+    const stream = await streamAgentResponse(connectionId, messages, userName);
     const rawText = await collectStreamText(stream);
 
     animation.stop();
@@ -157,9 +164,15 @@ async function callWithoutStreaming(
   messages: MessageWithImages[],
   options: LLMResponseOptions,
 ): Promise<string> {
-  const { channel, replyTo, thinkingMessageTs, useBlocks = true } = options;
+  const {
+    channel,
+    replyTo,
+    thinkingMessageTs,
+    useBlocks = true,
+    userName,
+  } = options;
 
-  const stream = await streamAgentResponse(connectionId, messages);
+  const stream = await streamAgentResponse(connectionId, messages, userName);
   const response = cleanAgentResponse(await collectStreamText(stream));
 
   if (!response.trim()) {


### PR DESCRIPTION
## Summary

The decopilot `/stream` endpoint enforces *"exactly one non-system message"* per call, so slack-mcp's multi-turn context arrays were being rejected with 400. This PR:

- Collapses Slack-thread / channel history into a single `system` message and emits a single `user` message with the current request (`context-builder.ts`).
- Forwards `thread_id` to decopilot using the resolved Slack display name (`display_name → real_name → name`), giving the agent memory per person across DMs/channels/threads (`llm.ts`, `llm-handler.ts`, `eventHandler.ts`).
- On 401/403/404 with a permission/not-found body, retries once with `thread_id=<name>-<timestamp>` so the bot still responds when the user-named thread isn't accessible.

## Test plan

- [ ] Send a DM to the bot → first message should reply; check decopilot logs for `thread_id=<your name>`.
- [ ] Send a 2nd DM with reference to the first → agent should have context (proves thread memory works).
- [ ] @mention the bot in a channel with prior conversation → no more `Expected exactly one non-system message` 400.
- [ ] Reply in an existing thread → still works, uses sender name as thread_id.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 400s from `/decopilot/stream` by sending exactly one non-system message per call. Adds per-user memory by using the Slack display name as `thread_id`, with a fallback when access is denied.

- **Bug Fixes**
  - Collapse prior conversation into one `system` message; send the current request as a single `user` message.
  - On 401/403/404 with permission/not-found, retry once with `thread_id=<name>-<timestamp>` to ensure a reply.

- **New Features**
  - Use Slack display name (`display_name → real_name → name → userId`) as `thread_id` to give the agent memory per person across DMs, channels, and threads.

<sup>Written for commit 2328edfc1b23e8da860096cc36b52bfee4624425. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

