### PR TITLE
fix(slack): make AgentOf binding work + retry + stop double-trigger

### DIFF
--- a/slack-mcp/server/llm.ts
+++ b/slack-mcp/server/llm.ts
@@ -105,18 +105,15 @@ async function getDirectHttpAgent(
 
       let response = await send(initialThreadId);
 
-      // If the thread_id is not accessible (decopilot returns permission/forbidden),
-      // retry once with a temp thread_id derived from the original (name) + timestamp.
-      if (
-        !response.ok &&
-        initialThreadId &&
-        isThreadPermissionStatus(response.status)
-      ) {
+      // If the thread_id can't be used (decopilot doesn't auto-create threads,
+      // and rejects with 401/403/404 for permission or 500 "Thread not found"),
+      // retry once with a temp thread_id = <name>-<timestamp>.
+      if (!response.ok && initialThreadId) {
         const peek = await response.clone().text();
-        if (isThreadPermissionMessage(peek)) {
+        if (isThreadAccessFailure(response.status, peek)) {
           const tempThreadId = `${initialThreadId}-${Date.now()}`;
           console.log(
-            `[LLM] thread_id=${initialThreadId} returned ${response.status} (permission). Retrying with temp thread_id=${tempThreadId}`,
+            `[LLM] thread_id=${initialThreadId} returned ${response.status} (${peek.slice(0, 120)}). Retrying with temp thread_id=${tempThreadId}`,
           );
           response = await send(tempThreadId);
         }
@@ -134,14 +131,17 @@ async function getDirectHttpAgent(
   };
 }
 
-function isThreadPermissionStatus(status: number): boolean {
-  return status === 401 || status === 403 || status === 404;
-}
-
-function isThreadPermissionMessage(body: string): boolean {
-  return /permission|forbidden|unauthor|not[\s_-]?allowed|access denied|not[\s_-]?found/i.test(
-    body,
-  );
+function isThreadAccessFailure(status: number, body: string): boolean {
+  // 401/403/404 → almost always a thread access issue; trust the status alone.
+  if (status === 401 || status === 403 || status === 404) return true;
+  // 500 → only retry if the body explicitly mentions thread issues, to avoid
+  // looping on unrelated server errors.
+  if (status === 500) {
+    return /thread[^"]{0,40}(not[\s_-]?found|permission|forbidden|unauthor|access denied|not[\s_-]?allowed)/i.test(
+      body,
+    );
+  }
+  return false;
 }
 
 /**

--- a/slack-mcp/server/slack/handlers/eventHandler.ts
+++ b/slack-mcp/server/slack/handlers/eventHandler.ts
@@ -400,8 +400,14 @@ export async function handleSlackEvent(
 
   switch (type) {
     case "app_mention":
-      publishAppMention(connectionId, payload);
-      if (!triggerOnly) {
+      // Trigger publish and direct LLM handling are mutually exclusive:
+      // in normal mode, handleAppMention runs the LLM and only falls back
+      // to publishing a trigger inside handleLLMCall if the LLM call fails.
+      // Publishing here AND running the LLM caused every message to be
+      // answered twice (once by the LLM, once by the trigger subscriber).
+      if (triggerOnly) {
+        publishAppMention(connectionId, payload);
+      } else {
         await handleAppMention(
           payload as SlackAppMentionEvent,
           teamConfig,
@@ -410,8 +416,9 @@ export async function handleSlackEvent(
       }
       break;
     case "message":
-      publishMessageReceived(connectionId, payload);
-      if (!triggerOnly) {
+      if (triggerOnly) {
+        publishMessageReceived(connectionId, payload);
+      } else {
         await handleMessage(
           payload as SlackMessageEvent,
           teamConfig,


### PR DESCRIPTION
## Summary

Three follow-up fixes to #434 surfaced while testing the new thread_id flow:

**1. Use the runtime's `streamAgent` so the AgentOf binding path actually works** — `slack-mcp/server/llm.ts`
The old `getAgent()` read the binding from `instance.env.MESH_REQUEST_CONTEXT.state.AGENT`, but that env is captured during the configuration `onChange` (not per-request) and the Slack webhook path runs **outside** the runtime, so `state.AGENT` was always the raw `{ id, value }` config rather than a resolved proxy with `.STREAM`. Every webhook silently fell through to a hand-rolled fetch against `/api/<org>/decopilot/stream` with a custom SSE parser. Replace the dual binding/HTTP fallback with a single client that constructs the same proxy `createAgentProxy` builds for resolved bindings — via `streamAgent` from `@decocms/runtime/decopilot`. Endpoint becomes the canonical `/api/<org>/decopilot/runtime/stream`, wire format becomes AI SDK UIMessage chunks, and auth uses the persisted `meshApiKey`. **−229 LOC.**

**2. Retry with temp thread_id on thread-access failures** — `slack-mcp/server/llm.ts`
The decopilot `/runtime/stream` endpoint does not auto-create threads. The retry now catches the error thrown by `streamAgent` and matches `thread … not found / permission / forbidden / unauthorized / access denied / not allowed`, then re-sends with `thread_id=<name>-<timestamp>`. Unrelated errors still propagate.

**3. Stop double-publishing triggers** — `slack-mcp/server/slack/handlers/eventHandler.ts`
`handleSlackEvent` was publishing a trigger upfront **and** calling the LLM handler. The LLM handler also publishes a fallback trigger on failure. Net effect: every Slack message produced 2 trigger invocations (and 2 bot replies) in normal mode. Fix: trigger publish and direct LLM handling are now mutually exclusive — `triggerOnly` mode publishes, normal mode runs the LLM (which keeps the existing fallback publish on error). Resolves the "2 Pensando messages" symptom.

## Test plan

- [ ] Send a DM from a user whose name has never been seen as a `thread_id` — bot replies once and reuses the temp thread on subsequent messages.
- [ ] Pod logs show `streamAgent <meshUrl>/api/<org>/decopilot/runtime/stream (thread_id=<Name>)` and (on first message) `thread_id=<Name> failed (Thread not found...). Retrying with temp thread_id=<Name>-<ts>`.
- [ ] Only **one** reply per message in normal mode; one reply in `triggerOnly` mode.
- [ ] Unrelated agent failures (timeouts, etc.) propagate to the trigger fallback once instead of looping.
