### PR TITLE
Revert "Revert "feat(vtex): orders timeline MCP App UI + admin analytics trend""

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1041,7 +1041,18 @@
       "dependencies": {
         "@decocms/bindings": "^1.4.0",
         "@decocms/runtime": "^1.6.2",
+        "@modelcontextprotocol/ext-apps": "^1.1.2",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@tailwindcss/vite": "^4.2.1",
+        "@tanstack/history": "^1.133.5",
+        "@tanstack/react-router": "^1.133.5",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.576.0",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "recharts": "2.15.4",
+        "tailwind-merge": "^3.5.0",
+        "tailwindcss": "^4.2.1",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -1050,8 +1061,15 @@
         "@hey-api/client-fetch": "^0.8.0",
         "@hey-api/openapi-ts": "0.92.4",
         "@types/bun": "^1.2.14",
+        "@types/react": "^19.2.2",
+        "@types/react-dom": "^19.2.2",
+        "@vitejs/plugin-react": "^5.0.4",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "concurrently": "^9.2.1",
         "deco-cli": "^0.28.0",
         "typescript": "^5.7.2",
+        "vite": "^7.3.1",
+        "vite-plugin-singlefile": "^2.3.0",
       },
     },
     "vtex-docs": {
@@ -4418,6 +4436,8 @@
 
     "vtex/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
+    "vtex/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
     "vtex/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "vtex-docs/@decocms/runtime": ["@decocms/runtime@1.1.3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-pj6OccmpWulMjyOt9FHTNX41xHk800uzhmoYK/xq9h1f+DfDBMqyOZnt70Zmwrab7dMDO2w3VQD+NlgFKtrw1w=="],
@@ -4971,6 +4991,8 @@
     "vtex-docs/ai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "vtex/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
+
+    "vtex/vite/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
 
     "whatsapp-management/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
@@ -5543,6 +5565,58 @@
     "vtex-docs/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "vtex-docs/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "vtex/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
+
+    "vtex/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.0", "", { "os": "android", "cpu": "arm" }, "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ=="],
+
+    "vtex/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ=="],
+
+    "vtex/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.0", "", { "os": "android", "cpu": "x64" }, "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q=="],
+
+    "vtex/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg=="],
+
+    "vtex/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g=="],
+
+    "vtex/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw=="],
+
+    "vtex/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw=="],
+
+    "vtex/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w=="],
+
+    "vtex/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.0", "", { "os": "none", "cpu": "x64" }, "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA=="],
+
+    "vtex/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ=="],
+
+    "vtex/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A=="],
+
+    "vtex/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA=="],
+
+    "vtex/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA=="],
+
+    "vtex/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg=="],
+
+    "vtex/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ=="],
+
+    "vtex/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
 
     "whatsapp-management/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 

--- a/vtex/README.md
+++ b/vtex/README.md
@@ -41,6 +41,8 @@ These handle multi-step operations not available in the generated SDK:
 | `VTEX_SEARCH_COLLECTIONS` | Search collections by name or terms |
 | `VTEX_REORDER_COLLECTION` | Reorder collections with SKU/product IDs via XML import |
 | `VTEX_UPDATE_PRODUCT_SPECIFICATIONS` | Bulk replace product specifications |
+| `VTEX_ORDERS_TIMELINE` | Hourly orders bar chart for today (MCP App UI) |
+| `VTEX_ORDERS_SALES_CARD` | Sales card for `today`, `last_1h`, or `last_5min` (MCP App UI) |
 
 ## Authentication
 

--- a/vtex/components.json
+++ b/vtex/components.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://ui.shadcn.com/schema.json",
+	"style": "new-york",
+	"rsc": false,
+	"tsx": true,
+	"tailwind": {
+		"config": "",
+		"css": "web/globals.css",
+		"baseColor": "neutral",
+		"cssVariables": true,
+		"prefix": ""
+	},
+	"iconLibrary": "lucide",
+	"rtl": false,
+	"aliases": {
+		"components": "@/components",
+		"utils": "@/lib/utils",
+		"ui": "@/components/ui",
+		"lib": "@/lib",
+		"hooks": "@/hooks"
+	},
+	"registries": {}
+}

--- a/vtex/index.html
+++ b/vtex/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>VTEX MCP App</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./web/app.tsx"></script>
+	</body>
+</html>

--- a/vtex/package.json
+++ b/vtex/package.json
@@ -5,13 +5,16 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "bun run --hot server/main.ts",
+    "dev": "concurrently -k -n api,web -c magenta,cyan \"bun run dev:api\" \"bun run dev:web\"",
+    "dev:api": "bun run --hot server/main.ts",
+    "dev:web": "vite build --watch",
     "configure": "deco configure",
     "gen": "deco gen --output=shared/deco.gen.ts",
     "deploy": "npm run build && deco deploy ./dist/server",
     "check": "tsc --noEmit",
+    "build:web": "vite build",
     "build:server": "NODE_ENV=production bun build server/main.ts --target=bun --outfile=dist/server/main.js",
-    "build": "bun run build:server",
+    "build": "bun run build:web && bun run build:server",
     "openapi": "openapi-ts",
     "generate": "bun run download-schemas && bun run openapi",
     "download-schemas": "bun run scripts/download-schemas.ts",
