### PR TITLE
fix(vtex): add searchField companion query params to List Orders

### DIFF
--- a/vtex/scripts/download-schemas.ts
+++ b/vtex/scripts/download-schemas.ts
@@ -9,6 +9,21 @@ const RAW_BASE_URL =
   "https://raw.githubusercontent.com/vtex/openapi-schemas/master/";
 
 /**
+ * Schema overrides: use an alternative branch/fork for specific schemas
+ * while waiting for upstream PRs to be merged.
+ *
+ * Key: exact filename in the repository (e.g. "VTEX - Orders API.json")
+ * Value: raw GitHub URL pointing to the fork/branch with the fix
+ *
+ * TODO: remove overrides once the corresponding PRs are merged upstream
+ * - "VTEX - Orders API.json": https://github.com/vtex/openapi-schemas/pull/1728
+ */
+const SCHEMA_OVERRIDES: Record<string, string> = {
+  "VTEX - Orders API.json":
+    "https://raw.githubusercontent.com/guitavano/openapi-schemas/fix/list-orders-search-field-params/VTEX%20-%20Orders%20API.json",
+};
+
+/**
  * Derive a canonical schema name from a raw filename.
  *
  * Transform rules (applied in order):
@@ -95,10 +110,15 @@ async function downloadSchemas() {
 
   for (const file of jsonFiles) {
     const name = deriveSchemaName(file.name);
-    const rawUrl = `${RAW_BASE_URL}${encodeURIComponent(file.name)}`;
+    const override = SCHEMA_OVERRIDES[file.name];
+    const rawUrl =
+      override ?? `${RAW_BASE_URL}${encodeURIComponent(file.name)}`;
 
     console.log(`Processing: ${file.name}`);
     console.log(`  → name: ${name}`);
+    if (override) {
+      console.log(`  → OVERRIDE: using custom source (PR pending upstream)`);
+    }
 
     const response = await fetch(rawUrl, {
       headers: { "User-Agent": "vtex-mcp-schema-downloader" },

--- a/vtex/server/generated/orders/sdk.gen.ts
+++ b/vtex/server/generated/orders/sdk.gen.ts
@@ -1029,7 +1029,7 @@ export const getChangeHistory = <ThrowOnError extends boolean = false>(options: 
 /**
  * Create order modifications
  *
- * [Order modifications](https://help.vtex.com/en/tutorial/how-change-order-works-beta--56TO0bOFXsfmpc7YZ3wIUZ) feature allows you to modify an order, whether the modification is motivated by customer mistakes, product unavailability, or others. Both sellers and marketplaces can use this endpoint and modify orders in multiple scenarios, and it is possible to make a single modification or combine multiple ones in the same request.
+ * [Order modifications](https://help.vtex.com/docs/tutorials/how-order-modification-works) feature allows you to modify an order, whether the modification is motivated by customer mistakes, product unavailability, or others. Both sellers and marketplaces can use this endpoint and modify orders in multiple scenarios, and it is possible to make a single modification or combine multiple ones in the same request.
  * The possible order modifications operations you can perform are the following:
  * - **Add:** Adding items, quantity, or product weight.
  * - **Remove:** Removing a part of items or the total quantity.
@@ -1087,7 +1087,15 @@ export const getChangeHistory = <ThrowOnError extends boolean = false>(options: 
  * - If the payment hasn't been settled, an automatic notification is sent to the payment gateway to change the order's total amount.
  * - **Higher price after order modification:** An automatic notification is sent to the payment gateway to require the customer to pay for the additional cost.
  *
+ * ## Order modifications settings
+ *
+ * The Order modifications settings allow you to customize your account's behavior when receiving a modification request, such as configuring the order payments, defining tax recalculation, and compensating shipping costs. Before or during the API integration, you can consult and, if necessary, adjust the settings of the modifications.
+ *
+ * * If you wish to consult the current settings, run the [Get Order modifications settings](https://developers.vtex.com/docs/api-reference/orders-api#get-/api/order-system/orders/changes/settings) endpoint.
+ * * If you wish to alter the current settings, run the [Update Order modifications settings](https://developers.vtex.com/docs/api-reference/orders-api#put-/api/order-system/orders/changes/settings) endpoint.
+ *
  * ## Combining multiple operations
+ *
  * You can use this endpoint to make a single change operation or combine them in the same request. See some examples below.
  *
  * ### Adding request body example:

--- a/vtex/server/generated/orders/types.gen.ts
+++ b/vtex/server/generated/orders/types.gen.ts
@@ -8588,15 +8588,33 @@ export type ListOrdersData = {
          */
         f_RnB?: string;
         /**
-         * You can search orders by using one of the following criterias:
-         * - SKU ID - `sku_Ids&sku_Ids`
-         * - Gift List ID - `listId&listId`
-         * - Transaction ID (TID) - `tid&tid`
-         * - PCI Connector's Transaction ID (TID) - `pci_tid&pci_tid`
-         * - Payment ID (PID) - `paymentId&paymentId`
-         * - Connector's NSU - `nsu&nsu`
+         * Defines the search criteria for filtering orders. Must be used together with the corresponding query parameter that provides the search value. For example, to search by SKU ID: `?searchField=sku_Ids&sku_Ids=11223`.
          */
