### PR TITLE
fix(github): pin OAuth redirect_uri to decocms.com allowlist

### DIFF
--- a/github/server/constants.ts
+++ b/github/server/constants.ts
@@ -25,3 +25,11 @@ export const GRANT_KEY_PREFIX = "grant:";
 
 /** Opaque refresh-token prefix: `ghr_<grantId>.<secret>`. */
 export const REFRESH_TOKEN_PREFIX = "ghr_";
+
+/**
+ * Apex domains whose hosts (and any subdomain) are permitted as the OAuth
+ * `redirect_uri` we hand to GitHub. GitHub delivers the authorization `code`
+ * to this host, so an attacker-controlled value would mean code/token
+ * hijacking — pinning it to decocms.com (the canonical origin lives at
+ * `github-mcp.decocms.com`) closes that hole. */
+export const ALLOWED_REDIRECT_HOST_SUFFIXES = ["decocms.com"] as const;

--- a/github/server/lib/redirect-allowlist.test.ts
+++ b/github/server/lib/redirect-allowlist.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import {
+  assertAllowedRedirectUri,
+  isAllowedRedirectUri,
+} from "./redirect-allowlist.ts";
+
+describe("isAllowedRedirectUri", () => {
+  test("accepts the canonical origin", () => {
+    expect(
+      isAllowedRedirectUri("https://github-mcp.decocms.com/oauth/callback"),
+    ).toBe(true);
+  });
+
+  test("accepts apex and arbitrary subdomains over https", () => {
+    expect(isAllowedRedirectUri("https://decocms.com/cb")).toBe(true);
+    expect(isAllowedRedirectUri("https://preview.decocms.com/cb")).toBe(true);
+    expect(isAllowedRedirectUri("https://a.b.decocms.com/cb")).toBe(true);
+  });
+
+  test("allows loopback over http for local dev", () => {
+    expect(isAllowedRedirectUri("http://localhost:8787/oauth/callback")).toBe(
+      true,
+    );
+    expect(isAllowedRedirectUri("http://127.0.0.1:8787/cb")).toBe(true);
+  });
+
+  test("rejects non-loopback http", () => {
+    expect(isAllowedRedirectUri("http://github-mcp.decocms.com/cb")).toBe(
+      false,
+    );
+  });
+
+  test("rejects look-alike and suffix-confusion hosts", () => {
+    expect(isAllowedRedirectUri("https://evildecocms.com/cb")).toBe(false);
+    expect(isAllowedRedirectUri("https://decocms.com.attacker.io/cb")).toBe(
+      false,
+    );
+    expect(isAllowedRedirectUri("https://decocms.com.evil/cb")).toBe(false);
+    expect(isAllowedRedirectUri("https://notdecocms.com/cb")).toBe(false);
+  });
+
+  test("rejects other schemes and malformed input", () => {
+    expect(isAllowedRedirectUri("javascript:alert(1)")).toBe(false);
+    expect(isAllowedRedirectUri("ftp://decocms.com/cb")).toBe(false);
+    expect(isAllowedRedirectUri("not a url")).toBe(false);
+    expect(isAllowedRedirectUri("")).toBe(false);
+  });
+
+  test("is case-insensitive on the host", () => {
+    expect(isAllowedRedirectUri("https://GitHub-MCP.DecoCMS.com/cb")).toBe(
+      true,
+    );
+  });
+});
+
+describe("assertAllowedRedirectUri", () => {
+  test("passes for an allowed uri", () => {
+    expect(() =>
+      assertAllowedRedirectUri("https://github-mcp.decocms.com/oauth/callback"),
+    ).not.toThrow();
+  });
+
+  test("throws for a disallowed uri", () => {
+    expect(() => assertAllowedRedirectUri("https://attacker.io/cb")).toThrow(
+      /Refusing OAuth redirect_uri/,
+    );
+  });
+});