@@ -20,7 +23,18 @@
   "dependencies": {
     "@decocms/bindings": "^1.4.0",
     "@decocms/runtime": "^1.6.2",
+    "@modelcontextprotocol/ext-apps": "^1.1.2",
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "@tailwindcss/vite": "^4.2.1",
+    "@tanstack/history": "^1.133.5",
+    "@tanstack/react-router": "^1.133.5",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.576.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "recharts": "2.15.4",
+    "tailwind-merge": "^3.5.0",
+    "tailwindcss": "^4.2.1",
     "zod": "^4.0.0"
   },
   "devDependencies": {
@@ -29,8 +43,15 @@
     "@hey-api/client-fetch": "^0.8.0",
     "@hey-api/openapi-ts": "0.92.4",
     "@types/bun": "^1.2.14",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.2",
+    "@vitejs/plugin-react": "^5.0.4",
+    "babel-plugin-react-compiler": "^1.0.0",
+    "concurrently": "^9.2.1",
     "deco-cli": "^0.28.0",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vite": "^7.3.1",
+    "vite-plugin-singlefile": "^2.3.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/vtex/server/constants.ts
+++ b/vtex/server/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Shared resource URI for the VTEX MCP App UI bundle.
+ * Tools that render UI point their `_meta.ui.resourceUri` here.
+ */
+export const VTEX_RESOURCE_URI = "ui://vtex/dashboard";

--- a/vtex/server/main.ts
+++ b/vtex/server/main.ts
@@ -3,8 +3,8 @@
  *
  * MCP for VTEX Commerce APIs - Catalog, Orders, and Logistics/Inventory.
  */
-import { serve } from "@decocms/mcps-shared/serve";
 import { withRuntime } from "@decocms/runtime";
+import { dashboardResource } from "./resources/dashboard.ts";
 import { tools } from "./tools/index.ts";
 import { type Env, StateSchema } from "./types/env.ts";
 import packageJson from "../package.json" with { type: "json" };
@@ -14,11 +14,44 @@ console.log(`VTEX Commerce MCP v${packageJson.version}`);
 export type { Env };
 export { StateSchema };
 
+// biome-ignore lint/suspicious/noExplicitAny: runtime.fetch signature compatibility
+type Fetcher = (req: Request, ...args: any[]) => Response | Promise<Response>;
+
+function withMcpApiRoute(fetcher: Fetcher): Fetcher {
+  return (req: Request, ...args) => {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/mcp" || url.pathname.startsWith("/mcp/")) {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    if (url.pathname === "/api/mcp" || url.pathname.startsWith("/api/mcp/")) {
+      url.pathname = url.pathname.slice(4);
+      const rewrittenReq = new Request(url.toString(), req);
+      return fetcher(rewrittenReq, ...args);
+    }
+
+    return fetcher(req, ...args);
+  };
+}
+
 const runtime = withRuntime<Env, typeof StateSchema>({
   configuration: {
     state: StateSchema,
   },
   tools,
+  resources: [dashboardResource],
 });
 
-serve(runtime.fetch);
+const PORT = Number(process.env.PORT) || 3001;
+
+Bun.serve({
+  idleTimeout: 0,
+  hostname: "0.0.0.0",
+  port: PORT,
+  fetch: withMcpApiRoute(runtime.fetch),
+});
+
+console.log("");
+console.log(`MCP App: http://localhost:${PORT}/api/mcp`);
+console.log("");

--- a/vtex/server/resources/dashboard.ts
+++ b/vtex/server/resources/dashboard.ts
@@ -1,0 +1,29 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createPublicResource } from "@decocms/runtime/tools";
+import { VTEX_RESOURCE_URI } from "../constants.ts";
+import type { Env } from "../types/env.ts";
+
+const RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
+
+function getDistPath(): string {
+  const projectRoot = join(import.meta.dir, "../..");
+  return join(projectRoot, "dist", "client", "index.html");
+}
+
+export const dashboardResource = (_env: Env) =>
+  createPublicResource({
+    uri: VTEX_RESOURCE_URI,
+    name: "VTEX Dashboard",
+    description:
+      "Bundled React UI for visualizing VTEX commerce data — orders timeline dashboard.",
+    mimeType: RESOURCE_MIME_TYPE,
+    read: async () => {
+      const html = await readFile(getDistPath(), "utf-8");
+      return {
+        uri: VTEX_RESOURCE_URI,
+        mimeType: RESOURCE_MIME_TYPE,
+        text: html,
+      };
+    },
+  });

