### PR TITLE
feat(slack): DM-per-thread + trigger payload with reply-in-thread contract

### DIFF
--- a/slack-mcp/server/lib/event-publisher.ts
+++ b/slack-mcp/server/lib/event-publisher.ts
@@ -3,48 +3,117 @@
  *
  * Publishes Slack events via trigger callbacks for cross-MCP integration.
  * Other MCPs can subscribe to these events to react to Slack activity.
+ *
+ * For message-style events (`slack.message.received` and `slack.app_mention`)
+ * we enrich the payload with:
+ * - `user_name`: the resolved Slack display name of the author, so the
+ *   subscriber doesn't have to call SLACK_GET_USER_INFO just to address
+ *   the user properly.
+ * - `thread_messages`: when the incoming event lives in a thread, the
+ *   full set of replies from that thread (oldest → newest, including the
+ *   parent and the bot's own prior replies). Lets a trigger-driven agent
+ *   see the entire conversation in one shot and answer coherently with
+ *   SLACK_REPLY_IN_THREAD without having to fetch history itself.
  */
 
 import type { SlackEvent } from "./types.ts";
 import { triggers } from "./trigger-store.ts";
+import { getThreadReplies, getUserInfo } from "./slack-client.ts";
 
-export function publishMessageReceived(
+interface ThreadMessageSummary {
+  ts: string;
+  user?: string;
+  text: string;
+  is_bot: boolean;
+}
+
+async function resolveUserName(
+  userId: string | undefined,
+): Promise<string | undefined> {
+  if (!userId) return undefined;
+  try {
+    const info = await getUserInfo(userId);
+    return (
+      info?.profile?.display_name || info?.real_name || info?.name || undefined
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+async function fetchThreadMessages(
+  channel: string | undefined,
+  threadTs: string | undefined,
+): Promise<ThreadMessageSummary[] | undefined> {
+  if (!channel || !threadTs) return undefined;
+  try {
+    const replies = await getThreadReplies(channel, threadTs);
+    return replies
+      .sort((a, b) => Number.parseFloat(a.ts) - Number.parseFloat(b.ts))
+      .map((m) => ({
+        ts: m.ts,
+        user: m.user,
+        text: m.text ?? "",
+        is_bot: Boolean(m.bot_id),
+      }));
+  } catch {
+    return undefined;
+  }
+}
+
+export async function publishMessageReceived(
   connectionId: string,
   event: SlackEvent,
-): void {
+  extras?: { fallback?: boolean },
+): Promise<void> {
+  const [user_name, thread_messages] = await Promise.all([
+    resolveUserName(event.user),
+    fetchThreadMessages(event.channel, event.thread_ts),
+  ]);
+
   triggers.notify(connectionId, "slack.message.received", {
     event: "slack.message.received",
     channel_id: event.channel,
     user_id: event.user,
+    user_name,
     text: event.text ?? "",
     ts: event.ts,
     thread_ts: event.thread_ts,
     is_dm:
       event.channel?.startsWith("D") || (event as any).channel_type === "im",
     has_files: !!(event as any).files?.length,
+    thread_messages,
     timestamp: new Date().toISOString(),
+    ...(extras?.fallback ? { fallback: true } : {}),
   });
   console.log(
-    `[Triggers] Notified slack.message.received: channel=${event.channel}`,
+    `[Triggers] Notified slack.message.received: channel=${event.channel}${thread_messages ? ` (${thread_messages.length} thread msgs)` : ""}`,
   );
 }
 
-export function publishAppMention(
+export async function publishAppMention(
   connectionId: string,
   event: SlackEvent,
-): void {
+): Promise<void> {
+  const [user_name, thread_messages] = await Promise.all([
+    resolveUserName(event.user),
+    fetchThreadMessages(event.channel, event.thread_ts),
+  ]);
+
   triggers.notify(connectionId, "slack.app_mention", {
     event: "slack.app_mention",
     channel_id: event.channel,
     user_id: event.user,
+    user_name,
     text: event.text ?? "",
     ts: event.ts,
     thread_ts: event.thread_ts,
     has_files: !!(event as any).files?.length,
+    thread_messages,
     timestamp: new Date().toISOString(),
   });
   console.log(
-    `[Triggers] Notified slack.app_mention: channel=${event.channel}`,
+    `[Triggers] Notified slack.app_mention: channel=${event.channel}${thread_messages ? ` (${thread_messages.length} thread msgs)` : ""}`,
   );
 }
 

--- a/slack-mcp/server/slack/handlers/eventHandler.ts
+++ b/slack-mcp/server/slack/handlers/eventHandler.ts
@@ -598,7 +598,22 @@ async function handleMessage(
   const mediaForLLM =
     transcriptions.length > 0 ? media.filter((m) => m.type === "image") : media;
 
-  if (isDM) {
+  // A DM that is a reply inside an existing thread continues in that thread;
+  // a fresh top-level DM starts a brand-new thread under the user's message
+  // (see handleDirectMessage). Channel messages only reach this branch when
+  // thread_ts is set AND the bot has participated in that thread.
+  if (isDM && thread_ts) {
+    await handleThreadReply(
+      channel,
+      user,
+      fullText,
+      ts,
+      thread_ts,
+      mediaForLLM,
+      teamConfig,
+      connectionId,
+    );
+  } else if (isDM) {
     await handleDirectMessage(
       channel,
       user,
@@ -646,16 +661,24 @@ async function handleDirectMessage(
     await addReaction(channel, ts, "eyes");
   }
 
+  // Every top-level DM kicks off a brand-new thread under the user's
+  // message — bot's thinking message and final reply both live inside that
+  // thread. Subsequent replies from the user in the thread continue there
+  // (handled by handleThreadReply), so each subject stays isolated.
+  const replyTo = ts;
+
   const showThinking = showOnlyFinal
     ? false
     : (teamConfig.responseConfig?.showThinkingMessage ?? true);
-  const thinkingMsg = showThinking ? await sendThinkingMessage(channel) : null;
+  const thinkingMsg = showThinking
+    ? await sendThinkingMessage(channel, replyTo)
+    : null;
 
   if (!showOnlyFinal) {
     await removeReaction(channel, ts, "eyes");
   }
 
-  // Resolve sender name (used both as a prefix for the LLM and as the thread_id)
+  // Resolve sender name (used as a prefix for the LLM context)
   const senderName = await resolveUserName(user);
   const senderText =
     senderName && senderName !== user
@@ -673,7 +696,7 @@ async function handleDirectMessage(
   if (!(await isLLMAvailable(connectionId))) {
     const warningMsg =
       "Bot ainda inicializando. Por favor, tente novamente em alguns segundos.";
-    await sendMessage({ channel, text: warningMsg });
+    await replyInThread(channel, replyTo, warningMsg);
     if (thinkingMsg?.ts) {
       await deleteMessage(channel, thinkingMsg.ts);
     }
@@ -687,6 +710,7 @@ async function handleDirectMessage(
   try {
     await handleLLMCall(connectionId, messages, {
       channel,
+      replyTo,
       thinkingMessageTs: thinkingMsg?.ts,
       streamingEnabled: enableStreaming,
       userName: senderName,

--- a/slack-mcp/server/slack/handlers/eventHandler.ts
+++ b/slack-mcp/server/slack/handlers/eventHandler.ts
@@ -406,7 +406,7 @@ export async function handleSlackEvent(
       // Publishing here AND running the LLM caused every message to be
       // answered twice (once by the LLM, once by the trigger subscriber).
       if (triggerOnly) {
-        publishAppMention(connectionId, payload);
+        await publishAppMention(connectionId, payload);
       } else {
         await handleAppMention(
           payload as SlackAppMentionEvent,
@@ -417,7 +417,7 @@ export async function handleSlackEvent(
       break;
     case "message":
       if (triggerOnly) {
-        publishMessageReceived(connectionId, payload);
+        await publishMessageReceived(connectionId, payload);
       } else {
         await handleMessage(
           payload as SlackMessageEvent,

--- a/slack-mcp/server/slack/handlers/llm-handler.ts
+++ b/slack-mcp/server/slack/handlers/llm-handler.ts
@@ -18,7 +18,7 @@ import {
   deleteMessage,
 } from "../../lib/slack-client.ts";
 import { formatForSlack, buildResponseBlocks } from "../../lib/format.ts";
-import { triggers } from "../../lib/trigger-store.ts";
+import { publishMessageReceived } from "../../lib/event-publisher.ts";
 import type { MessageWithImages } from "./context-builder.ts";
 import { logger } from "../../lib/logger.ts";
 
@@ -246,20 +246,25 @@ export async function handleLLMCall(
         await deleteMessage(channel, thinkingMessageTs).catch(() => {});
       }
 
-      const isDM = channel.startsWith("D") || slackEvent.channel_type === "im";
-
-      triggers.notify(connectionId, "slack.message.received", {
-        event: "slack.message.received",
-        channel_id: channel,
-        user_id: slackEvent.user,
-        text: slackEvent.text,
-        ts: slackEvent.ts,
-        thread_ts: slackEvent.thread_ts,
-        is_dm: isDM,
-        has_files: false,
-        timestamp: new Date().toISOString(),
-        fallback: true,
-      });
+      // Reuse the standard publisher so the subscriber gets the same
+      // enriched payload (user_name, thread_messages, etc.) as the
+      // triggerOnly mode would deliver.
+      await publishMessageReceived(
+        connectionId,
+        {
+          type: "message",
+          event_ts: slackEvent.ts,
+          channel,
+          user: slackEvent.user,
+          text: slackEvent.text,
+          ts: slackEvent.ts,
+          thread_ts: slackEvent.thread_ts,
+          ...(slackEvent.channel_type
+            ? { channel_type: slackEvent.channel_type }
+            : {}),
+        } as Parameters<typeof publishMessageReceived>[1],
+        { fallback: true },
+      );
 
       // Don't throw — the trigger will handle the response
       return;


### PR DESCRIPTION
## Summary

Three changes that make Slack threads work end-to-end for both the direct LLM path **and** the trigger-driven agent path.

### 1. Start a new thread on every DM
- `handleDirectMessage` now uses the user's message `ts` as `thread_ts` for the bot's thinking message and final reply.
- `handleMessage` routes DMs with `thread_ts` to `handleThreadReply` instead of `handleDirectMessage` — fixes the previous `isDM` short-circuit that ignored `thread_ts`.

### 2. Enrich the trigger payload
`publishMessageReceived` / `publishAppMention` are now async and bake in:
- **`user_name`**: `display_name → real_name → name`, resolved via `getUserInfo`.
- **`thread_messages`**: when the event lives in a thread, the full ordered list of `{ts, user, text, is_bot}` from `getThreadReplies` — the agent sees the whole conversation in one shot.

The fallback path in `llm-handler.ts` now reuses `publishMessageReceived({ fallback: true })` instead of duplicating `triggers.notify` inline, so trigger-only mode and fallback mode deliver the same enriched payload.

### 3. Tell the agent exactly how to reply
The previous version still left it to the subscriber to derive the right `thread_ts`. For a top-level DM event, `thread_ts` is undefined — the agent couldn't figure out where to reply.

- New field **`reply_in_thread_ts = event.thread_ts ?? event.ts`** is computed by the publisher. For thread continuations it's the existing thread; for top-level messages it's the message's own ts, which kicks off a new thread the moment the bot replies. The agent never has to decide start-vs-continue.
- New field **`reply_instruction`**: a one-line directive spelling out the exact `SLACK_REPLY_IN_THREAD(channel, thread_ts, text)` tool call.
- Updated **trigger definitions** in `trigger-store.ts` so the description embedded in studio's UI tells the agent: *"To respond, ALWAYS call SLACK_REPLY_IN_THREAD with channel=channel_id and thread_ts=reply_in_thread_ts"*.

## Tools the agent already has

No new tools needed. Existing slack-mcp tools cover the workflow:
- `SLACK_REPLY_IN_THREAD(channel, thread_ts, text)` — primary action.
- `SLACK_SEND_MESSAGE(channel, text, thread_ts?)` — alternative.

## Test plan

- [ ] Send a top-level DM → bot replies in a thread under that message.
- [ ] Send a 2nd top-level DM → separate thread, prior one untouched.
- [ ] Reply inside an existing bot thread → continues in same thread.
- [ ] `triggerOnly` mode: subscriber receives `reply_in_thread_ts` populated even on first message.
- [ ] Trigger subscriber agent uses `SLACK_REPLY_IN_THREAD(channel_id, reply_in_thread_ts, ...)` and the answer appears in the right thread.
- [ ] `thread_messages` carries the full history on follow-up messages.
- [ ] @mention in a channel still threads (no regression).