--- a/github/server/lib/redirect-allowlist.ts
+++ b/github/server/lib/redirect-allowlist.ts
@@ -1,0 +1,57 @@
+/**
+ * OAuth `redirect_uri` allowlist.
+ *
+ * The runtime hands `authorizationUrl()` a callback URL that we forward to
+ * GitHub as the `redirect_uri`. GitHub delivers the authorization `code` to
+ * whatever host that URL points at, so if the origin is ever attacker-influenced
+ * (spoofed Host header, an injected query/redirect param, a misconfigured
+ * route) the code — and the access token minted from it — leaks to that host.
+ *
+ * We close this by refusing any `redirect_uri` whose host isn't decocms.com or
+ * one of its subdomains. Loopback hosts are allowed over http for local dev
+ * (RFC 8252 §7.3); everything else must be https.
+ */
+
+import { ALLOWED_REDIRECT_HOST_SUFFIXES } from "../constants.ts";
+
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+
+/** Returns true if `redirectUri` is a well-formed URL pointing at an allowed host. */
+export function isAllowedRedirectUri(redirectUri: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(redirectUri);
+  } catch {
+    return false;
+  }
+
+  const host = url.hostname.toLowerCase();
+  const isLoopback = LOOPBACK_HOSTS.has(host);
+
+  // https everywhere; http only for loopback dev hosts.
+  if (url.protocol === "https:") {
+    // ok
+  } else if (url.protocol === "http:" && isLoopback) {
+    return true;
+  } else {
+    return false;
+  }
+
+  if (isLoopback) return true;
+
+  // `endsWith(".decocms.com")` enforces a label boundary, so "evildecocms.com"
+  // and "decocms.com.attacker.io" are both rejected.
+  return ALLOWED_REDIRECT_HOST_SUFFIXES.some(
+    (suffix) => host === suffix || host.endsWith(`.${suffix}`),
+  );
+}
+
+/** Throws if `redirectUri` is not on the allowlist. */
+export function assertAllowedRedirectUri(redirectUri: string): void {
+  if (!isAllowedRedirectUri(redirectUri)) {
+    throw new Error(
+      `Refusing OAuth redirect_uri outside the allowed domains ` +
+        `(${ALLOWED_REDIRECT_HOST_SUFFIXES.join(", ")}): ${redirectUri}`,
+    );
+  }
+}

--- a/github/server/main.ts
+++ b/github/server/main.ts
@@ -25,6 +25,7 @@ import {
   handleRepoGrantTokenRequest,
 } from "./lib/repo-grant.ts";
 import { setRepoGrantKV } from "./lib/repo-grant-store.ts";
+import { assertAllowedRedirectUri } from "./lib/redirect-allowlist.ts";
 import { REPO_GRANT_REVOKE_PATH, REPO_GRANT_TOKEN_PATH } from "./constants.ts";
 import { setTriggerKV } from "./lib/trigger-store.ts";
 import { getTools } from "./tools/index.ts";
@@ -73,6 +74,11 @@ async function getRuntime(): Promise<Runtime> {
             // Remove state from redirect_uri — pass it as a separate param
             callbackUrlObj.searchParams.delete("state");
             const redirectUri = callbackUrlObj.toString();
+
+            // Defense-in-depth: never forward a redirect_uri off the decocms.com
+            // origin to GitHub. GitHub returns the authorization `code` here, so
+            // an attacker-influenced host would hijack the code/token.
+            assertAllowedRedirectUri(redirectUri);
 
             const url = new URL("https://github.com/login/oauth/authorize");
             url.searchParams.set("client_id", clientId);


### PR DESCRIPTION
authorizationUrl() forwarded the runtime-supplied callback URL verbatim as GitHub's redirect_uri. GitHub delivers the authorization code to that host, so an attacker-influenced origin (spoofed Host header, injected redirect param, misconfigured route) would hijack the code and the token minted from it in exchangeCode.

Add an allowlist validator that refuses any redirect_uri whose host is not decocms.com or a subdomain (https; http allowed only for loopback dev per RFC 8252), and call it before the value reaches GitHub.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin GitHub OAuth `redirect_uri` to the `decocms.com` allowlist to block code/token hijacking. Enforces https for production and allows http only on loopback hosts for local dev (RFC 8252).

- **Bug Fixes**
  - Added `isAllowedRedirectUri`/`assertAllowedRedirectUri` with `ALLOWED_REDIRECT_HOST_SUFFIXES = ["decocms.com"]`.
  - Require https for `decocms.com` and subdomains; allow http only for loopback hosts (localhost, 127.0.0.1, ::1/[::1]).
  - Validate `redirect_uri` before sending to GitHub; tests cover canonical, subdomains, loopback vs non-loopback http, suffix-confusion, case-insensitive hosts, and malformed schemes/URLs.

<sup>Written for commit 2e64509519c1a6f00f8ab481326ecd9d4cfa05d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

