### PR TITLE
feat(github): add MINT_REPO_TOKEN repo-scoped token tool

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -327,7 +327,7 @@
       "name": "github-repo-reports",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "1.2.5",
+        "@decocms/runtime": "^1.6.0",
         "@octokit/rest": "^22.0.1",
         "yaml": "^2.8.2",
         "zod": "^4.0.0",
@@ -4146,7 +4146,7 @@
 
     "github/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "github-repo-reports/@decocms/runtime": ["@decocms/runtime@1.2.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.1.1", "@modelcontextprotocol/sdk": "1.25.2", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-0s02lfj/O7nTAc7FTmFsA+lZpUDnapjQHnRYrQXItLKrbJvjSnfoq5V8HA1Npv5HelBvsVk7QQHaW8pSN/l37w=="],
+    "github-repo-reports/@decocms/runtime": ["@decocms/runtime@1.6.2", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-Z38pLHDoJOfiZVOfQgnfyK24vVV/m8MOm8dXB0dvkIM6yp31JNmW88t3d5hw6P5FYr9TvpvKxQE9uWEeCeN8QQ=="],
 
     "github-repo-reports/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
@@ -4668,9 +4668,7 @@
 
     "gemini-pro-vision/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
-    "github-repo-reports/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.2.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.25.3", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-+4/VOOVERB8UixGKmN0VkLazxeMAahbG0A9xOYTPL+MJIAM30htrLG2aHI2Dm5ASgccAD4bW5RuLqv2PDFZZPA=="],
-
-    "github-repo-reports/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
+    "github-repo-reports/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.4.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "1.27.1", "@tanstack/react-router": "1.139.7", "react": "^19.2.0", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-olUAzaV/lAaBLW5Z+sedJtms3vbUOL9WYXOU2Wkh311Kk1LBOuQmbJrVNVZH4yj8j2UVWxFVPcjkT9gxAC0zdw=="],
 
     "github-repo-reports/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 
@@ -5221,8 +5219,6 @@
     "gemini-pro-vision/@decocms/runtime/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "gemini-pro-vision/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "github-repo-reports/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "google-apps-script/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 