--- a/vtex/server/tools/custom/orders-oms.ts
+++ b/vtex/server/tools/custom/orders-oms.ts
@@ -1,0 +1,254 @@
+import { z } from "zod";
+
+export const DEFAULT_STORE_TIMEZONE = "-03:00";
+
+export const salesPeriodSchema = z.enum(["today", "last_1h", "last_5min"]);
+export type SalesPeriod = z.infer<typeof salesPeriodSchema>;
+
+export interface PeriodStats {
+  orders: number;
+  totalValue: number;
+}
+
+export interface HourlyOrderBucket {
+  hour: string;
+  count: number;
+  totalValue: number;
+}
+
+interface HourRange {
+  hour: string;
+  start: string;
+  end: string;
+}
+
+interface ListOrdersPage {
+  paging: {
+    total: number;
+  };
+  stats?: {
+    stats?: {
+      totalValue?: Record<string, unknown>;
+    };
+  };
+}
+
+export interface OmsCredentials {
+  accountName: string;
+  appKey?: string;
+  appToken?: string;
+}
+
+export function parseTimezoneOffsetMinutes(timezone: string): number {
+  const match = timezone.match(/^([+-])(\d{2}):(\d{2})$/);
+  if (!match) {
+    return 0;
+  }
+
+  const sign = match[1] === "+" ? 1 : -1;
+  return (
+    sign * (Number.parseInt(match[2], 10) * 60 + Number.parseInt(match[3], 10))
+  );
+}
+
+export function getTodayWindowInTimezone(timezone: string): {
+  startDate: string;
+  endDate: string;
+  date: string;
+} {
+  const offsetMinutes = parseTimezoneOffsetMinutes(timezone);
+  const now = new Date();
+  const shifted = new Date(now.getTime() + offsetMinutes * 60_000);
+  const year = shifted.getUTCFullYear();
+  const month = shifted.getUTCMonth();
+  const day = shifted.getUTCDate();
+  const startMs = Date.UTC(year, month, day) - offsetMinutes * 60_000;
+  const endMs = startMs + 86_400_000 - 1;
+
+  return {
+    startDate: new Date(startMs).toISOString(),
+    endDate: new Date(endMs).toISOString(),
+    date: `${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`,
+  };
+}
+
+export function getCurrentLocalHourIndex(
+  timezone: string,
+  now = new Date(),
+): number {
+  const offsetMinutes = parseTimezoneOffsetMinutes(timezone);
+  const totalMinutes =
+    now.getUTCHours() * 60 + now.getUTCMinutes() + offsetMinutes;
+  const normalized = ((totalMinutes % (24 * 60)) + 24 * 60) % (24 * 60);
+  return Math.floor(normalized / 60);
+}
+
+export function getRollingRange(minutes: number): {
+  start: string;
+  end: string;
+} {
+  const end = new Date();
+  const start = new Date(end.getTime() - minutes * 60 * 1000);
+
+  return { start: start.toISOString(), end: end.toISOString() };
+}
+
+export function getDateRangeForPeriod(
+  period: SalesPeriod,
+  timezone: string,
+): { start: string; end: string; date?: string } {
+  if (period === "today") {
+    const { startDate, endDate, date } = getTodayWindowInTimezone(timezone);
+    return { start: startDate, end: endDate, date };
+  }
+
+  if (period === "last_1h") {
+    return getRollingRange(60);
+  }
+
+  return getRollingRange(5);
+}
+
+export function buildOmsOrdersUrl(accountName: string): string {
+  return `https://${accountName}.vtexcommercestable.com.br/api/oms/pvt/orders`;
+}
+
+export function buildOmsHeaders(creds: OmsCredentials): Record<string, string> {
+  const { appKey, appToken } = creds;
+
+  return {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    ...(appKey && { "X-VTEX-API-AppKey": appKey }),
+    ...(appToken && { "X-VTEX-API-AppToken": appToken }),
+  };
+}
+
+function getHourRangesForLocalDate(
+  date: string,
+  timezone: string,
+): HourRange[] {
+  const offsetMinutes = parseTimezoneOffsetMinutes(timezone);
+  const [year, month, day] = date.split("-").map(Number);
+  const maxHour = getCurrentLocalHourIndex(timezone);
+
+  return Array.from({ length: maxHour + 1 }, (_, index) => {
+    const startMs =
+      Date.UTC(year, month - 1, day, 0, 0, 0, 0) -
+      offsetMinutes * 60_000 +
+      index * 3_600_000;
+    const endMs = startMs + 3_600_000 - 1;
+
+    return {
+      hour: `${String(index).padStart(2, "0")}:00`,
+      start: new Date(startMs).toISOString(),
+      end: new Date(endMs).toISOString(),
+    };
+  });
+}
+
+function padHourlyBuckets(fetched: HourlyOrderBucket[]): HourlyOrderBucket[] {
+  const byHour = new Map(fetched.map((bucket) => [bucket.hour, bucket]));
+
+  return Array.from({ length: 24 }, (_, index) => {
+    const hour = `${String(index).padStart(2, "0")}:00`;
+    return byHour.get(hour) ?? { hour, count: 0, totalValue: 0 };
+  });
+}
+
+function isListOrdersPage(data: unknown): data is ListOrdersPage {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "paging" in data &&
+    typeof data.paging === "object" &&
+    data.paging !== null &&
+    "total" in data.paging &&
+    typeof data.paging.total === "number"
+  );
+}
+
+function readNumericField(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function extractStatsSum(data: ListOrdersPage): number {
+  const totalValue = data.stats?.stats?.totalValue;
+  if (!totalValue || typeof totalValue !== "object") {
+    return 0;
+  }
+
+  return (
+    readNumericField(totalValue.Sum) ?? readNumericField(totalValue.sum) ?? 0
+  );
+}
+
+export async function fetchRangeStats(
+  baseUrl: string,
+  headers: Record<string, string>,
+  start: string,
+  end: string,
+): Promise<PeriodStats> {
+  const params = new URLSearchParams({
+    page: "1",
+    per_page: "1",
+    _stats: "1",
+    f_creationDate: `creationDate:[${start} TO ${end}]`,
+  });
+  const url = `${baseUrl}?${params.toString()}`;
+  console.log("[VTEX] GET", url);
+
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(
+      `VTEX API Error: ${response.status} - ${await response.text()}`,
+    );
+  }
+
+  const data: unknown = await response.json();
+  if (!isListOrdersPage(data)) {
+    throw new Error("Invalid VTEX List Orders response");
+  }
+
+  return {
+    orders: data.paging.total,
+    totalValue: extractStatsSum(data),
+  };
+}
+
+export async function fetchHourlyBuckets(
+  baseUrl: string,
+  headers: Record<string, string>,
+  date: string,
+  timezone: string,
+): Promise<HourlyOrderBucket[]> {
+  const hourRanges = getHourRangesForLocalDate(date, timezone);
+
+  const fetched = await Promise.all(
+    hourRanges.map(async (range) => {
+      const stats = await fetchRangeStats(
+        baseUrl,
+        headers,
+        range.start,
+        range.end,
+      );
+
+      return {
+        hour: range.hour,
+        count: stats.orders,
+        totalValue: stats.totalValue,
+      };
+    }),
+  );
+
+  return padHourlyBuckets(fetched);
+}

