### PR TITLE
fix(slack): make AgentOf binding work via runtime streamAgent

### DIFF
--- a/slack-mcp/server/llm.ts
+++ b/slack-mcp/server/llm.ts
@@ -1,15 +1,25 @@
 /**
  * LLM Module - AI Agent Integration for Slack MCP
  *
- * Resolution order:
- * 1. AgentOf() binding (fast, in-process — but depends on onChange)
- * 2. Direct HTTP to Mesh Decopilot API (reliable, same as health check)
+ * The Slack webhook path lives OUTSIDE the @decocms/runtime request context
+ * (no JWT, no per-request bindings resolution), so the AgentOf() binding
+ * proxy cannot be picked up from `env.MESH_REQUEST_CONTEXT.state.AGENT`.
  *
- * The direct HTTP path uses the persisted meshApiKey + organizationSlug
- * from Supabase, bypassing the runtime entirely.
+ * Instead we construct an agent client by hand, using the persisted
+ * `meshApiKey` + `organizationSlug` + `agentId` from Supabase, and call
+ * `streamAgent` from @decocms/runtime/decopilot — which is the exact same
+ * machinery the binding proxy uses internally (POST to
+ * `/api/<org>/decopilot/runtime/stream` with AI SDK UIMessage chunks).
+ *
+ * This makes the slack-mcp behave identically to a runtime-resolved binding.
  */
+import {
+  streamAgent,
+  type AgentBindingConfig,
+  type AgentStreamParams,
+  type ResolvedAgentClient,
+} from "@decocms/runtime/decopilot";
 
-import { getInstance } from "./connection-instance.ts";
 import { getCachedConnectionConfig } from "./lib/config-cache.ts";
 
 // ============================================================================
@@ -30,197 +40,113 @@ export interface SlackChatMessage {
 }
 
 // ============================================================================
-// Agent Binding
+// Agent client
 // ============================================================================
 
-/** Resolved agent client shape after binding resolution */
-interface AgentClient {
-  STREAM: (params: {
-    messages: Array<{
-      role: string;
-      parts: Array<Record<string, unknown>>;
-    }>;
-    thread_id?: string;
-    toolApprovalLevel?: "auto" | "readonly" | "plan";
-  }) => Promise<
-    AsyncIterable<{ parts: Array<{ type: string; text?: string }> }>
-  >;
-}
-
-function getAgent(connectionId: string): AgentClient | null {
-  const instance = getInstance(connectionId);
-  if (!instance) return null;
-  const agent = (
-    instance.env.MESH_REQUEST_CONTEXT?.state as Record<string, unknown>
-  )?.AGENT;
-  if (agent && typeof (agent as AgentClient).STREAM === "function") {
-    return agent as AgentClient;
-  }
-  return null;
-}
-
 /**
- * Direct HTTP agent — calls the Mesh Decopilot API directly.
- * Same approach as the /health check: fetch + SSE parsing.
- * Uses persisted meshApiKey (never expires) from Supabase.
+ * Build a ResolvedAgentClient for a given connection.
+ *
+ * Mirrors what the runtime's `createAgentProxy` builds for resolved bindings,
+ * but constructed manually because the Slack webhook path has no per-request
+ * runtime context. Uses the persisted `meshApiKey` so the call is always
+ * authenticated without depending on a session token.
  */