--- a/github-repo-reports/package.json
+++ b/github-repo-reports/package.json
@@ -11,7 +11,7 @@
     "build": "bun run build:server"
   },
   "dependencies": {
-    "@decocms/runtime": "1.2.5",
+    "@decocms/runtime": "^1.6.0",
     "@octokit/rest": "^22.0.1",
     "yaml": "^2.8.2",
     "zod": "^4.0.0"

--- a/github/server/lib/github-app-auth.test.ts
+++ b/github/server/lib/github-app-auth.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  GitHubAppApiError,
+  mintInstallationAccessToken,
+} from "./github-app-auth.ts";
+
+const realFetch = globalThis.fetch;
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("mintInstallationAccessToken", () => {
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  test("POSTs to the access_tokens endpoint with the App JWT and maps the response", async () => {
+    let seenUrl = "";
+    let seenInit: {
+      method?: string;
+      headers?: Record<string, string>;
+      body?: string;
+    } = {};
+    globalThis.fetch = (async (input: unknown, init: unknown) => {
+      seenUrl =
+        typeof input === "string" ? input : (input as { url: string }).url;
+      seenInit = init as typeof seenInit;
+      return json(
+        {
+          token: "ghs_x",
+          expires_at: "2026-01-01T00:00:00Z",
+          permissions: { contents: "write", metadata: "read" },
+          repositories: [{ id: 1, name: "web", full_name: "acme/web" }],
+        },
+        201,
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    const result = await mintInstallationAccessToken(
+      42,
+      { repository_ids: [1], permissions: { contents: "write" } },
+      "fake.jwt",
+    );
+
+    expect(seenUrl).toBe(
+      "https://api.github.com/app/installations/42/access_tokens",
+    );
+    expect(seenInit.method).toBe("POST");
+    expect(seenInit.headers?.Authorization).toBe("Bearer fake.jwt");
+    expect(JSON.parse(seenInit.body ?? "{}")).toEqual({
+      repository_ids: [1],
+      permissions: { contents: "write" },
+    });
+    expect(result.token).toBe("ghs_x");
+    expect(result.expires_at).toBe("2026-01-01T00:00:00Z");
+    expect(result.permissions).toEqual({ contents: "write", metadata: "read" });
+  });
+
+  test("throws GitHubAppApiError carrying the status on 422", async () => {
+    globalThis.fetch = (async () =>
+      json(
+        { message: "repo not in installation" },
+        422,
+      )) as unknown as typeof globalThis.fetch;
+
+    let caught: unknown;
+    try {
+      await mintInstallationAccessToken(42, {}, "fake.jwt");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(GitHubAppApiError);
+    expect((caught as GitHubAppApiError).status).toBe(422);
+  });
+
+  test("throws GitHubAppApiError carrying the status on 404", async () => {
+    globalThis.fetch = (async () =>
+      new Response("not found", {
+        status: 404,
+      })) as unknown as typeof globalThis.fetch;
+
+    let caught: unknown;
+    try {
+      await mintInstallationAccessToken(99, {}, "fake.jwt");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(GitHubAppApiError);
+    expect((caught as GitHubAppApiError).status).toBe(404);
+  });
+
+  test("throws GitHubAppApiError on 401 (bad JWT)", async () => {
+    globalThis.fetch = (async () =>
+      json(
+        { message: "A JSON web token could not be decoded" },
+        401,
+      )) as unknown as typeof globalThis.fetch;
+
+    let caught: unknown;
+    try {
+      await mintInstallationAccessToken(42, {}, "fake.jwt");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(GitHubAppApiError);
+    expect((caught as GitHubAppApiError).status).toBe(401);
+  });
+});

--- a/github/server/lib/github-app-auth.ts
+++ b/github/server/lib/github-app-auth.ts
@@ -91,7 +91,7 @@ function base64url(data: Buffer | string): string {
  * Create a JWT signed with the GitHub App's private key (RS256).
  * Valid for 10 minutes (GitHub's maximum).
  */
-function createAppJWT(): string {
+export function createAppJWT(): string {
   const appId = process.env.GITHUB_APP_ID || "";
   const privateKey = normalizePrivateKey(process.env.GITHUB_PRIVATE_KEY || "");
 
@@ -140,8 +140,93 @@ function createAppJWT(): string {
 }
 
 /**
+ * Error thrown when the GitHub App REST API rejects a request. Carries the
+ * HTTP status so callers can map it to a clear, leak-free error (e.g. 422 →
+ * "repo not in installation", 401/403 → internal config error). The upstream
+ * `message` is attached for diagnostics but callers must decide whether it is
+ * safe to surface (it is not for 401/403).
+ */
+export class GitHubAppApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "GitHubAppApiError";
+  }
+}
+
+export interface MintedInstallationToken {
+  token: string;
+  expires_at: string;
+  permissions: Record<string, string>;
+  repositories?: Array<{ id: number; name: string; full_name: string }>;
+}
+
+/**
+ * Mint an installation access token for the GitHub App.
+ *
+ * An empty body mints an installation-wide token (all repos, all granted
+ * permissions). Pass `repository_ids`/`repositories` + `permissions` to scope
+ * it down to least privilege. GitHub itself enforces that the repositories
+ * belong to the installation and that the permissions are a subset of the
+ * App's grant (422 otherwise).
+ *
+ * The signing JWT defaults to a freshly minted App JWT but can be injected for
+ * testing. Non-2xx responses throw `GitHubAppApiError` carrying the HTTP
+ * status. The minted token only ever appears in a 2xx body, so it is never
+ * included in a thrown error.
+ */
+export async function mintInstallationAccessToken(
+  installationId: number,
+  body: {
+    repositories?: string[];
+    repository_ids?: number[];
+    permissions?: Record<string, string>;
+  } = {},
+  jwt: string = createAppJWT(),
+): Promise<MintedInstallationToken> {
+  const res = await fetch(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+        "User-Agent": "deco-cms-github-mcp",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+
+  if (!res.ok) {
+    let detail = "";
+    try {
+      const parsed = (await res.json()) as { message?: string };
+      detail = parsed?.message ?? "";
+    } catch {
+      // Non-JSON error body — ignore.
+    }
+    throw new GitHubAppApiError(
+      res.status,
+      detail || `GitHub App token request failed: ${res.status}`,
+    );
+  }
+
+  const data = (await res.json()) as MintedInstallationToken;
+  return {
+    token: data.token,
+    expires_at: data.expires_at,
+    permissions: data.permissions ?? {},
+    repositories: data.repositories,
+  };
+}
+
+/**
  * Get an installation access token for the GitHub App.
- * Picks the first available installation.
+ * Picks the first available installation. Used for upstream tool discovery.
  */
 export async function getAppInstallationToken(): Promise<string> {
   const jwt = createAppJWT();
@@ -176,29 +261,10 @@ export async function getAppInstallationToken(): Promise<string> {
     );
   }
 
-  const installationId = installations[0].id;
-
-  // Create installation access token
-  const tokenRes = await fetch(
-    `https://api.github.com/app/installations/${installationId}/access_tokens`,
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${jwt}`,
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-        "User-Agent": "deco-cms-github-mcp",
-      },
-    },
+  const minted = await mintInstallationAccessToken(
+    installations[0].id,
+    {},
+    jwt,
   );
-
-  if (!tokenRes.ok) {
-    const text = await tokenRes.text();
-    throw new Error(
-      `Failed to create installation token: ${tokenRes.status} — ${text}`,
-    );
-  }
-
-  const data = (await tokenRes.json()) as { token: string };
-  return data.token;
+  return minted.token;
 }

--- a/github/server/lib/mcp-proxy.ts
+++ b/github/server/lib/mcp-proxy.ts
@@ -10,7 +10,7 @@
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { createTool, type AppContext } from "@decocms/runtime/tools";
+import { createTool } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../types/env.ts";
 import { getAppInstallationToken } from "./github-app-auth.ts";
@@ -158,7 +158,7 @@ export function buildUpstreamTools(
       description: toolDef.description || `GitHub tool: ${toolDef.name}`,
       inputSchema: jsonSchemaToZod(toolDef.inputSchema as any),
       execute: async ({ context }, ctx) => {
-        const env = (ctx as unknown as AppContext<Env>).env;
+        const env = (ctx as unknown as { env: Env }).env;
         const currentToken = env.MESH_REQUEST_CONTEXT?.authorization;
         const connectionId = env.MESH_REQUEST_CONTEXT?.connectionId;
         if (!currentToken) {

--- a/github/server/lib/repo-token.test.ts
+++ b/github/server/lib/repo-token.test.ts
@@ -1,0 +1,541 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { GitHubAppApiError } from "./github-app-auth.ts";
+import {
+  authorizeAndResolveRepoId,
+  capPermissions,
+  DEFAULT_PERMISSIONS,
+  mapMintError,
+  mintRepoScopedToken,
+  RepoTokenError,
+} from "./repo-token.ts";
+
+const realFetch = globalThis.fetch;
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+type AnyFetch = (input: unknown, init?: unknown) => Promise<Response>;
+function setFetch(impl: AnyFetch) {
+  globalThis.fetch = impl as unknown as typeof globalThis.fetch;
+}
+function urlOf(input: unknown): string {
+  return typeof input === "string" ? input : (input as { url: string }).url;
+}
+
+async function expectRejectCode(
+  fn: () => Promise<unknown>,
+  code: RepoTokenError["code"],
+): Promise<RepoTokenError> {
+  let caught: unknown;
+  try {
+    await fn();
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeInstanceOf(RepoTokenError);
+  expect((caught as RepoTokenError).code).toBe(code);
+  return caught as RepoTokenError;
+}
+
+// ============================================================================
+// capPermissions — least-privilege capping
+// ============================================================================
+
+describe("capPermissions", () => {
+  test("returns the default coding-agent permissions when none provided", () => {
+    expect(capPermissions(undefined)).toEqual(DEFAULT_PERMISSIONS);
+    expect(capPermissions({})).toEqual(DEFAULT_PERMISSIONS);
+  });
+
+  test("passes through an allowed subset and always includes metadata:read", () => {
+    expect(capPermissions({ contents: "read" })).toEqual({
+      contents: "read",
+      metadata: "read",
+    });
+    expect(capPermissions({ issues: "write" })).toEqual({
+      issues: "write",
+      metadata: "read",
+    });
+  });
+
+  test("forces metadata to read even if write is requested", () => {
+    expect(capPermissions({ metadata: "write" })).toEqual({ metadata: "read" });
+  });
+
+  test.each([
+    "administration",
+    "members",
+    "organization_administration",
+    "secrets",
+    "actions",
+    "environments",
+    "deployments",
+  ])("hard-rejects the disallowed permission %s", (perm) => {
+    let caught: unknown;
+    try {
+      capPermissions({ [perm]: "read" });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(RepoTokenError);
+    expect((caught as RepoTokenError).code).toBe("permission_denied");
+  });
+
+  test("rejects the admin permission level even for an allowed key", () => {
+    let caught: unknown;
+    try {
+      capPermissions({ contents: "admin" });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(RepoTokenError);
+    expect((caught as RepoTokenError).code).toBe("permission_denied");
+  });
+});
+
+// ============================================================================
+// authorizeAndResolveRepoId — the security gate + rename-proof id resolution
+// ============================================================================
+
+describe("authorizeAndResolveRepoId", () => {
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  function mockGitHub(opts: {
+    installations?: Array<{ id: number; account: { login: string } }> | "401";
+    repositories?: Record<
+      number,
+      Array<{ id: number; name: string; owner: { login: string } }>
+    >;
+  }) {
+    setFetch(async (input) => {
+      const url = urlOf(input);
+      const repoMatch = url.match(/\/user\/installations\/(\d+)\/repositories/);
+      if (repoMatch) {
+        const id = Number(repoMatch[1]);
+        const repos = (opts.repositories ?? {})[id] ?? [];
+        return json({ total_count: repos.length, repositories: repos });
+      }
+      if (url.includes("/user/installations")) {
+        if (opts.installations === "401") {
+          return new Response("bad credentials", { status: 401 });
+        }
+        const insts = opts.installations ?? [];
+        return json({ total_count: insts.length, installations: insts });
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+  }
+
+  test("returns the repo id when the caller is entitled to installation + repo", async () => {
+    mockGitHub({
+      installations: [{ id: 42, account: { login: "acme" } }],
+      repositories: {
+        42: [{ id: 999, name: "web", owner: { login: "acme" } }],
+      },
+    });
+    const id = await authorizeAndResolveRepoId({
+      callerToken: "ghu_x",
+      installationId: 42,
+      owner: "acme",
+      repo: "web",
+    });
+    expect(id).toBe(999);
+  });
+
+  test("throws unauthorized_caller when the installation is not in the caller's list", async () => {
+    mockGitHub({
+      installations: [{ id: 1, account: { login: "acme" } }],
+      repositories: {},
+    });
+    await expectRejectCode(
+      () =>
+        authorizeAndResolveRepoId({
+          callerToken: "ghu_x",
+          installationId: 42,
+          owner: "acme",
+          repo: "web",
+        }),
+      "unauthorized_caller",
+    );
+  });
+
+  test("throws unauthorized_caller when the installation belongs to a different owner", async () => {
+    mockGitHub({
+      installations: [{ id: 42, account: { login: "evil" } }],
+      repositories: { 42: [{ id: 5, name: "web", owner: { login: "evil" } }] },
+    });
+    await expectRejectCode(
+      () =>
+        authorizeAndResolveRepoId({
+          callerToken: "ghu_x",
+          installationId: 42,
+          owner: "acme",
+          repo: "web",
+        }),
+      "unauthorized_caller",
+    );
+  });
+
+  test("throws repo_not_accessible when the repo is not in the installation", async () => {
+    mockGitHub({
+      installations: [{ id: 42, account: { login: "acme" } }],
+      repositories: {
+        42: [{ id: 1, name: "other", owner: { login: "acme" } }],
+      },
+    });
+    await expectRejectCode(
+      () =>
+        authorizeAndResolveRepoId({
+          callerToken: "ghu_x",
+          installationId: 42,
+          owner: "acme",
+          repo: "web",
+        }),
+      "repo_not_accessible",
+    );
+  });
+
+  test("matches owner and repo case-insensitively", async () => {
+    mockGitHub({
+      installations: [{ id: 42, account: { login: "Acme" } }],
+      repositories: { 42: [{ id: 7, name: "Web", owner: { login: "Acme" } }] },
+    });
+    const id = await authorizeAndResolveRepoId({
+      callerToken: "ghu_x",
+      installationId: 42,
+      owner: "acme",
+      repo: "web",
+    });
+    expect(id).toBe(7);
+  });
+
+  test("throws unauthorized_caller when the caller token is rejected (401)", async () => {
+    mockGitHub({ installations: "401" });
+    await expectRejectCode(
+      () =>
+        authorizeAndResolveRepoId({
+          callerToken: "bad",
+          installationId: 42,
+          owner: "acme",
+          repo: "web",
+        }),
+      "unauthorized_caller",
+    );
+  });
+
+  test("throws unauthorized_caller when no caller token is supplied", async () => {
+    let called = false;
+    setFetch(async () => {
+      called = true;
+      return json({ installations: [] });
+    });
+    await expectRejectCode(
+      () =>
+        authorizeAndResolveRepoId({
+          callerToken: "",
+          installationId: 42,
+          owner: "acme",
+          repo: "web",
+        }),
+      "unauthorized_caller",
+    );
+    expect(called).toBe(false);
+  });
+
+  test("resolves a repo id found on a later page", async () => {
+    setFetch(async (input) => {
+      const url = urlOf(input);
+      if (/\/user\/installations\/42\/repositories/.test(url)) {
+        const page = Number(new URL(url).searchParams.get("page"));
+        if (page === 1) {
+          const repos = Array.from({ length: 100 }, (_, i) => ({
+            id: i + 1,
+            name: `r${i}`,
+            owner: { login: "acme" },
+          }));
+          return json({ total_count: 101, repositories: repos });
+        }
+        return json({
+          total_count: 101,
+          repositories: [{ id: 5000, name: "web", owner: { login: "acme" } }],
+        });
+      }
+      if (url.includes("/user/installations")) {
+        return json({
+          total_count: 1,
+          installations: [{ id: 42, account: { login: "acme" } }],
+        });
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+    const id = await authorizeAndResolveRepoId({
+      callerToken: "ghu_x",
+      installationId: 42,
+      owner: "acme",
+      repo: "web",
+    });
+    expect(id).toBe(5000);
+  });
+
+  test("classifies a 5xx on /user/installations as transient upstream_error, not a denial", async () => {
+    setFetch(async (input) => {
+      const url = urlOf(input);
+      if (url.includes("/user/installations")) {
+        return new Response("upstream down", { status: 503 });
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+    await expectRejectCode(
+      () =>
+        authorizeAndResolveRepoId({
+          callerToken: "ghu_x",
+          installationId: 42,
+          owner: "acme",
+          repo: "web",
+        }),
+      "upstream_error",
+    );
+  });
+
+  test("classifies a 403 secondary-rate-limit on the gate as upstream_error, not a denial", async () => {
+    setFetch(async (input) => {
+      const url = urlOf(input);
+      if (url.includes("/user/installations")) {
+        return new Response("rate limited", {
+          status: 403,
+          headers: { "x-ratelimit-remaining": "0", "retry-after": "60" },
+        });
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+    await expectRejectCode(
+      () =>
+        authorizeAndResolveRepoId({
+          callerToken: "ghu_x",
+          installationId: 42,
+          owner: "acme",
+          repo: "web",
+        }),
+      "upstream_error",
+    );
+  });
+
+  test("classifies a 5xx on the repositories endpoint as transient upstream_error", async () => {
+    setFetch(async (input) => {
+      const url = urlOf(input);
+      if (/\/user\/installations\/42\/repositories/.test(url)) {
+        return new Response("bad gateway", { status: 502 });
+      }
+      if (url.includes("/user/installations")) {
+        return json({
+          total_count: 1,
+          installations: [{ id: 42, account: { login: "acme" } }],
+        });
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+    await expectRejectCode(
+      () =>
+        authorizeAndResolveRepoId({
+          callerToken: "ghu_x",
+          installationId: 42,
+          owner: "acme",
+          repo: "web",
+        }),
+      "upstream_error",
+    );
+  });
+});
+
+// ============================================================================
+// mapMintError — GitHub mint-endpoint status → clear, leak-free error
+// ============================================================================
+
+describe("mapMintError", () => {
+  test("maps 422 to repo_not_accessible", () => {
+    expect(mapMintError(new GitHubAppApiError(422, "x")).code).toBe(
+      "repo_not_accessible",
+    );
+  });
+
+  test("maps 404 to installation_not_found", () => {
+    expect(mapMintError(new GitHubAppApiError(404, "x")).code).toBe(
+      "installation_not_found",
+    );
+  });
+
+  test("maps 401 to config_error without leaking the upstream detail", () => {
+    const mapped = mapMintError(new GitHubAppApiError(401, "private key bad"));
+    expect(mapped.code).toBe("config_error");
+    expect(mapped.message).not.toContain("private key");
+  });
+
+  test("maps 403 to config_error", () => {
+    expect(mapMintError(new GitHubAppApiError(403, "x")).code).toBe(
+      "config_error",
+    );
+  });
+
+  test("maps 5xx to a transient upstream_error (not a config error)", () => {
+    expect(mapMintError(new GitHubAppApiError(503, "x")).code).toBe(
+      "upstream_error",
+    );
+  });
+
+  test("maps 429 (rate limited) to upstream_error", () => {
+    expect(mapMintError(new GitHubAppApiError(429, "x")).code).toBe(
+      "upstream_error",
+    );
+  });
+
+  test("passes a RepoTokenError through unchanged", () => {
+    const orig = new RepoTokenError("unauthorized_caller", "m");
+    expect(mapMintError(orig)).toBe(orig);
+  });
+});
+
+// ============================================================================
+// mintRepoScopedToken — full orchestration
+// ============================================================================
+
+describe("mintRepoScopedToken", () => {
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  test("mints a repo-scoped token end to end with the expected output shape", async () => {
+    setFetch(async (input, init) => {
+      const url = urlOf(input);
+      if (/\/user\/installations\/42\/repositories/.test(url)) {
+        return json({
+          total_count: 1,
+          repositories: [{ id: 999, name: "web", owner: { login: "acme" } }],
+        });
+      }
+      if (url.includes("/user/installations")) {
+        return json({
+          total_count: 1,
+          installations: [{ id: 42, account: { login: "acme" } }],
+        });
+      }
+      if (/\/app\/installations\/42\/access_tokens/.test(url)) {
+        const reqInit = init as { method?: string; body?: string };
+        expect(reqInit.method).toBe("POST");
+        const body = JSON.parse(reqInit.body ?? "{}");
+        expect(body.repository_ids).toEqual([999]);
+        expect(body.permissions).toEqual({
+          contents: "write",
+          metadata: "read",
+          pull_requests: "write",
+        });
+        return json(
+          {
+            token: "ghs_minted",
+            expires_at: "2026-06-05T12:00:00Z",
+            permissions: body.permissions,
+            repositories: [{ id: 999, name: "web", full_name: "acme/web" }],
+          },
+          201,
+        );
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+
+    const result = await mintRepoScopedToken({
+      callerToken: "ghu_x",
+      installationId: 42,
+      owner: "acme",
+      repo: "web",
+      jwt: "fake.jwt",
+    });
+
+    expect(result).toEqual({
+      token: "ghs_minted",
+      expiresAt: "2026-06-05T12:00:00Z",
+      permissions: {
+        contents: "write",
+        metadata: "read",
+        pull_requests: "write",
+      },
+      repository: { owner: "acme", name: "web" },
+      installationId: 42,
+    });
+  });
+
+  test("rejects owner/repo passed together in the repo field", async () => {
+    await expectRejectCode(
+      () =>
+        mintRepoScopedToken({
+          callerToken: "ghu_x",
+          installationId: 42,
+          owner: "acme",
+          repo: "acme/web",
+          jwt: "fake.jwt",
+        }),
+      "invalid_input",
+    );
+  });
+
+  test("maps a 422 from the mint endpoint to repo_not_accessible", async () => {
+    setFetch(async (input) => {
+      const url = urlOf(input);
+      if (/\/user\/installations\/42\/repositories/.test(url)) {
+        return json({
+          repositories: [{ id: 999, name: "web", owner: { login: "acme" } }],
+        });
+      }
+      if (url.includes("/user/installations")) {
+        return json({
+          installations: [{ id: 42, account: { login: "acme" } }],
+        });
+      }
+      if (/access_tokens/.test(url)) {
+        return json({ message: "one repository does not exist" }, 422);
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+    await expectRejectCode(
+      () =>
+        mintRepoScopedToken({
+          callerToken: "ghu_x",
+          installationId: 42,
+          owner: "acme",
+          repo: "web",
+          jwt: "fake.jwt",
+        }),
+      "repo_not_accessible",
+    );
+  });
+
+  test("mints NOTHING when the caller is not authorized", async () => {
+    let mintCalled = false;
+    setFetch(async (input) => {
+      const url = urlOf(input);
+      if (/access_tokens/.test(url)) {
+        mintCalled = true;
+        return json({ token: "ghs_should_not_happen" }, 201);
+      }
+      if (url.includes("/user/installations")) {
+        return json({ installations: [] });
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+    await expectRejectCode(
+      () =>
+        mintRepoScopedToken({
+          callerToken: "ghu_x",
+          installationId: 42,
+          owner: "acme",
+          repo: "web",
+          jwt: "fake.jwt",
+        }),
+      "unauthorized_caller",
+    );
+    expect(mintCalled).toBe(false);
+  });
+});

--- a/github/server/lib/repo-token.ts
+++ b/github/server/lib/repo-token.ts
@@ -1,0 +1,395 @@
+/**
+ * Repository-scoped GitHub token minting.
+ *
+ * Mints a GitHub App *installation access token* scoped to exactly ONE
+ * repository with least-privilege permissions. The whole point is least
+ * privilege: an imported agent must be able to touch ONLY its own repo.
+ *
+ * Security model — minting is gated on the CALLER's own authenticated GitHub
+ * context, never on the raw input. We derive the caller's entitlement from
+ * their user-to-server token (the token this MCP connection was established
+ * with) before minting:
+ *   1. The installation must appear in the caller's `GET /user/installations`
+ *      AND its account login must equal `owner`.
+ *   2. The repository must appear in the caller's
+ *      `GET /user/installations/{id}/repositories`. That call also yields the
+ *      numeric repo id, so we mint with `repository_ids` (rename-proof).
+ * Only then do we mint, using the GitHub App's private key (JWT). GitHub
+ * additionally enforces repo-in-installation and permission-subset (422).
+ */
+
+import {
+  createAppJWT,
+  GitHubAppApiError,
+  mintInstallationAccessToken,
+} from "./github-app-auth.ts";
+
+export type RepoTokenErrorCode =
+  | "invalid_input"
+  | "unauthorized_caller"
+  | "repo_not_accessible"
+  | "permission_denied"
+  | "installation_not_found"
+  | "upstream_error"
+  | "config_error";
+
+/** Error surfaced by the MINT_REPO_TOKEN flow. `code` is stable; `message` is
+ * safe to show to the caller (it never contains the minted token or upstream
+ * auth detail). */
+export class RepoTokenError extends Error {
+  constructor(
+    public readonly code: RepoTokenErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "RepoTokenError";
+  }
+}
+
+/**
+ * Positive allowlist of permissions we are willing to mint — strictly
+ * repo-content / PR / issue level. Anything outside this list is hard-rejected,
+ * which by construction also rejects every escalation vector the spec bans
+ * (administration, members, organization_*, secrets, actions, ...).
+ */
+export const ALLOWED_PERMISSIONS = new Set([
+  "contents",
+  "metadata",
+  "pull_requests",
+  "issues",
+]);
+
+/** GitHub permission levels we allow. `admin` is never granted. */
+const ALLOWED_VALUES = new Set(["read", "write"]);
+
+/** Default least-privilege grant for a coding agent (clone, read, push, PR). */
+export const DEFAULT_PERMISSIONS: Record<string, string> = {
+  contents: "write",
+  metadata: "read",
+  pull_requests: "write",
+};
+
+const GITHUB_API = "https://api.github.com";
+const PER_PAGE = 100;
+
+function githubHeaders(callerToken: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${callerToken}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "deco-cms-github-mcp",
+  };
+}
+
+/**
+ * Whether a non-OK GitHub response is transient (retry later) rather than a
+ * definitive authorization/visibility failure. We must NOT collapse a GitHub
+ * outage or rate-limit window into a hard "not authorized" / "not accessible"
+ * denial — that would tell an entitled caller they permanently lost access.
+ * Mirrors the 5xx-is-transient convention in github-client.ts.
+ */
+function isTransientGitHubResponse(res: Response): boolean {
+  if (res.status >= 500 || res.status === 429) return true;
+  // GitHub signals secondary/primary rate limits with a 403 plus either a
+  // Retry-After header or an exhausted rate-limit budget.
+  if (res.status === 403) {
+    return (
+      res.headers.get("retry-after") !== null ||
+      res.headers.get("x-ratelimit-remaining") === "0"
+    );
+  }
+  return false;
+}
+
+/**
+ * Cap a requested permission map to the least-privilege allowlist.
+ *
+ * - No input → the default coding-agent grant.
+ * - Each key must be in {@link ALLOWED_PERMISSIONS}; otherwise hard-reject.
+ * - Each value must be "read" or "write"; `admin` (or anything else) is
+ *   rejected.
+ * - `metadata:read` is always required by GitHub, so it is forced in (and
+ *   never elevated to write).
+ */
+export function capPermissions(
+  input?: Record<string, string>,
+): Record<string, string> {
+  if (!input || Object.keys(input).length === 0) {
+    return { ...DEFAULT_PERMISSIONS };
+  }
+
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (!ALLOWED_PERMISSIONS.has(key)) {
+      throw new RepoTokenError(
+        "permission_denied",
+        `Permission "${key}" is not allowed. This tool only mints repo-scoped ` +
+          `code access (${[...ALLOWED_PERMISSIONS].join(", ")}).`,
+      );
+    }
+    if (!ALLOWED_VALUES.has(value)) {
+      throw new RepoTokenError(
+        "permission_denied",
+        `Permission "${key}" must be "read" or "write" (got "${value}").`,
+      );
+    }
+    out[key] = value;
+  }
+
+  // GitHub always requires metadata:read; never grant metadata:write.
+  out.metadata = "read";
+  return out;
+}
+
+/**
+ * Verify the caller is entitled to `installationId` and that it belongs to
+ * `owner`, by checking the caller's own `GET /user/installations`.
+ * Returns the matching installation, or undefined if the caller has no such
+ * installation. Throws on a non-OK response (e.g. 401 → caller token bad).
+ */
+async function findCallerInstallation(
+  callerToken: string,
+  installationId: number,
+): Promise<{ id: number; account: { login: string } } | undefined> {
+  let page = 1;
+  while (true) {
+    const res = await fetch(
+      `${GITHUB_API}/user/installations?per_page=${PER_PAGE}&page=${page}`,
+      { headers: githubHeaders(callerToken) },
+    );
+    if (!res.ok) {
+      if (isTransientGitHubResponse(res)) {
+        throw new RepoTokenError(
+          "upstream_error",
+          `GitHub is temporarily unavailable (${res.status}) while verifying ` +
+            `the caller's installations. Please retry.`,
+        );
+      }
+      throw new RepoTokenError(
+        "unauthorized_caller",
+        `Could not verify the caller's GitHub installations (${res.status}).`,
+      );
+    }
+    const data = (await res.json()) as {
+      installations: Array<{ id: number; account: { login: string } }>;
+    };
+    const match = data.installations.find((i) => i.id === installationId);
+    if (match) return match;
+    if (data.installations.length < PER_PAGE) return undefined;
+    page++;
+  }
+}
+
+/**
+ * Find `owner/repo` within the caller's view of an installation and return its
+ * numeric id (used for rename-proof minting). Returns undefined if the repo is
+ * not present. Throws on a non-OK response (e.g. installation not accessible to
+ * the caller).
+ */
+async function findRepoIdInInstallation(
+  callerToken: string,
+  installationId: number,
+  owner: string,
+  repo: string,
+): Promise<number | undefined> {
+  const ownerLc = owner.toLowerCase();
+  const repoLc = repo.toLowerCase();
+  let page = 1;
+  while (true) {
+    const res = await fetch(
+      `${GITHUB_API}/user/installations/${installationId}/repositories` +
+        `?per_page=${PER_PAGE}&page=${page}`,
+      { headers: githubHeaders(callerToken) },
+    );
+    if (!res.ok) {
+      if (isTransientGitHubResponse(res)) {
+        throw new RepoTokenError(
+          "upstream_error",
+          `GitHub is temporarily unavailable (${res.status}) while listing ` +
+            `repositories for installation ${installationId}. Please retry.`,
+        );
+      }
+      throw new RepoTokenError(
+        "repo_not_accessible",
+        `Could not list repositories for installation ${installationId} ` +
+          `(${res.status}).`,
+      );
+    }
+    const data = (await res.json()) as {
+      repositories: Array<{
+        id: number;
+        name: string;
+        owner: { login: string };
+      }>;
+    };
+    const match = data.repositories.find(
+      (r) =>
+        r.name.toLowerCase() === repoLc &&
+        r.owner.login.toLowerCase() === ownerLc,
+    );
+    if (match) return match.id;
+    if (data.repositories.length < PER_PAGE) return undefined;
+    page++;
+  }
+}
+
+/**
+ * The security gate. Confirms the caller is entitled to `owner/repo` under
+ * `installationId` using the caller's own GitHub context, and resolves the
+ * repository's numeric id. Throws {@link RepoTokenError} (and mints nothing)
+ * if the caller is not entitled.
+ */
+export async function authorizeAndResolveRepoId(params: {
+  callerToken: string;
+  installationId: number;
+  owner: string;
+  repo: string;
+}): Promise<number> {
+  const { callerToken, installationId, owner, repo } = params;
+
+  if (!callerToken) {
+    throw new RepoTokenError(
+      "unauthorized_caller",
+      "Missing caller GitHub authorization.",
+    );
+  }
+
+  const installation = await findCallerInstallation(
+    callerToken,
+    installationId,
+  );
+  if (!installation) {
+    throw new RepoTokenError(
+      "unauthorized_caller",
+      `Caller is not authorized for installation ${installationId}.`,
+    );
+  }
+  if (installation.account.login.toLowerCase() !== owner.toLowerCase()) {
+    throw new RepoTokenError(
+      "unauthorized_caller",
+      `Installation ${installationId} does not belong to "${owner}".`,
+    );
+  }
+
+  const repoId = await findRepoIdInInstallation(
+    callerToken,
+    installationId,
+    owner,
+    repo,
+  );
+  if (repoId === undefined) {
+    throw new RepoTokenError(
+      "repo_not_accessible",
+      `Repository "${owner}/${repo}" is not accessible to installation ` +
+        `${installationId} for this caller.`,
+    );
+  }
+  return repoId;
+}
+
+/**
+ * Map an error from the mint endpoint to a clear, leak-free RepoTokenError.
+ * RepoTokenErrors (from the authorization gate) pass through unchanged.
+ */
+export function mapMintError(err: unknown): RepoTokenError {
+  if (err instanceof RepoTokenError) return err;
+  if (err instanceof GitHubAppApiError) {
+    if (err.status === 422) {
+      return new RepoTokenError(
+        "repo_not_accessible",
+        "Repository is not in this installation, or the requested permissions " +
+          "exceed what the GitHub App was granted.",
+      );
+    }
+    if (err.status === 404) {
+      return new RepoTokenError(
+        "installation_not_found",
+        "GitHub App installation not found.",
+      );
+    }
+    if (err.status >= 500 || err.status === 429) {
+      // Transient GitHub outage / rate limit — retryable, not a config issue.
+      return new RepoTokenError(
+        "upstream_error",
+        "GitHub is temporarily unavailable while minting the token. Please retry.",
+      );
+    }
+    // 401/403 (and anything else) → internal config problem; never leak the
+    // upstream detail, which can hint at private-key/JWT internals.
+    return new RepoTokenError(
+      "config_error",
+      "GitHub App authentication failed. This is a server configuration issue.",
+    );
+  }
+  return new RepoTokenError(
+    "config_error",
+    "Unexpected error while minting the repository token.",
+  );
+}
+
+export interface RepoTokenResult {
+  token: string;
+  expiresAt: string;
+  permissions: Record<string, string>;
+  repository: { owner: string; name: string };
+  installationId: number;
+}
+
+/**
+ * Mint a fresh, short-lived (~1h) repository-scoped GitHub token.
+ *
+ * Idempotent in the sense that the same inputs always produce a fresh valid
+ * token (no caching, no refresh token). The `jwt` parameter is for testing;
+ * production calls omit it so a real App JWT is signed from env.
+ */
+export async function mintRepoScopedToken(params: {
+  callerToken: string;
+  installationId: number;
+  owner: string;
+  repo: string;
+  permissions?: Record<string, string>;
+  jwt?: string;
+}): Promise<RepoTokenResult> {
+  const { callerToken, installationId, owner, repo, permissions, jwt } = params;
+
+  if (!owner) {
+    throw new RepoTokenError("invalid_input", `"owner" is required.`);
+  }
+  if (!repo || repo.includes("/")) {
+    throw new RepoTokenError(
+      "invalid_input",
+      `"repo" must be a bare repository name, not "owner/repo" (got "${repo}").`,
+    );
+  }
+
+  // Cap permissions BEFORE any network call so an over-broad request is
+  // rejected without touching GitHub.
+  const cappedPermissions = capPermissions(permissions);
+
+  // Security gate — mints nothing if the caller is not entitled.
+  const repositoryId = await authorizeAndResolveRepoId({
+    callerToken,
+    installationId,
+    owner,
+    repo,
+  });
+
+  let minted;
+  try {
+    minted = await mintInstallationAccessToken(
+      installationId,
+      { repository_ids: [repositoryId], permissions: cappedPermissions },
+      jwt ?? createAppJWT(),
+    );
+  } catch (err) {
+    throw mapMintError(err);
+  }
+
+  return {
+    token: minted.token,
+    expiresAt: minted.expires_at,
+    permissions: minted.permissions,
+    repository: { owner, name: repo },
+    installationId,
+  };
+}

--- a/github/server/tools/index.ts
+++ b/github/server/tools/index.ts
@@ -8,12 +8,21 @@
 
 import { buildUpstreamTools, getUpstreamToolDefs } from "../lib/mcp-proxy.ts";
 import { triggers } from "../lib/trigger-store.ts";
+import { createMintRepoTokenTool } from "./mint-repo-token.ts";
 
 /**
  * Resolve the full tool set. Cached for the isolate's lifetime once
  * upstream discovery succeeds (caching happens inside getUpstreamToolDefs).
+ *
+ * Beyond the proxied upstream tools and trigger tools, we add first-party
+ * tools that need the GitHub App private key — which only this MCP holds:
+ *   - MINT_REPO_TOKEN: mint a repo-scoped, least-privilege installation token.
  */
 export async function getTools() {
   const toolDefs = await getUpstreamToolDefs();
-  return [...buildUpstreamTools(toolDefs), ...triggers.tools()];
+  return [
+    ...buildUpstreamTools(toolDefs),
+    ...triggers.tools(),
+    createMintRepoTokenTool(),
+  ];
 }

--- a/github/server/tools/mint-repo-token.ts
+++ b/github/server/tools/mint-repo-token.ts
@@ -1,0 +1,83 @@
+/**
+ * MINT_REPO_TOKEN — mint a GitHub App installation access token scoped to
+ * exactly one repository, with least-privilege permissions.
+ *
+ * Used by Deco Studio to give an imported agent a token that can touch ONLY
+ * its own repo (baked into the sandbox clone URL). Tokens are short-lived
+ * (~1h) with no refresh token — Studio calls this again to refresh.
+ *
+ * `createPrivateTool` ensures the request is authenticated before executing;
+ * the heavy lifting (caller authorization, permission capping, minting) lives
+ * in `../lib/repo-token.ts`. Env (and thus the caller's GitHub token) is read
+ * from `runtimeContext.env` at execution time — on Workers there is no env at
+ * tool-build time.
+ */
+
+import { createPrivateTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { mintRepoScopedToken } from "../lib/repo-token.ts";
+import type { Env } from "../types/env.ts";
+
+export function createMintRepoTokenTool() {
+  return createPrivateTool({
+    id: "MINT_REPO_TOKEN",
+    description:
+      "Mint a short-lived (~1h) GitHub token scoped to exactly ONE repository " +
+      "with least-privilege permissions, using the GitHub App. The authenticated " +
+      "caller must already be entitled to the installation and repository — the " +
+      "tool verifies this against the caller's own GitHub context before minting. " +
+      "The token grants only repo-content / pull-request / issue access. Tokens " +
+      "are not cached and have no refresh token; call again to refresh.",
+    inputSchema: z.object({
+      installationId: z
+        .number()
+        .int()
+        .describe("GitHub App installation id to mint the token under."),
+      owner: z
+        .string()
+        .describe(
+          'The installation account login, e.g. "acme" (NOT "owner/repo").',
+        ),
+      repo: z
+        .string()
+        .describe('The repository NAME only, e.g. "web" (NOT "acme/web").'),
+      permissions: z
+        .record(z.string(), z.string())
+        .optional()
+        .describe(
+          "Optional GitHub permission map, capped to least privilege. Allowed " +
+            "keys: contents, metadata, pull_requests, issues; values: read | " +
+            'write. Defaults to { contents: "write", metadata: "read", ' +
+            'pull_requests: "write" }. Anything broader is rejected.',
+        ),
+    }),
+    outputSchema: z.object({
+      token: z
+        .string()
+        .describe("The ghs_ repository-scoped installation token."),
+      expiresAt: z
+        .string()
+        .describe("ISO8601 expiry (~1h from now; issued by GitHub)."),
+      permissions: z
+        .record(z.string(), z.string())
+        .describe("The permissions actually granted, echoed from GitHub."),
+      repository: z.object({
+        owner: z.string(),
+        name: z.string(),
+      }),
+      installationId: z.number(),
+    }),
+    execute: async ({ context, runtimeContext }) => {
+      const env = runtimeContext.env as unknown as Env;
+      const callerToken = env.MESH_REQUEST_CONTEXT?.authorization ?? "";
+
+      return await mintRepoScopedToken({
+        callerToken,
+        installationId: context.installationId,
+        owner: context.owner,
+        repo: context.repo,
+        permissions: context.permissions,
+      });
+    },
+  });
+}


### PR DESCRIPTION
Adds a `MINT_REPO_TOKEN` tool to the GitHub MCP that mints a GitHub App installation access token scoped to a single repository with least-privilege permissions, so an imported agent (e.g. in Deco Studio) can touch only its own repo. Minting is gated on the **caller's own** GitHub entitlement (`GET /user/installations` + `/repositories`) and uses `repository_ids` (rename-proof); requested permissions are capped to a repo-content/PR/issue allowlist, and the minted token is never logged or echoed (401/403 surface a generic config error). It also refactors `github-app-auth` to share a `mintInstallationAccessToken` primitive (reused by `getAppInstallationToken`) and classifies transient GitHub failures (5xx / 429 / 403 rate-limit) as a retryable error rather than a hard authorization denial. Output fields are exactly `token`, `expiresAt`, `permissions`, `repository:{owner,name}`, `installationId`, and the change is covered by 37 new tests (all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `MINT_REPO_TOKEN` tool that mints a short-lived, repo-scoped GitHub App token with least-privilege, gated by the caller’s own GitHub access. Also fixes CI typecheck by correcting a context cast and updating `@decocms/runtime` in `github-repo-reports`.

- **New Features**
  - Private `MINT_REPO_TOKEN` tool that mints a token for exactly one repository using `repository_ids`, gated via `GET /user/installations` and `/repositories` (case-insensitive) and resolving the numeric repo id.
  - Permissions capped to an allowlist: contents, metadata, pull_requests, issues (defaults: contents:write, metadata:read, pull_requests:write). Output: token, expiresAt, permissions, repository {owner, name}, installationId. Token is never logged. Also introduced `mintInstallationAccessToken` (reused by `getAppInstallationToken`) and exported `createAppJWT`; transient 5xx/429/403 rate-limit are treated as retryable and 401/403 as config errors.

- **Bug Fixes**
  - Fixed typecheck by casting `ctx` to `{ env: Env }` in `github/server/lib/mcp-proxy.ts` (no behavior change).
  - Bumped `@decocms/runtime` to `^1.6.0` in `github-repo-reports` to resolve TypeScript issues.

<sup>Written for commit 195eac17d4a7ac54779dc68fae12a66002b6cf59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