--- a/vtex/server/tools/custom/orders-sales-card.ts
+++ b/vtex/server/tools/custom/orders-sales-card.ts
@@ -1,0 +1,56 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { VTEX_RESOURCE_URI } from "../../constants.ts";
+import type { Env } from "../../types/env.ts";
+import {
+  buildOmsHeaders,
+  buildOmsOrdersUrl,
+  DEFAULT_STORE_TIMEZONE,
+  fetchRangeStats,
+  getDateRangeForPeriod,
+  salesPeriodSchema,
+} from "./orders-oms.ts";
+
+const outputSchema = z.object({
+  period: salesPeriodSchema,
+  orders: z.number(),
+  totalValue: z.number(),
+  date: z.string().optional(),
+});
+
+export const ordersSalesCard = (_env: Env) =>
+  createTool({
+    id: "VTEX_ORDERS_SALES_CARD",
+    description:
+      "Sales summary card for a time window: today, last hour, or last 5 minutes. Uses OMS List Orders with _stats=1 (single request).",
+    inputSchema: z.object({
+      period: salesPeriodSchema.describe(
+        'Time window: "today" (local calendar day), "last_1h", or "last_5min".',
+      ),
+    }),
+    outputSchema,
+    _meta: { ui: { resourceUri: VTEX_RESOURCE_URI } },
+    annotations: { readOnlyHint: true },
+    execute: async ({ context, runtimeContext }) => {
+      const env = runtimeContext.env as Env;
+      const { accountName, appKey, appToken } = env.MESH_REQUEST_CONTEXT.state;
+      const timezone = DEFAULT_STORE_TIMEZONE;
+      const { period } = context;
+      const range = getDateRangeForPeriod(period, timezone);
+
+      const creds = { accountName, appKey, appToken };
+      const stats = await fetchRangeStats(
+        buildOmsOrdersUrl(accountName),
+        buildOmsHeaders(creds),
+        range.start,
+        range.end,
+      );
+
+      return {
+        period,
+        orders: stats.orders,
+        totalValue: stats.totalValue,
+        ...(range.date ? { date: range.date } : {}),
+      };
+    },
+  });

--- a/vtex/server/tools/custom/orders-timeline.ts
+++ b/vtex/server/tools/custom/orders-timeline.ts
@@ -1,0 +1,49 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { VTEX_RESOURCE_URI } from "../../constants.ts";
+import type { Env } from "../../types/env.ts";
+import {
+  buildOmsHeaders,
+  buildOmsOrdersUrl,
+  DEFAULT_STORE_TIMEZONE,
+  fetchHourlyBuckets,
+  getTodayWindowInTimezone,
+} from "./orders-oms.ts";
+
+const hourBucketSchema = z.object({
+  hour: z.string(),
+  count: z.number(),
+  totalValue: z.number(),
+});
+
+const outputSchema = z.object({
+  hours: z.array(hourBucketSchema),
+  date: z.string(),
+});
+
+export const ordersTimeline = (_env: Env) =>
+  createTool({
+    id: "VTEX_ORDERS_TIMELINE",
+    description:
+      "Fetch today's orders aggregated by hour for a bar chart. Uses OMS List Orders with _stats=1 (one request per elapsed hour today).",
+    inputSchema: z.object({}),
+    outputSchema,
+    _meta: { ui: { resourceUri: VTEX_RESOURCE_URI } },
+    annotations: { readOnlyHint: true },
+    execute: async ({ runtimeContext }) => {
+      const env = runtimeContext.env as Env;
+      const { accountName, appKey, appToken } = env.MESH_REQUEST_CONTEXT.state;
+      const timezone = DEFAULT_STORE_TIMEZONE;
+      const { date } = getTodayWindowInTimezone(timezone);
+
+      const creds = { accountName, appKey, appToken };
+      const hours = await fetchHourlyBuckets(
+        buildOmsOrdersUrl(accountName),
+        buildOmsHeaders(creds),
+        date,
+        timezone,
+      );
+
+      return { hours, date };
+    },
+  });

--- a/vtex/server/tools/index.ts
+++ b/vtex/server/tools/index.ts
@@ -81,6 +81,8 @@ import {
 } from "./registry.ts";
 
 // ── Custom tools ──────────────────────────────────────────────────────────────
+import { ordersTimeline } from "./custom/orders-timeline.ts";
+import { ordersSalesCard } from "./custom/orders-sales-card.ts";
 import { searchCollections } from "./custom/search-collections.ts";
 import { reorderCollection } from "./custom/reorder-collection.ts";
 import { updateProductSpecifications } from "./custom/update-product-specifications.ts";
