### PR TITLE
fix(github): bind repo grants KV namespace

### DIFF
--- a/github/wrangler.toml
+++ b/github/wrangler.toml
@@ -31,4 +31,4 @@ id = "c81656fe0e4347d39205c0f2103ca5c9"
 # Then replace the id below with the returned id BEFORE deploying.
 [[kv_namespaces]]
 binding = "REPO_GRANTS"
-id = "REPLACE_WITH_REPO_GRANTS_KV_ID"
+id = "800a6e64bcd14c11adc4ed5b45e76fb8"


### PR DESCRIPTION
## Summary
- Bind the GitHub MCP REPO_GRANTS KV namespace to the real Cloudflare namespace id.
- Fixes the deploy workflow failure caused by the placeholder KV namespace id.

## Test Plan
- bun test (from github/)
- git diff --check
- CLOUDFLARE_ACCOUNT_ID=c95fc4cec7fc52453228d9db170c372c bunx wrangler deploy --dry-run --outdir=dist

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind the GitHub MCP `REPO_GRANTS` KV namespace to the real Cloudflare ID to unblock deployments. Replaces the placeholder in `github/wrangler.toml` so the deploy workflow stops failing.

<sup>Written for commit de38c4a9e652b431b55ca4123bce4b811f89c8be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

