### PR TITLE
fix(microsoft-teams): rename public host to graph-mcp.decocms.com

### DIFF
--- a/microsoft-teams/app.json
+++ b/microsoft-teams/app.json
@@ -4,7 +4,7 @@
   "friendlyName": "Microsoft Teams",
   "connection": {
     "type": "HTTP",
-    "url": "https://microsoft-teams-mcp.decocms.com/mcp"
+    "url": "https://graph-mcp.decocms.com/mcp"
   },
   "description": "Microsoft Teams integration — send channel and private chat messages, manage meetings, and trigger agents on new Teams messages via the Microsoft Graph API.",
   "icon": "https://upload.wikimedia.org/wikipedia/commons/9/94/Microsoft_Office_Teams_%282019%E2%80%932025%29.svg",

--- a/microsoft-teams/server/tools/subscriptions.ts
+++ b/microsoft-teams/server/tools/subscriptions.ts
@@ -88,8 +88,7 @@ function getConnectionId(env: Env): string {
 }
 
 function buildNotificationUrl(connectionId: string): string {
-  const base =
-    process.env.SERVER_PUBLIC_URL ?? `https://graph-mcp.decocms.com`;
+  const base = process.env.SERVER_PUBLIC_URL ?? `https://graph-mcp.decocms.com`;
   return `${base.replace(/\/$/, "")}/teams/notifications/${connectionId}`;
 }
 

--- a/microsoft-teams/server/tools/subscriptions.ts
+++ b/microsoft-teams/server/tools/subscriptions.ts
@@ -89,7 +89,7 @@ function getConnectionId(env: Env): string {
 
 function buildNotificationUrl(connectionId: string): string {
   const base =
-    process.env.SERVER_PUBLIC_URL ?? `https://microsoft-teams-mcp.decocms.com`;
+    process.env.SERVER_PUBLIC_URL ?? `https://graph-mcp.decocms.com`;
   return `${base.replace(/\/$/, "")}/teams/notifications/${connectionId}`;
 }
 

--- a/microsoft-teams/server/types/env.ts
+++ b/microsoft-teams/server/types/env.ts
@@ -16,9 +16,7 @@ export const StateSchema = z.object({
   // Webhook URL shown to the user so they know where Graph notifications land
   WEBHOOK_URL: z
     .string()
-    .default(
-      "https://graph-mcp.decocms.com/teams/notifications/{connectionId}",
-    )
+    .default("https://graph-mcp.decocms.com/teams/notifications/{connectionId}")
     .readonly()
     .describe(
       "Endpoint where Microsoft Graph change notifications are delivered. When developing locally, expose this via ngrok.",

--- a/microsoft-teams/server/types/env.ts
+++ b/microsoft-teams/server/types/env.ts
@@ -17,7 +17,7 @@ export const StateSchema = z.object({
   WEBHOOK_URL: z
     .string()
     .default(
-      "https://microsoft-teams-mcp.decocms.com/teams/notifications/{connectionId}",
+      "https://graph-mcp.decocms.com/teams/notifications/{connectionId}",
     )
     .readonly()
     .describe(

--- a/microsoft-teams/wrangler.toml
+++ b/microsoft-teams/wrangler.toml
@@ -4,7 +4,7 @@ compatibility_date = "2025-06-17"
 compatibility_flags = ["nodejs_compat"]
 
 routes = [
-  { pattern = "microsoft-teams-mcp.decocms.com", custom_domain = true },
+  { pattern = "graph-mcp.decocms.com", custom_domain = true },
 ]
 
 [observability]


### PR DESCRIPTION
## Summary
- Azure AD rejected `https://microsoft-teams-mcp.decocms.com/oauth/callback` with *"Your reply url contains prohibited words or prohibited domains"* — the filter blocks brand tokens like `microsoft` and `teams` in the host, and the old subdomain contained both
- Rename the MCP's public host to `graph-mcp.decocms.com` (references Microsoft Graph without using the trademarked word). Worker name, package name, and log service id are left as `microsoft-teams-mcp` since those don't affect the URL filter and renaming the worker would orphan the `TEAMS_KV` binding
- Updated: `wrangler.toml` custom-domain route, `app.json` connection URL, `WEBHOOK_URL` default in `env.ts`, and `SERVER_PUBLIC_URL` fallback in `subscriptions.ts`

## Out-of-repo follow-up
- Add `graph-mcp.decocms.com` CNAME in the `decocms.com` Cloudflare zone (the route in `wrangler.toml` provisions the custom-domain binding on next `wrangler deploy`)
- In the Azure AD app registration: Authentication → Web → register `https://graph-mcp.decocms.com/oauth/callback`

## Test plan
- [ ] `wrangler deploy` provisions the new custom domain
- [ ] Azure AD accepts `https://graph-mcp.decocms.com/oauth/callback` as a reply URL
- [ ] "Connect to Microsoft" OAuth flow completes end-to-end on the new host
- [ ] Re-running `subscribe_to_channel` produces a Graph subscription whose `notificationUrl` points at the new host, and a test message in that channel fires the `teams.message.received` trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the Teams MCP public host to `graph-mcp.decocms.com` to bypass Azure AD’s reply URL filter. Updated the connection URL, default `WEBHOOK_URL`, and `SERVER_PUBLIC_URL` fallback so OAuth and Graph subscriptions use the new domain.

- **Migration**
  - Add a `graph-mcp.decocms.com` CNAME in the `decocms.com` Cloudflare zone.
  - In Azure AD, add `https://graph-mcp.decocms.com/oauth/callback` as a reply URL.

<sup>Written for commit 2fbd2bd30f70cc0a084b3c5b3aa4cac95f1b4be5. Summary will update on new commits. <a href="https://cubic.dev/pr/decocms/mcps/pull/445?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