@@ -162,6 +164,10 @@ const registryFactories = [
 ];
 
 const customFactories = [
+  // Today's orders timeline chart (MCP App UI)
+  ordersTimeline,
+  // Sales summary card for today / last hour / last 5 min (MCP App UI)
+  ordersSalesCard,
   // Collection search (endpoint absent from generated SDKs)
   searchCollections,
   // Collection overwrite/reorder via XML import flow

--- a/vtex/tsconfig.json
+++ b/vtex/tsconfig.json
@@ -18,8 +18,11 @@
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "types": ["@cloudflare/workers-types", "bun"]
+    "types": ["@cloudflare/workers-types", "bun", "vite/client"],
+    "paths": {
+      "@/*": ["./web/*"]
+    }
   },
-  "include": ["server", "shared", "scripts"],
+  "include": ["server", "shared", "scripts", "web"],
   "exclude": ["server/generated"]
 }

--- a/vtex/vite.config.ts
+++ b/vtex/vite.config.ts
@@ -1,0 +1,29 @@
+import path from "node:path";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+import { viteSingleFile } from "vite-plugin-singlefile";
+
+export default defineConfig({
+  plugins: [
+    react({
+      babel: {
+        plugins: ["babel-plugin-react-compiler"],
+      },
+    }),
+    tailwindcss(),
+    viteSingleFile(),
+  ],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./web"),
+    },
+  },
+  build: {
+    outDir: "dist/client",
+    emptyOutDir: true,
+    rollupOptions: {
+      input: "index.html",
+    },
+  },
+});

--- a/vtex/web/app.tsx
+++ b/vtex/web/app.tsx
@@ -1,0 +1,20 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { McpProvider } from "./context.tsx";
+import { AppRouter } from "./router.tsx";
+import "./globals.css";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+  throw new Error("Missing root element");
+}
+
+const root = createRoot(rootElement);
+root.render(
+  <StrictMode>
+    <McpProvider>
+      <AppRouter />
+    </McpProvider>
+  </StrictMode>,
+);

--- a/vtex/web/components/page-header.tsx
+++ b/vtex/web/components/page-header.tsx
@@ -1,0 +1,19 @@
+interface PageHeaderProps {
+  title: string;
+  subtitle?: string;
+  right?: React.ReactNode;
+}
+
+export function PageHeader({ title, subtitle, right }: PageHeaderProps) {
+  return (
+    <header className="flex items-start justify-between gap-4 mb-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+        {subtitle ? (
+          <p className="text-sm text-muted-foreground mt-1">{subtitle}</p>
+        ) : null}
+      </div>
+      {right ? <div>{right}</div> : null}
+    </header>
+  );
+}

--- a/vtex/web/components/status-frame.tsx
+++ b/vtex/web/components/status-frame.tsx
@@ -1,0 +1,90 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.tsx";
+import type { McpStatus } from "../types.ts";
+
+interface StatusFrameProps {
+  status: McpStatus;
+  error?: string;
+  pendingMessage?: string;
+  connectedTitle?: string;
+  connectedHint?: string;
+}
+
+export function StatusFrame({
+  status,
+  error,
+  pendingMessage = "Loading…",
+  connectedTitle = "VTEX Dashboard",
+  connectedHint = "Invoke a tool to see analytics here.",
+}: StatusFrameProps) {
+  if (status === "initializing") {
+    return (
+      <div className="flex items-center justify-center min-h-dvh p-6">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <span className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
+          <span className="text-sm">Connecting to host…</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "connected") {
+    return (
+      <div className="flex items-center justify-center min-h-dvh p-6">
+        <Card className="w-full max-w-md text-center">
+          <CardHeader>
+            <CardTitle>{connectedTitle}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-muted-foreground text-sm">{connectedHint}</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <div className="flex items-center justify-center min-h-dvh p-6">
+        <Card className="w-full max-w-md border-destructive">
+          <CardHeader>
+            <CardTitle className="text-destructive">Error</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-destructive whitespace-pre-wrap break-words">
+              {error ?? "Unknown error"}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (status === "tool-cancelled") {
+    return (
+      <div className="flex items-center justify-center min-h-dvh p-6">
+        <Card className="w-full max-w-md border-destructive">
+          <CardHeader>
+            <CardTitle className="text-destructive">Cancelled</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-destructive">Tool call was cancelled.</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-dvh p-6">
+      <div className="flex items-center gap-3 text-muted-foreground">
+        <span className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
+        <span className="text-sm">{pendingMessage}</span>
+      </div>
+    </div>
+  );
+}

--- a/vtex/web/components/ui/card.tsx
+++ b/vtex/web/components/ui/card.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import { cn } from "@/lib/utils.ts";
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  );
+}
+
+export { Card, CardContent, CardHeader, CardTitle };

--- a/vtex/web/context.tsx
+++ b/vtex/web/context.tsx
@@ -1,0 +1,102 @@
+import {
+  type App,
+  type McpUiHostContext,
+  useApp,
+  useHostStyles,
+} from "@modelcontextprotocol/ext-apps/react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useState,
+} from "react";
+import { INITIAL_STATE, type McpState } from "./types.ts";
+
+const McpStateContext = createContext<McpState>(INITIAL_STATE);
+const McpAppContext = createContext<App | null>(null);
+const McpHostContext = createContext<McpUiHostContext | undefined>(undefined);
+
+export function McpProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<McpState>(INITIAL_STATE);
+  const [hostContext, setHostContext] = useState<McpUiHostContext | undefined>(
+    undefined,
+  );
+
+  const onAppCreated = useCallback((app: App) => {
+    app.ontoolinput = (params) => {
+      setState((prev) => ({
+        ...prev,
+        status: "tool-input",
+        toolInput: params.arguments,
+      }));
+    };
+
+    app.ontoolresult = (result) => {
+      if (result.isError) {
+        const textBlock = result.content?.find((c) => c.type === "text");
+        const errorText =
+          (textBlock?.type === "text" ? textBlock.text : undefined) ??
+          "Tool returned an error";
+        setState((prev) => ({ ...prev, status: "error", error: errorText }));
+        return;
+      }
+      setState((prev) => ({
+        ...prev,
+        status: "tool-result",
+        toolResult: result.structuredContent,
+      }));
+    };
+
+    app.ontoolcancelled = () => {
+      setState((prev) => ({ ...prev, status: "tool-cancelled" }));
+    };
+
+    app.onerror = (err) => {
+      console.error("MCP App error:", err);
+    };
+
+    app.onhostcontextchanged = (ctx) => {
+      setHostContext((prev) => ({ ...prev, ...ctx }));
+    };
+  }, []);
+
+  const { app, isConnected } = useApp({
+    appInfo: { name: "VTEX MCP App", version: "1.0.0" },
+    capabilities: {},
+    onAppCreated,
+  });
+
+  useHostStyles(app, app?.getHostContext());
+
+  if (isConnected && state.status === "initializing") {
+    const ctx = app?.getHostContext();
+    if (ctx) setHostContext(ctx);
+    const toolName = ctx?.toolInfo?.tool.name;
+    setState({ status: "connected", toolName });
+  }
+
+  return (
+    <McpAppContext.Provider value={app}>
+      <McpHostContext.Provider value={hostContext}>
+        <McpStateContext.Provider value={state}>
+          {children}
+        </McpStateContext.Provider>
+      </McpHostContext.Provider>
+    </McpAppContext.Provider>
+  );
+}
+
+export function useMcpState<TInput = unknown, TResult = unknown>() {
+  return useContext(McpStateContext) as McpState<TInput, TResult>;
+}
+
+export function useMcpApp() {
+  return useContext(McpAppContext);
+}
+
+export function useMcpHostContext() {
+  return useContext(McpHostContext);
+}
+
+export { useDocumentTheme as useTheme } from "@modelcontextprotocol/ext-apps/react";