-async function getDirectHttpAgent(
+async function getAgentClient(
   connectionId: string,
-): Promise<AgentClient | null> {
+): Promise<ResolvedAgentClient | null> {
   const config = await getCachedConnectionConfig(connectionId);
-  const token = config?.meshApiKey || config?.meshToken;
-  const orgPath = config?.organizationSlug || config?.organizationId;
-  if (!token || !orgPath || !config?.meshUrl || !config?.agentId) {
+  const token = config?.meshApiKey ?? config?.meshToken;
+  const orgSlug = config?.organizationSlug ?? config?.organizationId;
+  if (!token || !orgSlug || !config?.meshUrl || !config?.agentId) {
     return null;
   }
 
-  const { meshUrl, agentId } = config;
-
-  const url = `${meshUrl}/api/${orgPath}/decopilot/stream`;
+  const streamUrl = `${config.meshUrl}/api/${orgSlug}/decopilot/runtime/stream`;
+  const agentConfig: AgentBindingConfig = {
+    __type: "@deco/agent",
+    id: config.agentId,
+  };
 
   return {
-    STREAM: async (params) => {
+    STREAM: async (params, opts) => {
       const initialThreadId = params.thread_id;
 
-      const send = async (threadId: string | undefined) => {
+      try {
         console.log(
-          `[LLM] Direct HTTP call to ${url} (thread_id=${threadId ?? "none"})`,
+          `[LLM] streamAgent ${streamUrl} (thread_id=${initialThreadId ?? "none"})`,
         );
-        return fetch(url, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-            Accept: "application/json, text/event-stream",
-          },
-          body: JSON.stringify({
-            messages: params.messages,
-            agent: { id: agentId },
-            stream: true,
-            toolApprovalLevel: params.toolApprovalLevel ?? "auto",
-            ...(threadId ? { thread_id: threadId } : {}),
-          }),
-        });
-      };
-
-      let response = await send(initialThreadId);
-
-      // If the thread_id can't be used (decopilot doesn't auto-create threads,
-      // and rejects with 401/403/404 for permission or 500 "Thread not found"),
-      // retry once with a temp thread_id = <name>-<timestamp>.
-      if (!response.ok && initialThreadId) {
-        const peek = await response.clone().text();
-        if (isThreadAccessFailure(response.status, peek)) {
+        return await streamAgent(streamUrl, token, agentConfig, params, opts);
+      } catch (err) {
+        // The decopilot endpoint does not auto-create threads — it returns
+        // an error like "Thread not found: <name>" (and also rejects with
+        // permission errors for threads owned by other principals). Retry
+        // once with a temp thread_id derived from the original.
+        if (initialThreadId && isThreadAccessFailure(err)) {
           const tempThreadId = `${initialThreadId}-${Date.now()}`;
           console.log(
-            `[LLM] thread_id=${initialThreadId} returned ${response.status} (${peek.slice(0, 120)}). Retrying with temp thread_id=${tempThreadId}`,
+            `[LLM] thread_id=${initialThreadId} failed (${stringifyError(err).slice(0, 120)}). Retrying with temp thread_id=${tempThreadId}`,
           );
-          response = await send(tempThreadId);
+          return await streamAgent(
+            streamUrl,
+            token,
+            agentConfig,
+            { ...params, thread_id: tempThreadId },
+            opts,
+          );
         }
+        throw err;
       }
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(
-          `Direct HTTP decopilot call failed (${response.status}): ${errorText}`,
-        );
-      }
-
-      return sseResponseToAsyncIterable(response);
     },
   };
 }
 
-function isThreadAccessFailure(status: number, body: string): boolean {
-  // 401/403/404 → almost always a thread access issue; trust the status alone.
-  if (status === 401 || status === 403 || status === 404) return true;
-  // 500 → only retry if the body explicitly mentions thread issues, to avoid
-  // looping on unrelated server errors.
-  if (status === 500) {
-    return /thread[^"]{0,40}(not[\s_-]?found|permission|forbidden|unauthor|access denied|not[\s_-]?allowed)/i.test(
-      body,
-    );
-  }
-  return false;
+function stringifyError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
 }
 
+function isThreadAccessFailure(err: unknown): boolean {
+  const message = stringifyError(err);
+  // `streamAgent` throws Error(message) where message is `body.error` (when
+  // the response was JSON) or the raw body text — see runtime/decopilot.ts.
+  // We match on the patterns the decopilot uses for thread access failures.
+  return /thread[^"]{0,40}(not[\s_-]?found|permission|forbidden|unauthor|access[\s_-]?denied|not[\s_-]?allowed)/i.test(
+    message,
+  );
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
 /**
- * Convert an SSE Response into an async iterable of message objects
- * compatible with the AgentClient STREAM interface.
+ * Sync availability check (no I/O).
+ * Kept for API compatibility — the actual config lookup is async, so this
+ * always returns true and lets the caller hit the agent and handle failures.
  */
-async function* sseResponseToAsyncIterable(
-  response: Response,
-): AsyncGenerator<{ parts: Array<{ type: string; text?: string }> }> {
-  const reader = response.body!.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-  let textContent = "";
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
-
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed || !trimmed.startsWith("data:")) continue;
-        const data = trimmed.slice("data:".length).trim();
-        if (!data || data === "[DONE]") continue;
-
-        try {
-          const event = JSON.parse(data);
-          if (event.type === "text-delta" && event.delta) {
-            textContent += event.delta;
-          } else if (event.type === "text" && event.text) {
-            textContent += event.text;
-          } else if (
-            event.type === "tool-call" ||
-            event.type === "tool-input-start"
-          ) {
-            textContent = "";
-          } else if (event.type === "finish") {
-            break;
-          }
-        } catch {
-          // ignore parse errors
-        }
-      }
-    }
-  } finally {
-    reader.releaseLock();
-  }
-
-  yield { parts: [{ type: "text", text: textContent }] };
+export function isAgentAvailable(_connectionId: string): boolean {
+  return true;
 }
 
 /**
- * Check if the agent binding is available and configured.
- */
-export function isAgentAvailable(connectionId: string): boolean {
-  return getAgent(connectionId) !== null;
-}
-
-/**
- * Check if agent is available (binding or direct HTTP fallback).
+ * Async availability check — verifies the connection has the credentials
+ * needed to build an agent client.
  */
 export async function isAgentAvailableAsync(
   connectionId: string,
 ): Promise<boolean> {
-  if (getAgent(connectionId)) return true;
-  const direct = await getDirectHttpAgent(connectionId);
-  return direct !== null;
+  return (await getAgentClient(connectionId)) !== null;
 }
 
 /**
- * Convert SlackChatMessage[] to the message format expected by STREAM API.
+ * Convert SlackChatMessage[] to the UIMessage format expected by
+ * @decocms/runtime/decopilot's `streamAgent`.
  */