-        searchField?: string;
+        searchField?: 'sku_Ids' | 'listId' | 'tid' | 'pci_tid' | 'paymentId' | 'nsu';
+        /**
+         * SKU ID to filter orders. Must be used with `searchField=sku_Ids`.
+         */
+        sku_Ids?: string;
+        /**
+         * Gift List ID to filter orders. Must be used with `searchField=listId`.
+         */
+        listId?: string;
+        /**
+         * Transaction ID (TID) to filter orders. Must be used with `searchField=tid`.
+         */
+        tid?: string;
+        /**
+         * PCI Connector's Transaction ID (TID) to filter orders. Must be used with `searchField=pci_tid`.
+         */
+        pci_tid?: string;
+        /**
+         * Payment ID (PID) to filter orders. Must be used with `searchField=paymentId`.
+         */
+        paymentId?: string;
+        /**
+         * Connector's NSU to filter orders. Must be used with `searchField=nsu`.
+         */
+        nsu?: string;
         /**
          * When set as `true`, this parameter filters orders made via [inStore](https://help.vtex.com/en/tracks/what-is-instore--zav76TFEZlAjnyBVL5tRc), and when set as `false`, it filters orders that were not made via inStore.
          */

--- a/vtex/server/generated/orders/zod.gen.ts
+++ b/vtex/server/generated/orders/zod.gen.ts
@@ -3773,7 +3773,20 @@ export const zListOrdersData = z.object({
         incompleteOrders: z.optional(z.boolean()),
         f_paymentNames: z.optional(z.string()),
         f_RnB: z.optional(z.string()),
-        searchField: z.optional(z.string()),
+        searchField: z.optional(z.enum([
+            'sku_Ids',
+            'listId',
+            'tid',
+            'pci_tid',
+            'paymentId',
+            'nsu'
+        ])),
+        sku_Ids: z.optional(z.string()),
+        listId: z.optional(z.string()),
+        tid: z.optional(z.string()),
+        pci_tid: z.optional(z.string()),
+        paymentId: z.optional(z.string()),
+        nsu: z.optional(z.string()),
         f_isInstore: z.optional(z.boolean())
     })),
     headers: z.object({


### PR DESCRIPTION
## Summary
- Uses schema override in `download-schemas.ts` to pull the Orders API schema from a fork with the fix, while waiting for [vtex/openapi-schemas#1728](https://github.com/vtex/openapi-schemas/pull/1728) to be merged upstream
- Regenerates the Orders API SDK/types/zod with the corrected schema, adding:
  - `searchField` as an enum (`sku_Ids`, `listId`, `tid`, `pci_tid`, `paymentId`, `nsu`) instead of free-form string
  - 6 companion query parameters required for order filtering

## Test plan
- [x] `bun test` passes (77 tests, 0 failures)
- [x] Server loads without errors
- [ ] Verify `VTEX_LIST_ORDERS` tool exposes the new parameters

> **Note:** Remove the `SCHEMA_OVERRIDES` entry once vtex/openapi-schemas#1728 is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes VTEX Orders “List Orders” filtering by making `searchField` a strict enum and adding the required companion query params. Regenerates the SDK/types/zod using a temporary schema override until the upstream schema fix is merged.

- **Bug Fixes**
  - `List Orders`: `searchField` is now an enum (`sku_Ids`, `listId`, `tid`, `pci_tid`, `paymentId`, `nsu`) with matching query params added (`sku_Ids`, `listId`, `tid`, `pci_tid`, `paymentId`, `nsu`).
  - Adds a schema override in `vtex/scripts/download-schemas.ts` to pull the corrected Orders schema from a fork while the upstream PR is pending.

- **Migration**
  - When calling `List Orders`, use one of the allowed `searchField` values and include its matching parameter (e.g., `searchField=sku_Ids&sku_Ids=11223`).

<sup>Written for commit 436ade4cd7bee04beba6ff375223484cd16ba855. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