--- a/vtex/web/globals.css
+++ b/vtex/web/globals.css
@@ -1,0 +1,111 @@
+@import "tailwindcss";
+
+@custom-variant dark (&:is([data-theme="dark"] *));
+
+:root {
+	/* Host variable fallbacks (light) */
+	--color-background-primary: hsl(0 0% 100%);
+	--color-background-secondary: hsl(240 4.8% 95.9%);
+	--color-background-tertiary: hsl(240 4.8% 95.9%);
+	--color-background-danger: hsl(0 84.2% 60.2%);
+	--color-text-primary: hsl(240 10% 3.9%);
+	--color-text-secondary: hsl(240 3.8% 46.1%);
+	--color-border-primary: hsl(240 5.9% 90%);
+	--color-border-secondary: hsl(240 5.9% 90%);
+	--color-ring-primary: hsl(240 5.9% 10%);
+
+	/* VTEX brand */
+	--primary: #f71963;
+	--primary-foreground: #ffffff;
+	--color-ring-primary: #f71963;
+
+	/* Sidebar tokens (existing) */
+	--sidebar: hsl(0 0% 98%);
+	--sidebar-foreground: hsl(240 5.3% 26.1%);
+	--sidebar-primary: #f71963;
+	--sidebar-primary-foreground: #ffffff;
+	--sidebar-accent: hsl(240 4.8% 95.9%);
+	--sidebar-accent-foreground: hsl(240 5.9% 10%);
+	--sidebar-border: hsl(220 13% 91%);
+	--sidebar-ring: #f71963;
+}
+
+[data-theme="dark"] {
+	/* Host variable fallbacks (dark) */
+	--color-background-primary: hsl(240 10% 3.9%);
+	--color-background-secondary: hsl(240 3.7% 15.9%);
+	--color-background-tertiary: hsl(240 3.7% 15.9%);
+	--color-background-danger: hsl(0 62.8% 30.6%);
+	--color-text-primary: hsl(0 0% 98%);
+	--color-text-secondary: hsl(240 5% 64.9%);
+	--color-border-primary: hsl(240 3.7% 15.9%);
+	--color-border-secondary: hsl(240 3.7% 15.9%);
+	--color-ring-primary: hsl(240 4.9% 83.9%);
+
+	/* VTEX brand */
+	--primary: #f71963;
+	--primary-foreground: #ffffff;
+	--color-ring-primary: #f71963;
+
+	/* Sidebar tokens (existing) */
+	--sidebar: hsl(240 5.9% 10%);
+	--sidebar-foreground: hsl(240 4.8% 95.9%);
+	--sidebar-primary: #f71963;
+	--sidebar-primary-foreground: #ffffff;
+	--sidebar-accent: hsl(240 3.7% 15.9%);
+	--sidebar-accent-foreground: hsl(240 4.8% 95.9%);
+	--sidebar-border: hsl(240 3.7% 15.9%);
+	--sidebar-ring: #f71963;
+}
+
+@layer base {
+	button,
+	a,
+	select,
+	summary,
+	[role="button"],
+	[role="tab"],
+	[role="checkbox"],
+	[role="radio"],
+	[role="switch"],
+	[role="menuitem"],
+	[role="option"],
+	label[for] {
+		cursor: pointer;
+	}
+}
+
+@theme inline {
+	/* Core colors — mapped from host variables */
+	--color-background: var(--color-background-primary);
+	--color-foreground: var(--color-text-primary);
+	--color-card: var(--color-background-primary);
+	--color-card-foreground: var(--color-text-primary);
+	--color-popover: var(--color-background-primary);
+	--color-popover-foreground: var(--color-text-primary);
+	--color-primary: var(--primary);
+	--color-primary-foreground: var(--primary-foreground);
+	--color-secondary: var(--color-background-secondary);
+	--color-secondary-foreground: var(--color-text-primary);
+	--color-muted: var(--color-background-secondary);
+	--color-muted-foreground: var(--color-text-secondary);
+	--color-accent: var(--color-background-tertiary);
+	--color-accent-foreground: var(--color-text-primary);
+	--color-destructive: var(--color-background-danger);
+	--color-border: var(--color-border-primary);
+	--color-input: var(--color-border-secondary);
+	--color-ring: var(--color-ring-primary);
+
+	/* Layout */
+	--radius-DEFAULT: var(--border-radius-md, 0.375rem);
+
+	/* Sidebar (existing) */
+	--color-sidebar: var(--sidebar);
+	--color-sidebar-foreground: var(--sidebar-foreground);
+	--color-sidebar-primary: var(--sidebar-primary);
+	--color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+	--color-sidebar-accent: var(--sidebar-accent);
+	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+	--color-sidebar-border: var(--sidebar-border);
+	--color-sidebar-ring: var(--sidebar-ring);
+}