-function toUIMessages(messages: SlackChatMessage[]) {
+function toUIMessages(
+  messages: SlackChatMessage[],
+): AgentStreamParams["messages"] {
   return messages.map((m) => ({
-    role: m.role as "system" | "user" | "assistant",
+    role: m.role,
     parts: [
       { type: "text" as const, text: m.content },
       ...(m.images?.map((img) => ({
@@ -234,91 +160,39 @@ function toUIMessages(messages: SlackChatMessage[]) {
 }
 
 /**
- * Stream an agent response.
- *
- * 1. Try AgentOf() binding (fast, in-process)
- *    - If it returns empty text, retry with Direct HTTP
- * 2. Fall back to direct HTTP (same path as health check — always works)
- * 3. If both fail, caller publishes a trigger as last resort
+ * Stream an agent response via the runtime's decopilot streamAgent —
+ * the same path the AgentOf() binding would use.
  */
 export async function streamAgentResponse(
   connectionId: string,
   messages: SlackChatMessage[],
   threadId?: string,
 ) {
-  const streamParams = {
+  const client = await getAgentClient(connectionId);
+  if (!client) {
+    throw new Error(
+      "Agent not configured.\n\n" +
+        "How to fix:\n" +
+        "1. Open Mesh Dashboard\n" +
+        "2. Go to this MCP's configuration\n" +
+        "3. Configure the AGENT binding (and save) so we have an agentId\n",
+    );
+  }
+
+  return client.STREAM({
     messages: toUIMessages(messages),
-    toolApprovalLevel: "auto" as const,
+    toolApprovalLevel: "auto",
     ...(threadId ? { thread_id: threadId } : {}),
-  };
-
-  // 1. Try AgentOf() binding
-  const bindingAgent = getAgent(connectionId);
-  if (bindingAgent) {
-    try {
-      const stream = await bindingAgent.STREAM(streamParams);
-      // Consume the stream and check if it has text
-      const text = await collectStreamTextInternal(stream);
-      if (text.trim()) {
-        // Re-wrap as async iterable with the collected text
-        return textToAsyncIterable(text);
-      }
-      console.log(
-        `[LLM] AgentOf() binding returned empty for ${connectionId}, trying direct HTTP`,
-      );
-    } catch (err) {
-      console.log(
-        `[LLM] AgentOf() STREAM failed for ${connectionId}: ${err}, trying direct HTTP`,
-      );
-    }
-  }
-
-  // 2. Direct HTTP — same reliable path as /health check
-  console.log(`[LLM] Using direct HTTP for ${connectionId}`);
-  const directAgent = await getDirectHttpAgent(connectionId);
-  if (directAgent) {
-    return await directAgent.STREAM(streamParams);
-  }
-
-  throw new Error(
-    "Agent not configured.\n\n" +
-      "How to fix:\n" +
-      "1. Open Mesh Dashboard\n" +
-      "2. Go to this MCP's configuration\n" +
-      "3. Configure AGENT binding\n" +
-      "4. Click Save to apply",
-  );
+  });
 }
 
 /**
- * Internal helper to collect text from a stream (same as collectStreamText).
- */
-async function collectStreamTextInternal(
-  stream: AsyncIterable<{ parts: Array<{ type: string; text?: string }> }>,
-): Promise<string> {
-  let text = "";
-  for await (const message of stream) {
-    for (const part of message.parts) {
-      if (part.type === "text" && part.text) {
-        text = part.text;
-      }
-    }
-  }
-  return text;
-}
-
-/**
- * Wrap already-collected text back into the async iterable format.
- */
-async function* textToAsyncIterable(
-  text: string,
-): AsyncGenerator<{ parts: Array<{ type: string; text?: string }> }> {
-  yield { parts: [{ type: "text", text }] };
-}
-
-/**
- * Collect full text from an agent stream.
- * Convenience helper for non-streaming mode.
+ * Collect the final text from a UIMessage stream.
+ *
+ * `streamAgent` yields a UIMessage that's progressively rebuilt as chunks
+ * arrive; each yield carries the cumulative `parts` array. We take the last
+ * text part of the last yield, which equals the final assistant message.
+ * Tool-call parts are ignored (we don't surface them to Slack).
  */
 export async function collectStreamText(
   stream: AsyncIterable<{ parts: Array<{ type: string; text?: string }> }>,


### PR DESCRIPTION
## Summary

Follow-up to #435. The slack-mcp had a dead-code AgentOf binding path that always fell through to a hand-rolled fetch.

The old `getAgent()` read the binding from `instance.env.MESH_REQUEST_CONTEXT.state.AGENT`, but `instance.env` is captured during the configuration `onChange` (not per-request) and the Slack webhook runs **outside** the runtime, so `state.AGENT` was always the raw `{ id, value }` config rather than a resolved proxy with `.STREAM`. Every webhook silently fell through to a custom fetch against `/api/<org>/decopilot/stream` with a hand-rolled SSE parser.

Replace the dual binding/HTTP setup with a single client that constructs the same proxy `createAgentProxy` builds for resolved bindings — via `streamAgent` from `@decocms/runtime/decopilot`. Endpoint is now the canonical `/api/<org>/decopilot/runtime/stream`, wire format is AI SDK UIMessage chunks parsed by `readUIMessageStream`, and auth uses the persisted `meshApiKey` so it works even though the webhook has no runtime context. The thread-not-found retry was preserved (now triggered by the message of the `Error` `streamAgent` throws, instead of polling status codes).

**−229 LOC.** slack-mcp now behaves identically to a real binding caller.

## Test plan

- [ ] Send a DM → pod logs show `[LLM] streamAgent <meshUrl>/api/<org>/decopilot/runtime/stream (thread_id=<Name>)`.
- [ ] First DM from a new user → retry kicks in: `thread_id=<Name> failed (Thread not found...). Retrying with temp thread_id=<Name>-<ts>`.
- [ ] Bot replies correctly with the agent's response.
- [ ] No reference to the deprecated `/decopilot/stream` (no `runtime/` segment) in pod logs.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Slack AgentOf binding by routing all calls through `streamAgent` from `@decocms/runtime/decopilot`, matching runtime behavior and removing the dead HTTP fallback. All requests now hit the canonical /api/<org>/decopilot/runtime/stream with UIMessage chunks and persisted auth.

- **Bug Fixes**
  - AgentOf binding works from Slack webhooks by constructing a resolved agent client via `streamAgent` and using the stored `meshApiKey`.
  - Preserves the thread-not-found retry using the thrown error message instead of status polling.

- **Refactors**
  - Removed dual binding/HTTP paths and the custom SSE parser; all traffic goes through the runtime stream endpoint.
  - Simplified availability checks and client construction; net −229 LOC.

<sup>Written for commit 5a1667600ffb80503a02ca6e8ad4d3d14bc71a79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

