### PR TITLE
fix(slack): stop sending thread_id to decopilot — it rejects unknown ids

### DIFF
--- a/slack-mcp/server/llm.ts
+++ b/slack-mcp/server/llm.ts
@@ -69,50 +69,22 @@ async function getAgentClient(
 
   return {
     STREAM: async (params, opts) => {
-      const initialThreadId = params.thread_id;
-
-      try {
-        console.log(
-          `[LLM] streamAgent ${streamUrl} (thread_id=${initialThreadId ?? "none"})`,
-        );
-        return await streamAgent(streamUrl, token, agentConfig, params, opts);
-      } catch (err) {
-        // The decopilot endpoint does not auto-create threads — it returns
-        // an error like "Thread not found: <name>" (and also rejects with
-        // permission errors for threads owned by other principals). Retry
-        // once with a temp thread_id derived from the original.
-        if (initialThreadId && isThreadAccessFailure(err)) {
-          const tempThreadId = `${initialThreadId}-${Date.now()}`;
-          console.log(
-            `[LLM] thread_id=${initialThreadId} failed (${stringifyError(err).slice(0, 120)}). Retrying with temp thread_id=${tempThreadId}`,
-          );
-          return await streamAgent(
-            streamUrl,
-            token,
-            agentConfig,
-            { ...params, thread_id: tempThreadId },
-            opts,
-          );
-        }
-        throw err;
-      }
+      // We deliberately strip `thread_id` from the request: the decopilot
+      // endpoint does not auto-create threads — passing an unknown id (the
+      // user's name, a temp `<name>-<ts>`, anything not minted by studio)
+      // results in 500 "Thread not found". Without a thread_id, the
+      // decopilot allocates a fresh thread per call. Slack-side context
+      // is already rebuilt every webhook via `buildContextMessages`
+      // (channel/thread history → 1 system message), so the agent stays
+      // coherent within a conversation without depending on decopilot's
+      // own thread memory. Per-person decopilot memory would require us
+      // to call a thread-create API and cache the returned id — out of
+      // scope here.
+      const { thread_id: _ignored, ...rest } = params;
+      console.log(`[LLM] streamAgent ${streamUrl} (no thread_id)`);
+      return await streamAgent(streamUrl, token, agentConfig, rest, opts);
     },
   };
-}
-
-function stringifyError(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  return String(err);
-}
-
-function isThreadAccessFailure(err: unknown): boolean {
-  const message = stringifyError(err);
-  // `streamAgent` throws Error(message) where message is `body.error` (when
-  // the response was JSON) or the raw body text — see runtime/decopilot.ts.
-  // We match on the patterns the decopilot uses for thread access failures.
-  return /thread[^"]{0,40}(not[\s_-]?found|permission|forbidden|unauthor|access[\s_-]?denied|not[\s_-]?allowed)/i.test(
-    message,
-  );
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Follow-up to #435/#436. The temp-thread_id retry from #435 still fails in production with `Thread not found: <name>-<timestamp>` — the decopilot endpoint rejects **any** unknown thread_id, including the temp fallback. The retry just postponed the same error.

Drop `thread_id` from the request entirely. Without it, the decopilot allocates a fresh thread per call. The slack-mcp already rebuilds conversation context from Slack history on every webhook (`buildContextMessages` → 1 system message), so the agent stays coherent within a Slack thread/DM without depending on decopilot-side memory.

The `userName` → `threadId` plumbing is **kept** upstream in `llm-handler.ts` / `eventHandler.ts` so we can plug a real thread-create call (cached id per user) later if per-person decopilot memory becomes important.

## Test plan

- [ ] Send a DM → pod logs show `[LLM] streamAgent <url> (no thread_id)`.
- [ ] Bot replies on first message (no more 500 Thread-not-found).
- [ ] Slack thread context survives within a thread (verified by sending a 2nd message referencing the first — context comes from `buildContextMessages`, not decopilot memory).
- [ ] Unrelated agent failures still fall back to the trigger publish as before.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sending `thread_id` to decopilot to eliminate “Thread not found” errors; each call now creates a fresh decopilot thread while Slack-side context continues to be rebuilt per webhook.

- **Bug Fixes**
  - Strip `thread_id` before calling `streamAgent`; log now shows “(no thread_id)”.
  - Removed temp `thread_id` retry and access-failure heuristics to avoid repeated 500s.
  - Left upstream `userName` → `threadId` plumbing intact for a future thread-create flow.

<sup>Written for commit 160b632a0bcfd6f0334be0636a87f1faab8daa2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