--- a/vtex/web/lib/utils.ts
+++ b/vtex/web/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/vtex/web/router.tsx
+++ b/vtex/web/router.tsx
@@ -1,0 +1,84 @@
+import { createHashHistory } from "@tanstack/history";
+import {
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { useMcpHostContext, useMcpState } from "./context.tsx";
+import OrdersTimelinePage from "./tools/orders-timeline/index.tsx";
+import OrdersSalesCardPage from "./tools/orders-sales-card/index.tsx";
+
+const TOOL_PAGES: Record<string, React.ComponentType> = {
+  VTEX_ORDERS_TIMELINE: OrdersTimelinePage,
+  VTEX_ORDERS_SALES_CARD: OrdersSalesCardPage,
+};
+
+function ToolRouter() {
+  const { toolName } = useMcpState();
+
+  if (!toolName) {
+    return (
+      <div className="flex items-center justify-center min-h-dvh p-6">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <span className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
+          <span className="text-sm">Connecting to host...</span>
+        </div>
+      </div>
+    );
+  }
+
+  const Page = TOOL_PAGES[toolName];
+
+  if (!Page) {
+    return (
+      <div className="flex items-center justify-center min-h-dvh p-6">
+        <p className="text-sm text-destructive">Unknown tool: {toolName}</p>
+      </div>
+    );
+  }
+
+  return <Page />;
+}
+
+const rootRoute = createRootRoute({ component: RootLayout });
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  component: ToolRouter,
+});
+
+const routeTree = rootRoute.addChildren([indexRoute]);
+
+const router = createRouter({
+  routeTree,
+  history: createHashHistory(),
+});
+
+export function AppRouter() {
+  return <RouterProvider router={router} />;
+}
+
+function RootLayout() {
+  const hostContext = useMcpHostContext();
+  const insets = hostContext?.safeAreaInsets;
+
+  return (
+    <div
+      style={
+        insets
+          ? {
+              paddingTop: `${insets.top}px`,
+              paddingRight: `${insets.right}px`,
+              paddingBottom: `${insets.bottom}px`,
+              paddingLeft: `${insets.left}px`,
+            }
+          : undefined
+      }
+    >
+      <Outlet />
+    </div>
+  );
+}

