### PR TITLE
feat(slack): tell trigger agent to always reply in the user's thread

### DIFF
--- a/slack-mcp/server/lib/event-publisher.ts
+++ b/slack-mcp/server/lib/event-publisher.ts
@@ -61,6 +61,39 @@ async function fetchThreadMessages(
   }
 }
 
+/**
+ * The thread_ts the agent must use when replying.
+ *
+ * - If the user message is already inside a thread → that thread's ts.
+ * - If the user message is top-level → its own ts, which starts a new
+ *   thread under it (Slack's "first reply with thread_ts=parent" rule).
+ *
+ * Pre-computing this on the publisher side guarantees that the agent
+ * NEVER has to decide whether to start or continue a thread — every
+ * reply is anchored to a single thread per subject.
+ */
+function replyInThreadTs(event: SlackEvent): string | undefined {
+  return event.thread_ts ?? event.ts;
+}
+
+/**
+ * Reply instruction baked into the trigger payload so a trigger-driven
+ * agent knows exactly how to respond without prompt engineering on the
+ * subscriber side.
+ */
+function buildReplyInstruction(
+  channelId: string | undefined,
+  threadTs: string | undefined,
+): string {
+  return [
+    "When you respond, ALWAYS call the SLACK_REPLY_IN_THREAD tool with:",
+    `  channel = "${channelId ?? ""}"`,
+    `  thread_ts = "${threadTs ?? ""}"`,
+    "Never send a top-level message — every reply must live in this thread",
+    "so each subject stays isolated.",
+  ].join("\n");
+}
+
 export async function publishMessageReceived(
   connectionId: string,
   event: SlackEvent,
@@ -71,6 +104,8 @@ export async function publishMessageReceived(
     fetchThreadMessages(event.channel, event.thread_ts),
   ]);
 
+  const reply_in_thread_ts = replyInThreadTs(event);
+
   triggers.notify(connectionId, "slack.message.received", {
     event: "slack.message.received",
     channel_id: event.channel,
@@ -79,6 +114,8 @@ export async function publishMessageReceived(
     text: event.text ?? "",
     ts: event.ts,
     thread_ts: event.thread_ts,
+    reply_in_thread_ts,
+    reply_instruction: buildReplyInstruction(event.channel, reply_in_thread_ts),
     is_dm:
       event.channel?.startsWith("D") || (event as any).channel_type === "im",
     has_files: !!(event as any).files?.length,
@@ -100,6 +137,8 @@ export async function publishAppMention(
     fetchThreadMessages(event.channel, event.thread_ts),
   ]);
 
+  const reply_in_thread_ts = replyInThreadTs(event);
+
   triggers.notify(connectionId, "slack.app_mention", {
     event: "slack.app_mention",
     channel_id: event.channel,
@@ -108,6 +147,8 @@ export async function publishAppMention(
     text: event.text ?? "",
     ts: event.ts,
     thread_ts: event.thread_ts,
+    reply_in_thread_ts,
+    reply_instruction: buildReplyInstruction(event.channel, reply_in_thread_ts),
     has_files: !!(event as any).files?.length,
     thread_messages,
     timestamp: new Date().toISOString(),

--- a/slack-mcp/server/lib/trigger-store.ts
+++ b/slack-mcp/server/lib/trigger-store.ts
@@ -44,7 +44,13 @@ export const triggers = createTriggers({
   definitions: [
     {
       type: "slack.message.received",
-      description: "Triggered when a message is sent in a Slack channel or DM",
+      description:
+        "Triggered when a message is sent in a Slack channel or DM. " +
+        "The payload carries `channel_id`, `reply_in_thread_ts`, `text`, " +
+        "`user_name`, and (when applicable) `thread_messages` with the full " +
+        "thread history. To respond, ALWAYS call SLACK_REPLY_IN_THREAD with " +
+        "channel=channel_id and thread_ts=reply_in_thread_ts so every answer " +
+        "lives inside the user's thread and each subject stays isolated.",
       params: z.object({
         channel_id: z
           .string()
@@ -58,7 +64,13 @@ export const triggers = createTriggers({
     },
     {
       type: "slack.app_mention",
-      description: "Triggered when the bot is mentioned with @",
+      description:
+        "Triggered when the bot is @mentioned in a channel. The payload " +
+        "carries `channel_id`, `reply_in_thread_ts`, `text`, `user_name`, " +
+        "and (when applicable) `thread_messages`. To respond, ALWAYS call " +
+        "SLACK_REPLY_IN_THREAD with channel=channel_id and " +
+        "thread_ts=reply_in_thread_ts so the answer lives inside the user's " +
+        "thread.",
       params: z.object({
         channel_id: z
           .string()


### PR DESCRIPTION
## Summary

Follow-up to #439. Even with `thread_messages` and `user_name` in the trigger payload, the subscriber had no explicit signal saying which `thread_ts` to use when replying — and for a fresh top-level DM `event.thread_ts` is `undefined`, so the agent could not derive it from the event alone.

Bake the reply contract into both the payload and the trigger definition:

- **`reply_in_thread_ts = event.thread_ts ?? event.ts`** is now computed by the publisher. For thread continuations it's the existing thread; for top-level messages it's the message's own ts, which kicks off a new thread the moment the bot replies. The agent never has to decide *start-vs-continue*.
- **`reply_instruction`**: a one-line natural-language directive spelling out the exact `SLACK_REPLY_IN_THREAD(channel, thread_ts)` tool call, so prompt-driven subscribers see the contract inline.
- **Trigger definitions** in `trigger-store.ts` now embed the contract in the description that studio (and any agent reading the schema) sees: *"To respond, ALWAYS call SLACK_REPLY_IN_THREAD with channel=channel_id and thread_ts=reply_in_thread_ts so every answer lives inside the user's thread."*

## Test plan

- [ ] In `triggerOnly` mode, send a top-level DM → `reply_in_thread_ts` in the payload equals `event.ts`.
- [ ] Reply inside the bot's thread → `reply_in_thread_ts` equals the thread's `thread_ts`.
- [ ] Trigger subscriber agent uses `SLACK_REPLY_IN_THREAD(channel_id, reply_in_thread_ts, ...)` and the reply appears in the right thread.
- [ ] Studio shows the updated trigger description.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Slack agents always reply in the user’s thread. Adds `reply_in_thread_ts` and a `reply_instruction` to trigger payloads and documents the contract in trigger descriptions.

- **New Features**
  - Compute `reply_in_thread_ts = event.thread_ts ?? event.ts` for `slack.message.received` and `slack.app_mention`, so agents never decide start vs continue.
  - Include `reply_instruction` that spells the exact `SLACK_REPLY_IN_THREAD(channel_id, reply_in_thread_ts)` call.
  - Update trigger descriptions to document the reply contract and keep all answers in the user’s thread.

<sup>Written for commit 78bd494718cf4fae02d00e23ef6ea56c49d41509. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