--- a/vtex/web/tools/orders-sales-card/index.tsx
+++ b/vtex/web/tools/orders-sales-card/index.tsx
@@ -1,0 +1,85 @@
+import { Clock, Timer, TrendingUp } from "lucide-react";
+import { StatusFrame } from "@/components/status-frame.tsx";
+import { Card, CardContent } from "@/components/ui/card.tsx";
+import { useMcpState } from "@/context.tsx";
+
+type SalesPeriod = "today" | "last_1h" | "last_5min";
+
+interface SalesCardInput {
+  period: SalesPeriod;
+}
+
+interface SalesCardOutput {
+  period: SalesPeriod;
+  orders: number;
+  totalValue: number;
+  date?: string;
+}
+
+const PERIOD_LABELS: Record<SalesPeriod, string> = {
+  today: "Vendas hoje",
+  last_1h: "Última 1h",
+  last_5min: "Últimos 5 min",
+};
+
+const PERIOD_ICONS: Record<SalesPeriod, React.ReactNode> = {
+  today: <TrendingUp className="w-5 h-5" />,
+  last_1h: <Clock className="w-5 h-5" />,
+  last_5min: <Timer className="w-5 h-5" />,
+};
+
+function fmt(n: number | undefined) {
+  return new Intl.NumberFormat("pt-BR").format(n ?? 0);
+}
+
+function fmtCurrency(cents: number | undefined) {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  }).format((cents ?? 0) / 100);
+}
+
+export default function OrdersSalesCardPage() {
+  const state = useMcpState<SalesCardInput, SalesCardOutput>();
+
+  if (state.status !== "tool-result") {
+    return (
+      <StatusFrame
+        status={state.status}
+        error={state.error}
+        pendingMessage="Carregando vendas…"
+        connectedTitle="Sales Card"
+        connectedHint='Chame VTEX_ORDERS_SALES_CARD com period: "today", "last_1h" ou "last_5min".'
+      />
+    );
+  }
+
+  const period = state.toolResult?.period ?? state.toolInput?.period ?? "today";
+  const orders = state.toolResult?.orders ?? 0;
+  const totalValue = state.toolResult?.totalValue ?? 0;
+  const date = state.toolResult?.date;
+
+  return (
+    <div className="p-4">
+      <Card>
+        <CardContent className="p-4 flex items-center gap-3">
+          <div className="w-10 h-10 rounded-md bg-primary/10 flex items-center justify-center text-primary shrink-0">
+            {PERIOD_ICONS[period]}
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs text-muted-foreground">
+              {PERIOD_LABELS[period]}
+            </p>
+            <p className="text-xl font-semibold tabular-nums truncate">
+              {fmtCurrency(totalValue)}
+            </p>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {fmt(orders)} pedidos
+              {period === "today" && date ? ` · ${date}` : ""}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/vtex/web/tools/orders-timeline/index.tsx
+++ b/vtex/web/tools/orders-timeline/index.tsx
@@ -1,0 +1,107 @@
+import { DollarSign } from "lucide-react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { PageHeader } from "@/components/page-header.tsx";
+import { StatusFrame } from "@/components/status-frame.tsx";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.tsx";
+import { useMcpState } from "@/context.tsx";
+
+interface HourBucket {
+  hour: string;
+  count: number;
+  totalValue: number;
+}
+
+interface OrdersTimelineOutput {
+  hours: HourBucket[];
+  date: string;
+}
+
+function fmt(n: number | undefined) {
+  return new Intl.NumberFormat("pt-BR").format(n ?? 0);
+}
+
+function fmtCurrency(cents: number | undefined) {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  }).format((cents ?? 0) / 100);
+}
+
+export default function OrdersTimelinePage() {
+  const state = useMcpState<Record<string, never>, OrdersTimelineOutput>();
+
+  if (state.status !== "tool-result") {
+    return (
+      <StatusFrame
+        status={state.status}
+        error={state.error}
+        pendingMessage="Carregando timeline…"
+        connectedTitle="Orders Timeline"
+        connectedHint="Chame VTEX_ORDERS_TIMELINE."
+      />
+    );
+  }
+
+  const { hours, date } = state.toolResult ?? { hours: [], date: "" };
+
+  return (
+    <div className="p-6">
+      <PageHeader
+        title="Orders Timeline"
+        subtitle={`Pedidos de hoje (${date}, UTC-3) por hora`}
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <DollarSign className="w-4 h-4" />
+            Pedidos por hora
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {hours.every((bucket) => bucket.count === 0) ? (
+            <p className="text-sm text-muted-foreground">
+              Nenhum pedido encontrado hoje.
+            </p>
+          ) : (
+            <ResponsiveContainer width="100%" height={300}>
+              <BarChart
+                data={hours}
+                margin={{ top: 8, right: 16, bottom: 8, left: 0 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                <XAxis dataKey="hour" tick={{ fontSize: 11 }} interval={1} />
+                <YAxis tick={{ fontSize: 11 }} allowDecimals={false} />
+                <Tooltip
+                  formatter={(value: number, name: string) => {
+                    if (name === "count") return [fmt(value), "Pedidos"];
+                    return [fmtCurrency(value), "Vendas"];
+                  }}
+                />
+                <Bar
+                  dataKey="count"
+                  fill="#f71963"
+                  radius={[4, 4, 0, 0]}
+                  name="count"
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/vtex/web/types.ts
+++ b/vtex/web/types.ts
@@ -1,0 +1,17 @@
+export type McpStatus =
+  | "initializing"
+  | "connected"
+  | "tool-input"
+  | "tool-result"
+  | "tool-cancelled"
+  | "error";
+
+export interface McpState<TInput = unknown, TResult = unknown> {
+  status: McpStatus;
+  toolName?: string;
+  error?: string;
+  toolInput?: TInput;
+  toolResult?: TResult;
+}
+
+export const INITIAL_STATE: McpState = { status: "initializing" };


### PR DESCRIPTION
Reverts decocms/mcps#457

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a VTEX MCP App UI that renders an orders dashboard with today’s hourly timeline and a sales summary card, and wires it to new tools backed by OMS stats. Also serves a single-file React build via a public MCP resource and routes `/api/mcp` to the MCP server.

- **New Features**
  - Bundled React UI (Tailwind) via `vite`, served as `ui://vtex/dashboard`; tools point `_meta.ui.resourceUri` to it.
  - New tools: `VTEX_ORDERS_TIMELINE` (today’s orders by hour) and `VTEX_ORDERS_SALES_CARD` (`today`, `last_1h`, `last_5min`).
  - Server updates: public dashboard resource reader, `/api/mcp` route shim, `Bun.serve` on port 3001, web bundle at `dist/client/index.html`.
  - OMS helpers aggregate with `_stats=1` per range and default store timezone `-03:00`.
  - README lists both tools.

- **Dependencies**
  - Adds `react`, `react-dom`, `@modelcontextprotocol/ext-apps`, `@tanstack/react-router`, `recharts`, `tailwindcss`, `@tailwindcss/vite`, `lucide-react`; dev: `vite`, `vite-plugin-singlefile`, `@vitejs/plugin-react`, `concurrently`.
  - Scripts: `dev` runs API and web in parallel; `build` compiles web first, then server.

<sup>Written for commit 758e3c7944444723b1859264b7b904775038ab7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

