### PR TITLE
Revert "Revert "feat(vtex): orders timeline MCP App UI backed by analytics trend""

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1041,7 +1041,18 @@
       "dependencies": {
         "@decocms/bindings": "^1.4.0",
         "@decocms/runtime": "^1.6.2",
+        "@modelcontextprotocol/ext-apps": "^1.1.2",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "@tailwindcss/vite": "^4.2.1",
+        "@tanstack/history": "^1.133.5",
+        "@tanstack/react-router": "^1.133.5",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.576.0",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "recharts": "2.15.4",
+        "tailwind-merge": "^3.5.0",
+        "tailwindcss": "^4.2.1",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -1050,8 +1061,15 @@
         "@hey-api/client-fetch": "^0.8.0",
         "@hey-api/openapi-ts": "0.92.4",
         "@types/bun": "^1.2.14",
+        "@types/react": "^19.2.2",
+        "@types/react-dom": "^19.2.2",
+        "@vitejs/plugin-react": "^5.0.4",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "concurrently": "^9.2.1",
         "deco-cli": "^0.28.0",
         "typescript": "^5.7.2",
+        "vite": "^7.3.1",
+        "vite-plugin-singlefile": "^2.3.0",
       },
     },
     "vtex-docs": {
@@ -4418,6 +4436,8 @@
 
     "vtex/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
+    "vtex/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
     "vtex/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "vtex-docs/@decocms/runtime": ["@decocms/runtime@1.1.3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-pj6OccmpWulMjyOt9FHTNX41xHk800uzhmoYK/xq9h1f+DfDBMqyOZnt70Zmwrab7dMDO2w3VQD+NlgFKtrw1w=="],
@@ -4971,6 +4991,8 @@
     "vtex-docs/ai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "vtex/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
+
+    "vtex/vite/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
 
     "whatsapp-management/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
@@ -5543,6 +5565,58 @@
     "vtex-docs/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
 
     "vtex-docs/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "vtex/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
+
+    "vtex/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.0", "", { "os": "android", "cpu": "arm" }, "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ=="],
+
+    "vtex/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ=="],
+
+    "vtex/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.0", "", { "os": "android", "cpu": "x64" }, "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q=="],
+
+    "vtex/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg=="],
+
+    "vtex/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g=="],
+
+    "vtex/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw=="],
+
+    "vtex/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w=="],
+
+    "vtex/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw=="],
+
+    "vtex/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w=="],
+
+    "vtex/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.0", "", { "os": "none", "cpu": "x64" }, "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA=="],
+
+    "vtex/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ=="],
+
+    "vtex/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A=="],
+
+    "vtex/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA=="],
+
+    "vtex/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA=="],
+
+    "vtex/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg=="],
+
+    "vtex/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ=="],
+
+    "vtex/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
 
     "whatsapp-management/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
 

--- a/vtex/README.md
+++ b/vtex/README.md
@@ -41,10 +41,21 @@ These handle multi-step operations not available in the generated SDK:
 | `VTEX_SEARCH_COLLECTIONS` | Search collections by name or terms |
 | `VTEX_REORDER_COLLECTION` | Reorder collections with SKU/product IDs via XML import |
 | `VTEX_UPDATE_PRODUCT_SPECIFICATIONS` | Bulk replace product specifications |
+| `VTEX_ORDERS_TIMELINE` | Hourly orders bar chart for today (MCP App UI; `ui://vtex/orders-timeline`) |
+| `VTEX_ORDERS_SALES_CARD` | Sales cards for `today`, `last_1h`, and `last_5min` (MCP App UI; `ui://vtex/orders-sales-card`; all three by default) |
 | `VTEX_GET_ORDERS_TREND` | Admin home dashboard orders trend (internal analytics service); exchanges App Key/Token for a session token under the hood |
 | `VTEX_GET_HOME_METRICS_SUMMARY` | Admin home dashboard metrics summary (revenue, orders, sessions, conversion) vs previous day |
 | `VTEX_GET_HOME_TOP_VIEWED_PRODUCTS` | Most viewed products on the admin home dashboard |
 | `VTEX_GET_HOME_TOP_PRODUCTS` | Top-selling products on the admin home dashboard ranked by revenue vs previous day |
+
+### MCP App UI
+
+Each web tool has its own MCP resource URI and HTML bundle:
+
+| Tool | Resource URI | HTML bundle |
+|------|--------------|-------------|
+| `VTEX_ORDERS_TIMELINE` | `ui://vtex/orders-timeline` | `dist/client/orders-timeline.html` |
+| `VTEX_ORDERS_SALES_CARD` | `ui://vtex/orders-sales-card` | `dist/client/orders-sales-card.html` |
 
 ## Authentication
 

--- a/vtex/components.json
+++ b/vtex/components.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://ui.shadcn.com/schema.json",
+	"style": "new-york",
+	"rsc": false,
+	"tsx": true,
+	"tailwind": {
+		"config": "",
+		"css": "web/globals.css",
+		"baseColor": "neutral",
+		"cssVariables": true,
+		"prefix": ""
+	},
+	"iconLibrary": "lucide",
+	"rtl": false,
+	"aliases": {
+		"components": "@/components",
+		"utils": "@/lib/utils",
+		"ui": "@/components/ui",
+		"lib": "@/lib",
+		"hooks": "@/hooks"
+	},
+	"registries": {}
+}

--- a/vtex/orders-sales-card.html
+++ b/vtex/orders-sales-card.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>VTEX Orders Sales Card</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./web/tools/orders-sales-card/main.tsx"></script>
+	</body>
+</html>

--- a/vtex/orders-timeline.html
+++ b/vtex/orders-timeline.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>VTEX Orders Timeline</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./web/tools/orders-timeline/main.tsx"></script>
+	</body>
+</html>

--- a/vtex/package.json
+++ b/vtex/package.json
@@ -5,13 +5,16 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "bun run --hot server/main.ts",
+    "dev": "concurrently -k -n api,web -c magenta,cyan \"bun run dev:api\" \"bun run dev:web\"",
+    "dev:api": "bun run --hot server/main.ts",
+    "dev:web": "bun run build:web && concurrently -n timeline,sales \"MCP_APP_ENTRY=orders-timeline MCP_APP_EMPTY_OUTDIR=false vite build --watch\" \"MCP_APP_ENTRY=orders-sales-card MCP_APP_EMPTY_OUTDIR=false vite build --watch\"",
     "configure": "deco configure",
     "gen": "deco gen --output=shared/deco.gen.ts",
     "deploy": "npm run build && deco deploy ./dist/server",
     "check": "tsc --noEmit",
+    "build:web": "MCP_APP_ENTRY=orders-timeline MCP_APP_EMPTY_OUTDIR=true vite build && MCP_APP_ENTRY=orders-sales-card MCP_APP_EMPTY_OUTDIR=false vite build",
     "build:server": "NODE_ENV=production bun build server/main.ts --target=bun --outfile=dist/server/main.js",
-    "build": "bun run build:server",
+    "build": "bun run build:web && bun run build:server",
     "openapi": "openapi-ts",
     "generate": "bun run download-schemas && bun run openapi",
     "download-schemas": "bun run scripts/download-schemas.ts",
@@ -20,7 +23,18 @@
   "dependencies": {
     "@decocms/bindings": "^1.4.0",
     "@decocms/runtime": "^1.6.2",
+    "@modelcontextprotocol/ext-apps": "^1.1.2",
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "@tailwindcss/vite": "^4.2.1",
+    "@tanstack/history": "^1.133.5",
+    "@tanstack/react-router": "^1.133.5",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.576.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "recharts": "2.15.4",
+    "tailwind-merge": "^3.5.0",
+    "tailwindcss": "^4.2.1",
     "zod": "^4.0.0"
   },
   "devDependencies": {
@@ -29,8 +43,15 @@
     "@hey-api/client-fetch": "^0.8.0",
     "@hey-api/openapi-ts": "0.92.4",
     "@types/bun": "^1.2.14",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.2",
+    "@vitejs/plugin-react": "^5.0.4",
+    "babel-plugin-react-compiler": "^1.0.0",
+    "concurrently": "^9.2.1",
     "deco-cli": "^0.28.0",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vite": "^7.3.1",
+    "vite-plugin-singlefile": "^2.3.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/vtex/server/constants.ts
+++ b/vtex/server/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * MCP App resource URIs — one exclusive URI per web tool page.
+ */
+export const VTEX_ORDERS_TIMELINE_RESOURCE_URI = "ui://vtex/orders-timeline";
+export const VTEX_ORDERS_SALES_CARD_RESOURCE_URI =
+  "ui://vtex/orders-sales-card";

--- a/vtex/server/lib/vtexid-session.test.ts
+++ b/vtex/server/lib/vtexid-session.test.ts
@@ -4,6 +4,7 @@ import {
   buildAppTokenLoginUrl,
   getVtexIdSessionToken,
   jwtExpirySeconds,
+  vtexIdAuthHeaders,
   vtexIdCookieHeader,
   VTEXID_COOKIE_NAME,
 } from "./vtexid-session.ts";
@@ -23,6 +24,25 @@ describe("vtexIdCookieHeader", () => {
     expect(vtexIdCookieHeader("abc.def.ghi")).toBe(
       `${VTEXID_COOKIE_NAME}=abc.def.ghi`,
     );
+  });
+});
+
+describe("vtexIdAuthHeaders", () => {
+  test("includes admin Origin/Referer and optional app credentials", () => {
+    expect(
+      vtexIdAuthHeaders("lojafarm", "token123", {
+        appKey: "key",
+        appToken: "secret",
+      }),
+    ).toEqual({
+      Accept: "application/json",
+      Cookie: `${VTEXID_COOKIE_NAME}=token123`,
+      [VTEXID_COOKIE_NAME]: "token123",
+      Referer: "https://lojafarm.myvtex.com/admin/",
+      Origin: "https://lojafarm.myvtex.com",
+      "X-VTEX-API-AppKey": "key",
+      "X-VTEX-API-AppToken": "secret",
+    });
   });
 });
 

--- a/vtex/server/lib/vtexid-session.ts
+++ b/vtex/server/lib/vtexid-session.ts
@@ -40,6 +40,32 @@ export function vtexIdCookieHeader(token: string): string {
   return `${VTEXID_COOKIE_NAME}=${token}`;
 }
 
+/** Headers for internal VTEX admin endpoints (matches browser fetch shape). */
+export function vtexIdAuthHeaders(
+  accountName: string,
+  token: string,
+  creds?: Pick<VTEXCredentials, "appKey" | "appToken">,
+): Record<string, string> {
+  const origin = `https://${accountName}.myvtex.com`;
+
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    Cookie: vtexIdCookieHeader(token),
+    [VTEXID_COOKIE_NAME]: token,
+    Referer: `${origin}/admin/`,
+    Origin: origin,
+  };
+
+  if (creds?.appKey) {
+    headers["X-VTEX-API-AppKey"] = creds.appKey;
+  }
+  if (creds?.appToken) {
+    headers["X-VTEX-API-AppToken"] = creds.appToken;
+  }
+
+  return headers;
+}
+
 /**
  * Decode the `exp` (seconds since epoch) claim from a JWT without verifying it.
  * Returns null when the token isn't a parseable JWT or has no `exp`.

--- a/vtex/server/main.ts
+++ b/vtex/server/main.ts
@@ -3,8 +3,11 @@
  *
  * MCP for VTEX Commerce APIs - Catalog, Orders, and Logistics/Inventory.
  */
-import { serve } from "@decocms/mcps-shared/serve";
 import { withRuntime } from "@decocms/runtime";
+import {
+  ordersSalesCardResource,
+  ordersTimelineResource,
+} from "./resources/index.ts";
 import { tools } from "./tools/index.ts";
 import { type Env, StateSchema } from "./types/env.ts";
 import packageJson from "../package.json" with { type: "json" };
@@ -14,11 +17,44 @@ console.log(`VTEX Commerce MCP v${packageJson.version}`);
 export type { Env };
 export { StateSchema };
 
+// biome-ignore lint/suspicious/noExplicitAny: runtime.fetch signature compatibility
+type Fetcher = (req: Request, ...args: any[]) => Response | Promise<Response>;
+
+function withMcpApiRoute(fetcher: Fetcher): Fetcher {
+  return (req: Request, ...args) => {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/mcp" || url.pathname.startsWith("/mcp/")) {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    if (url.pathname === "/api/mcp" || url.pathname.startsWith("/api/mcp/")) {
+      url.pathname = url.pathname.slice(4);
+      const rewrittenReq = new Request(url.toString(), req);
+      return fetcher(rewrittenReq, ...args);
+    }
+
+    return fetcher(req, ...args);
+  };
+}
+
 const runtime = withRuntime<Env, typeof StateSchema>({
   configuration: {
     state: StateSchema,
   },
   tools,
+  resources: [ordersTimelineResource, ordersSalesCardResource],
 });
 
-serve(runtime.fetch);
+const PORT = Number(process.env.PORT) || 3001;
+
+Bun.serve({
+  idleTimeout: 0,
+  hostname: "0.0.0.0",
+  port: PORT,
+  fetch: withMcpApiRoute(runtime.fetch),
+});
+
+console.log("");
+console.log(`MCP App: http://localhost:${PORT}/api/mcp`);
+console.log("");

--- a/vtex/server/main.ts
+++ b/vtex/server/main.ts
@@ -3,6 +3,7 @@
  *
  * MCP for VTEX Commerce APIs - Catalog, Orders, and Logistics/Inventory.
  */
+import { serve } from "@decocms/mcps-shared/serve";
 import { withRuntime } from "@decocms/runtime";
 import {
   ordersSalesCardResource,
@@ -17,27 +18,6 @@ console.log(`VTEX Commerce MCP v${packageJson.version}`);
 export type { Env };
 export { StateSchema };
 
-// biome-ignore lint/suspicious/noExplicitAny: runtime.fetch signature compatibility
-type Fetcher = (req: Request, ...args: any[]) => Response | Promise<Response>;
-
-function withMcpApiRoute(fetcher: Fetcher): Fetcher {
-  return (req: Request, ...args) => {
-    const url = new URL(req.url);
-
-    if (url.pathname === "/mcp" || url.pathname.startsWith("/mcp/")) {
-      return new Response("Not Found", { status: 404 });
-    }
-
-    if (url.pathname === "/api/mcp" || url.pathname.startsWith("/api/mcp/")) {
-      url.pathname = url.pathname.slice(4);
-      const rewrittenReq = new Request(url.toString(), req);
-      return fetcher(rewrittenReq, ...args);
-    }
-
-    return fetcher(req, ...args);
-  };
-}
-
 const runtime = withRuntime<Env, typeof StateSchema>({
   configuration: {
     state: StateSchema,
@@ -46,15 +26,4 @@ const runtime = withRuntime<Env, typeof StateSchema>({
   resources: [ordersTimelineResource, ordersSalesCardResource],
 });
 
-const PORT = Number(process.env.PORT) || 3001;
-
-Bun.serve({
-  idleTimeout: 0,
-  hostname: "0.0.0.0",
-  port: PORT,
-  fetch: withMcpApiRoute(runtime.fetch),
-});
-
-console.log("");
-console.log(`MCP App: http://localhost:${PORT}/api/mcp`);
-console.log("");
+serve(runtime.fetch);

--- a/vtex/server/resources/index.ts
+++ b/vtex/server/resources/index.ts
@@ -1,0 +1,20 @@
+import {
+  VTEX_ORDERS_SALES_CARD_RESOURCE_URI,
+  VTEX_ORDERS_TIMELINE_RESOURCE_URI,
+} from "../constants.ts";
+import { createMcpAppResource } from "./mcp-app-resource.ts";
+
+export const ordersTimelineResource = createMcpAppResource({
+  uri: VTEX_ORDERS_TIMELINE_RESOURCE_URI,
+  name: "VTEX Orders Timeline",
+  description: "MCP App UI for today's hourly orders bar chart.",
+  htmlFile: "orders-timeline.html",
+});
+
+export const ordersSalesCardResource = createMcpAppResource({
+  uri: VTEX_ORDERS_SALES_CARD_RESOURCE_URI,
+  name: "VTEX Orders Sales Card",
+  description:
+    "MCP App UI for sales summary cards (today, last hour, last 5 minutes).",
+  htmlFile: "orders-sales-card.html",
+});

--- a/vtex/server/resources/mcp-app-resource.ts
+++ b/vtex/server/resources/mcp-app-resource.ts
@@ -1,0 +1,45 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createPublicResource } from "@decocms/runtime/tools";
+import type { Env } from "../types/env.ts";
+
+const RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
+
+function getHtmlPath(filename: string): string {
+  const projectRoot = join(import.meta.dir, "../..");
+  return join(projectRoot, "dist", "client", filename);
+}
+
+export function createMcpAppResource(options: {
+  uri: string;
+  name: string;
+  description: string;
+  htmlFile: string;
+}) {
+  return (_env: Env) =>
+    createPublicResource({
+      uri: options.uri,
+      name: options.name,
+      description: options.description,
+      mimeType: RESOURCE_MIME_TYPE,
+      read: async () => {
+        const htmlPath = getHtmlPath(options.htmlFile);
+        try {
+          const html = await readFile(htmlPath, "utf-8");
+          return {
+            uri: options.uri,
+            mimeType: RESOURCE_MIME_TYPE,
+            text: html,
+          };
+        } catch (err) {
+          const message =
+            err instanceof Error && "code" in err && err.code === "ENOENT"
+              ? `MCP App bundle not found at ${htmlPath}. Run "bun run build:web" in the vtex folder (or "bun run dev" to build and watch).`
+              : err instanceof Error
+                ? err.message
+                : "Failed to read MCP App bundle";
+          throw new Error(message);
+        }
+      },
+    });
+}

--- a/vtex/server/tools/custom/analytics-consumption.ts
+++ b/vtex/server/tools/custom/analytics-consumption.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import {
   getVtexIdSessionToken,
-  vtexIdCookieHeader,
+  vtexIdAuthHeaders,
 } from "../../lib/vtexid-session.ts";
 import type { VTEXCredentials } from "../../types/env.ts";
 import { DEFAULT_STORE_TIMEZONE } from "./orders-oms.ts";
@@ -33,10 +33,7 @@ export async function fetchAnalyticsConsumption(
   const url = buildAnalyticsConsumptionUrl(creds.accountName, path, params);
 
   const response = await fetch(url, {
-    headers: {
-      Accept: "application/json",
-      Cookie: vtexIdCookieHeader(token),
-    },
+    headers: vtexIdAuthHeaders(creds.accountName, token, creds),
   });
 
   if (!response.ok) {

--- a/vtex/server/tools/custom/orders-sales-card.ts
+++ b/vtex/server/tools/custom/orders-sales-card.ts
@@ -1,0 +1,79 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { VTEX_ORDERS_SALES_CARD_RESOURCE_URI } from "../../constants.ts";
+import type { Env } from "../../types/env.ts";
+import {
+  buildOmsHeaders,
+  buildOmsOrdersUrl,
+  DEFAULT_STORE_TIMEZONE,
+  fetchRangeStats,
+  getDateRangeForPeriod,
+  salesPeriodSchema,
+  type SalesPeriod,
+} from "./orders-oms.ts";
+
+const ALL_SALES_PERIODS = ["today", "last_1h", "last_5min"] as const;
+
+const salesCardSchema = z.object({
+  period: salesPeriodSchema,
+  orders: z.number(),
+  totalValue: z.number(),
+  date: z.string().optional(),
+});
+
+const outputSchema = z.object({
+  cards: z.array(salesCardSchema),
+});
+
+async function fetchSalesCard(
+  period: SalesPeriod,
+  creds: { accountName: string; appKey?: string; appToken?: string },
+  timezone: string,
+) {
+  const range = getDateRangeForPeriod(period, timezone);
+  const stats = await fetchRangeStats(
+    buildOmsOrdersUrl(creds.accountName),
+    buildOmsHeaders(creds),
+    range.start,
+    range.end,
+  );
+
+  return {
+    period,
+    orders: stats.orders,
+    totalValue: stats.totalValue,
+    ...(range.date ? { date: range.date } : {}),
+  };
+}
+
+export const ordersSalesCard = (_env: Env) =>
+  createTool({
+    id: "VTEX_ORDERS_SALES_CARD",
+    description:
+      "Sales summary cards for today, last hour, and last 5 minutes (default). Uses OMS List Orders with _stats=1. Pass an optional period to fetch a single window only.",
+    inputSchema: z.object({
+      period: salesPeriodSchema
+        .optional()
+        .describe(
+          'Optional single window: "today", "last_1h", or "last_5min". Omit to return all three.',
+        ),
+    }),
+    outputSchema,
+    _meta: { ui: { resourceUri: VTEX_ORDERS_SALES_CARD_RESOURCE_URI } },
+    annotations: { readOnlyHint: true },
+    execute: async ({ context, runtimeContext }) => {
+      const env = runtimeContext.env as Env;
+      const { accountName, appKey, appToken } = env.MESH_REQUEST_CONTEXT.state;
+      const timezone = DEFAULT_STORE_TIMEZONE;
+      const creds = { accountName, appKey, appToken };
+      const periods = context.period
+        ? [context.period]
+        : [...ALL_SALES_PERIODS];
+
+      const cards = await Promise.all(
+        periods.map((period) => fetchSalesCard(period, creds, timezone)),
+      );
+
+      return { cards };
+    },
+  });

--- a/vtex/server/tools/custom/orders-timeline.ts
+++ b/vtex/server/tools/custom/orders-timeline.ts
@@ -1,0 +1,75 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { VTEX_ORDERS_TIMELINE_RESOURCE_URI } from "../../constants.ts";
+import type { Env } from "../../types/env.ts";
+import { fetchAnalyticsConsumption } from "./analytics-consumption.ts";
+import {
+  DEFAULT_STORE_TIMEZONE,
+  getTodayWindowInTimezone,
+} from "./orders-oms.ts";
+import {
+  hasUsableTrendChartData,
+  parseAnalyticsHourlyBuckets,
+  resolveOrdersTrendParams,
+} from "./orders-trend.ts";
+
+const DEFAULT_STORE_CURRENCY = "BRL";
+
+const hourBucketSchema = z.object({
+  hour: z.string(),
+  count: z.number(),
+  totalValue: z.number(),
+});
+
+const outputSchema = z.object({
+  hours: z.array(hourBucketSchema),
+  date: z.string(),
+});
+
+export const ordersTimeline = (_env: Env) =>
+  createTool({
+    id: "VTEX_ORDERS_TIMELINE",
+    description:
+      "Fetch today's orders aggregated by hour for a bar chart. Uses the admin home orders trend analytics endpoint (single request).",
+    inputSchema: z.object({}),
+    outputSchema,
+    _meta: { ui: { resourceUri: VTEX_ORDERS_TIMELINE_RESOURCE_URI } },
+    annotations: { readOnlyHint: true },
+    execute: async ({ runtimeContext }) => {
+      const env = runtimeContext.env as Env;
+      const { accountName, appKey, appToken, currency } =
+        env.MESH_REQUEST_CONTEXT.state;
+      const timezone = DEFAULT_STORE_TIMEZONE;
+      const storeCurrency = currency ?? DEFAULT_STORE_CURRENCY;
+      const { date } = getTodayWindowInTimezone(timezone);
+      const params = resolveOrdersTrendParams({
+        agg: "hour",
+        currency: storeCurrency,
+        timezone,
+      });
+
+      const trend = await fetchAnalyticsConsumption(
+        { accountName, appKey, appToken },
+        "home-orders-trend",
+        {
+          an: accountName,
+          currency: params.currency,
+          startDate: params.startDate,
+          endDate: params.endDate,
+          agg: params.agg,
+          timezone: params.timezone,
+        },
+      );
+
+      if (!hasUsableTrendChartData(trend)) {
+        throw new Error(
+          "VTEX analytics returned empty trend data (null placeholders). Check store currency and app key access to admin analytics.",
+        );
+      }
+
+      return {
+        hours: parseAnalyticsHourlyBuckets(trend, timezone),
+        date,
+      };
+    },
+  });

--- a/vtex/server/tools/custom/orders-trend.test.ts
+++ b/vtex/server/tools/custom/orders-trend.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildOrdersTrendUrl,
+  extractOrdersTrendChartPoints,
+  hasUsableTrendChartData,
+  hourLabelInTimezone,
+  parseAnalyticsHourlyBuckets,
   resolveOrdersTrendParams,
 } from "./orders-trend.ts";
 
@@ -78,5 +82,131 @@ describe("resolveOrdersTrendParams", () => {
     expect(params.startDate).toBe("2026-06-01T00:00:00.000Z");
     expect(params.endDate).toBe("2026-06-01T23:59:00.000Z");
     expect(params.agg).toBe("day");
+  });
+});
+
+describe("hourLabelInTimezone", () => {
+  test("maps UTC bucket timestamps to local hour labels", () => {
+    expect(hourLabelInTimezone("2026-06-23T14:00:00.000Z", "-03:00")).toBe(
+      "11:00",
+    );
+    expect(hourLabelInTimezone("2026-06-23T03:00:00.000Z", "-03:00")).toBe(
+      "00:00",
+    );
+  });
+});
+
+describe("parseAnalyticsHourlyBuckets", () => {
+  test("maps dataChart points into 24 local hour buckets", () => {
+    const hours = parseAnalyticsHourlyBuckets(
+      {
+        dataChart: [
+          {
+            date: "2026-06-23T14:00:00.000Z",
+            orders: 120,
+          },
+          {
+            date: null,
+            orders: null,
+          },
+        ],
+      },
+      "-03:00",
+    );
+
+    expect(hours).toHaveLength(24);
+    expect(hours[11]).toEqual({
+      hour: "11:00",
+      count: 120,
+      totalValue: 0,
+    });
+    expect(hours[0]?.count).toBe(0);
+  });
+
+  test("accepts a top-level chart array", () => {
+    const hours = parseAnalyticsHourlyBuckets(
+      [
+        {
+          date: "2026-06-23T14:00:00.000Z",
+          orders: 42,
+        },
+      ],
+      "-03:00",
+    );
+
+    expect(hours[11]?.count).toBe(42);
+  });
+
+  test("accepts null dataChart as empty", () => {
+    const hours = parseAnalyticsHourlyBuckets({ dataChart: null }, "-03:00");
+    expect(hours.every((bucket) => bucket.count === 0)).toBe(true);
+  });
+
+  test("accepts VTEX ordersTrendData wrapper", () => {
+    const hours = parseAnalyticsHourlyBuckets(
+      {
+        ordersTrendData: {
+          dataChart: [
+            {
+              date: "2026-06-23T14:00:00.000Z",
+              orders: 99,
+            },
+          ],
+        },
+      },
+      "-03:00",
+    );
+
+    expect(hours[11]?.count).toBe(99);
+  });
+
+  test("accepts stringified JSON payloads", () => {
+    const hours = parseAnalyticsHourlyBuckets(
+      JSON.stringify({
+        dataChart: [
+          {
+            date: "2026-06-23T03:00:00.000Z",
+            orders: "7",
+          },
+        ],
+      }),
+      "-03:00",
+    );
+
+    expect(hours[0]?.count).toBe(7);
+  });
+});
+
+describe("hasUsableTrendChartData", () => {
+  test("returns false for null placeholder buckets", () => {
+    expect(
+      hasUsableTrendChartData({
+        ordersTrendData: {
+          dataChart: [
+            {
+              date: null,
+              orders: null,
+              status: "NORMAL",
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  test("returns true when at least one bucket has data", () => {
+    expect(
+      hasUsableTrendChartData({
+        dataChart: [{ date: "2026-06-23T14:00:00.000Z", orders: 5 }],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("extractOrdersTrendChartPoints", () => {
+  test("throws a descriptive error for unknown payloads", () => {
+    expect(() => extractOrdersTrendChartPoints({})).toThrow(
+      /Invalid VTEX orders trend response: object\(keys=none\)/,
+    );
   });
 });

--- a/vtex/server/tools/custom/orders-trend.ts
+++ b/vtex/server/tools/custom/orders-trend.ts
@@ -2,15 +2,191 @@ import { createTool } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../../types/env.ts";
 import {
-  getVtexIdSessionToken,
-  vtexIdCookieHeader,
-} from "../../lib/vtexid-session.ts";
-import { buildAnalyticsConsumptionUrl } from "./analytics-consumption.ts";
+  buildAnalyticsConsumptionUrl,
+  fetchAnalyticsConsumption,
+} from "./analytics-consumption.ts";
 import {
   DEFAULT_STORE_TIMEZONE,
   formatVtexAnalyticsTimestamp,
   getTodayTrendWindowInTimezone,
+  parseTimezoneOffsetMinutes,
+  type HourlyOrderBucket,
 } from "./orders-oms.ts";
+
+interface OrdersTrendChartPoint {
+  date: string | null;
+  orders: number | null;
+}
+
+const CHART_POINT_KEYS = ["dataChart", "DataChart", "chart", "data", "series"];
+
+function readNumericField(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function unwrapTrendPayload(data: unknown): unknown {
+  if (typeof data !== "string") {
+    return data;
+  }
+
+  try {
+    return unwrapTrendPayload(JSON.parse(data));
+  } catch {
+    return data;
+  }
+}
+
+function isChartPointLike(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    ("date" in value || "orders" in value)
+  );
+}
+
+function coerceChartPoints(value: unknown): OrdersTrendChartPoint[] | null {
+  if (value === null || value === undefined) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0 || value.every(isChartPointLike)) {
+      return value as OrdersTrendChartPoint[];
+    }
+  }
+
+  return null;
+}
+
+function findChartPoints(data: unknown): OrdersTrendChartPoint[] | null {
+  const unwrapped = unwrapTrendPayload(data);
+
+  const direct = coerceChartPoints(unwrapped);
+  if (direct !== null) {
+    return direct;
+  }
+
+  if (typeof unwrapped !== "object" || unwrapped === null) {
+    return null;
+  }
+
+  const record = unwrapped as Record<string, unknown>;
+
+  for (const key of CHART_POINT_KEYS) {
+    if (!(key in record)) {
+      continue;
+    }
+
+    const nested = findChartPoints(record[key]);
+    if (nested !== null) {
+      return nested;
+    }
+  }
+
+  // VTEX wraps chart data under endpoint-specific keys, e.g. ordersTrendData.
+  for (const value of Object.values(record)) {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      continue;
+    }
+
+    const nested = findChartPoints(value);
+    if (nested !== null) {
+      return nested;
+    }
+  }
+
+  return null;
+}
+
+function describeTrendPayload(data: unknown): string {
+  const unwrapped = unwrapTrendPayload(data);
+
+  if (unwrapped === null) {
+    return "null";
+  }
+
+  if (Array.isArray(unwrapped)) {
+    return `array(length=${unwrapped.length})`;
+  }
+
+  if (typeof unwrapped === "object") {
+    return `object(keys=${Object.keys(unwrapped).join(",") || "none"})`;
+  }
+
+  return typeof unwrapped;
+}
+
+export function extractOrdersTrendChartPoints(
+  data: unknown,
+): OrdersTrendChartPoint[] {
+  const points = findChartPoints(data);
+
+  if (points === null) {
+    throw new Error(
+      `Invalid VTEX orders trend response: ${describeTrendPayload(data)}`,
+    );
+  }
+
+  return points;
+}
+
+/** True when the trend payload has at least one bucket with date + order count. */
+export function hasUsableTrendChartData(data: unknown): boolean {
+  const points = extractOrdersTrendChartPoints(data);
+  return points.some(
+    (point) => point.date !== null && readNumericField(point.orders) !== null,
+  );
+}
+
+export function hourLabelInTimezone(isoDate: string, timezone: string): string {
+  const offsetMinutes = parseTimezoneOffsetMinutes(timezone);
+  const date = new Date(isoDate);
+  const totalMinutes =
+    date.getUTCHours() * 60 + date.getUTCMinutes() + offsetMinutes;
+  const normalized = ((totalMinutes % (24 * 60)) + 24 * 60) % (24 * 60);
+  return `${String(Math.floor(normalized / 60)).padStart(2, "0")}:00`;
+}
+
+/** Maps admin home-orders-trend `dataChart` into 24 local hour buckets for the MCP App UI. */
+export function parseAnalyticsHourlyBuckets(
+  data: unknown,
+  timezone: string,
+): HourlyOrderBucket[] {
+  const chartPoints = extractOrdersTrendChartPoints(data);
+  const byHour = new Map<string, HourlyOrderBucket>();
+
+  for (const point of chartPoints) {
+    if (!point.date) {
+      continue;
+    }
+
+    const count = readNumericField(point.orders);
+    if (count === null) {
+      continue;
+    }
+
+    const hour = hourLabelInTimezone(point.date, timezone);
+    byHour.set(hour, {
+      hour,
+      count,
+      totalValue: 0,
+    });
+  }
+
+  return Array.from({ length: 24 }, (_, index) => {
+    const hour = `${String(index).padStart(2, "0")}:00`;
+    return byHour.get(hour) ?? { hour, count: 0, totalValue: 0 };
+  });
+}
 
 /**
  * VTEX's admin home dashboard charts are served by an INTERNAL microservice at
@@ -104,29 +280,19 @@ export const getOrdersTrend = (_env: Env) =>
     execute: async ({ context, runtimeContext }) => {
       const env = runtimeContext.env as Env;
       const { accountName, appKey, appToken } = env.MESH_REQUEST_CONTEXT.state;
-
-      const token = await getVtexIdSessionToken({
-        accountName,
-        appKey,
-        appToken,
-      });
-
       const params = resolveOrdersTrendParams(context);
-      const url = buildOrdersTrendUrl(accountName, params);
 
-      const response = await fetch(url, {
-        headers: {
-          Accept: "application/json",
-          Cookie: vtexIdCookieHeader(token),
+      return fetchAnalyticsConsumption(
+        { accountName, appKey, appToken },
+        "home-orders-trend",
+        {
+          an: accountName,
+          currency: params.currency,
+          startDate: params.startDate,
+          endDate: params.endDate,
+          agg: params.agg,
+          timezone: params.timezone,
         },
-      });
-
-      if (!response.ok) {
-        throw new Error(
-          `VTEX API Error: ${response.status} - ${await response.text()}`,
-        );
-      }
-
-      return response.json();
+      );
     },
   });

--- a/vtex/server/tools/index.ts
+++ b/vtex/server/tools/index.ts
@@ -81,6 +81,8 @@ import {
 } from "./registry.ts";
 
 // ── Custom tools ──────────────────────────────────────────────────────────────
+import { ordersTimeline } from "./custom/orders-timeline.ts";
+import { ordersSalesCard } from "./custom/orders-sales-card.ts";
 import { searchCollections } from "./custom/search-collections.ts";
 import { reorderCollection } from "./custom/reorder-collection.ts";
 import { updateProductSpecifications } from "./custom/update-product-specifications.ts";
@@ -168,6 +170,10 @@ const registryFactories = [
 ];
 
 const customFactories = [
+  // Today's orders timeline chart (MCP App UI)
+  ordersTimeline,
+  // Sales summary card for today / last hour / last 5 min (MCP App UI)
+  ordersSalesCard,
   // Collection search (endpoint absent from generated SDKs)
   searchCollections,
   // Collection overwrite/reorder via XML import flow

--- a/vtex/server/types/env.ts
+++ b/vtex/server/types/env.ts
@@ -18,6 +18,12 @@ export const StateSchema = z.object({
     .describe(
       "VTEX App Token (required for private endpoints; not needed for public catalog searches)",
     ),
+  currency: z
+    .string()
+    .optional()
+    .describe(
+      "Store currency for analytics endpoints, e.g. BRL or USD (default BRL)",
+    ),
 });
 
 export type Env = DefaultEnv<typeof StateSchema>;

--- a/vtex/tsconfig.json
+++ b/vtex/tsconfig.json
@@ -18,8 +18,11 @@
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "types": ["@cloudflare/workers-types", "bun"]
+    "types": ["@cloudflare/workers-types", "bun", "vite/client"],
+    "paths": {
+      "@/*": ["./web/*"]
+    }
   },
-  "include": ["server", "shared", "scripts"],
+  "include": ["server", "shared", "scripts", "web"],
   "exclude": ["server/generated"]
 }

--- a/vtex/vite.config.ts
+++ b/vtex/vite.config.ts
@@ -1,0 +1,46 @@
+import path from "node:path";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+import { viteSingleFile } from "vite-plugin-singlefile";
+
+const MCP_APP_ENTRIES = {
+  "orders-timeline": path.resolve(__dirname, "orders-timeline.html"),
+  "orders-sales-card": path.resolve(__dirname, "orders-sales-card.html"),
+} as const;
+
+type McpAppEntry = keyof typeof MCP_APP_ENTRIES;
+
+function resolveEntry(): McpAppEntry {
+  const entry = process.env.MCP_APP_ENTRY;
+  if (entry && entry in MCP_APP_ENTRIES) {
+    return entry as McpAppEntry;
+  }
+  return "orders-timeline";
+}
+
+const activeEntry = resolveEntry();
+
+export default defineConfig({
+  plugins: [
+    react({
+      babel: {
+        plugins: ["babel-plugin-react-compiler"],
+      },
+    }),
+    tailwindcss(),
+    viteSingleFile(),
+  ],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./web"),
+    },
+  },
+  build: {
+    outDir: "dist/client",
+    emptyOutDir: process.env.MCP_APP_EMPTY_OUTDIR !== "false",
+    rollupOptions: {
+      input: MCP_APP_ENTRIES[activeEntry],
+    },
+  },
+});

--- a/vtex/web/bootstrap.tsx
+++ b/vtex/web/bootstrap.tsx
@@ -1,0 +1,24 @@
+import { StrictMode, type ComponentType } from "react";
+import { createRoot } from "react-dom/client";
+import { McpAppShell } from "@/components/mcp-app-shell.tsx";
+import { McpProvider } from "@/context.tsx";
+import "./globals.css";
+
+export function mountMcpApp(Page: ComponentType) {
+  const rootElement = document.getElementById("root");
+
+  if (!rootElement) {
+    throw new Error("Missing root element");
+  }
+
+  const root = createRoot(rootElement);
+  root.render(
+    <StrictMode>
+      <McpProvider>
+        <McpAppShell>
+          <Page />
+        </McpAppShell>
+      </McpProvider>
+    </StrictMode>,
+  );
+}

--- a/vtex/web/components/mcp-app-shell.tsx
+++ b/vtex/web/components/mcp-app-shell.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+import { useMcpHostContext } from "@/context.tsx";
+
+export function McpAppShell({ children }: { children: ReactNode }) {
+  const hostContext = useMcpHostContext();
+  const insets = hostContext?.safeAreaInsets;
+
+  return (
+    <div
+      className="flex min-h-0 w-full flex-1 flex-col overflow-hidden"
+      style={
+        insets
+          ? {
+              paddingTop: `${insets.top}px`,
+              paddingRight: `${insets.right}px`,
+              paddingBottom: `${insets.bottom}px`,
+              paddingLeft: `${insets.left}px`,
+            }
+          : undefined
+      }
+    >
+      {children}
+    </div>
+  );
+}

--- a/vtex/web/components/page-header.tsx
+++ b/vtex/web/components/page-header.tsx
@@ -1,0 +1,19 @@
+interface PageHeaderProps {
+  title: string;
+  subtitle?: string;
+  right?: React.ReactNode;
+}
+
+export function PageHeader({ title, subtitle, right }: PageHeaderProps) {
+  return (
+    <header className="flex items-start justify-between gap-4 mb-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+        {subtitle ? (
+          <p className="text-sm text-muted-foreground mt-1">{subtitle}</p>
+        ) : null}
+      </div>
+      {right ? <div>{right}</div> : null}
+    </header>
+  );
+}

--- a/vtex/web/components/status-frame.tsx
+++ b/vtex/web/components/status-frame.tsx
@@ -1,0 +1,90 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.tsx";
+import type { McpStatus } from "../types.ts";
+
+interface StatusFrameProps {
+  status: McpStatus;
+  error?: string;
+  pendingMessage?: string;
+  connectedTitle?: string;
+  connectedHint?: string;
+}
+
+export function StatusFrame({
+  status,
+  error,
+  pendingMessage = "Loading…",
+  connectedTitle = "VTEX Dashboard",
+  connectedHint = "Invoke a tool to see analytics here.",
+}: StatusFrameProps) {
+  if (status === "initializing") {
+    return (
+      <div className="flex items-center justify-center min-h-dvh p-6">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <span className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
+          <span className="text-sm">Connecting to host…</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "connected") {
+    return (
+      <div className="flex items-center justify-center min-h-dvh p-6">
+        <Card className="w-full max-w-md text-center">
+          <CardHeader>
+            <CardTitle>{connectedTitle}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-muted-foreground text-sm">{connectedHint}</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <div className="flex items-center justify-center min-h-dvh p-6">
+        <Card className="w-full max-w-md border-destructive">
+          <CardHeader>
+            <CardTitle className="text-destructive">Error</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-destructive whitespace-pre-wrap break-words">
+              {error ?? "Unknown error"}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (status === "tool-cancelled") {
+    return (
+      <div className="flex items-center justify-center min-h-dvh p-6">
+        <Card className="w-full max-w-md border-destructive">
+          <CardHeader>
+            <CardTitle className="text-destructive">Cancelled</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-destructive">Tool call was cancelled.</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-dvh p-6">
+      <div className="flex items-center gap-3 text-muted-foreground">
+        <span className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
+        <span className="text-sm">{pendingMessage}</span>
+      </div>
+    </div>
+  );
+}

--- a/vtex/web/components/ui/card.tsx
+++ b/vtex/web/components/ui/card.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import { cn } from "@/lib/utils.ts";
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  );
+}
+
+export { Card, CardContent, CardHeader, CardTitle };

--- a/vtex/web/constants.ts
+++ b/vtex/web/constants.ts
@@ -1,0 +1,5 @@
+/** Deco lime green — timeline bars and sales card icon backgrounds. */
+export const VTEX_ACCENT_GREEN = "#d0ec1a";
+
+/** Dark green for sales card icons (contrast on lime tint). */
+export const VTEX_ICON_GREEN = "#07401a";

--- a/vtex/web/context.tsx
+++ b/vtex/web/context.tsx
@@ -1,0 +1,111 @@
+import {
+  type App,
+  type McpUiHostContext,
+  useApp,
+  useHostStyles,
+} from "@modelcontextprotocol/ext-apps/react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useState,
+} from "react";
+import { INITIAL_STATE, type McpState } from "./types.ts";
+
+const McpStateContext = createContext<McpState>(INITIAL_STATE);
+const McpAppContext = createContext<App | null>(null);
+const McpHostContext = createContext<McpUiHostContext | undefined>(undefined);
+
+export function McpProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<McpState>(INITIAL_STATE);
+  const [hostContext, setHostContext] = useState<McpUiHostContext | undefined>(
+    undefined,
+  );
+
+  const onAppCreated = useCallback((app: App) => {
+    app.ontoolinput = (params) => {
+      setState((prev) => {
+        const toolName =
+          prev.toolName ?? app.getHostContext()?.toolInfo?.tool.name;
+        return {
+          ...prev,
+          status: "tool-input",
+          toolInput: params.arguments,
+          ...(toolName ? { toolName } : {}),
+        };
+      });
+    };
+
+    app.ontoolresult = (result) => {
+      if (result.isError) {
+        const textBlock = result.content?.find((c) => c.type === "text");
+        const errorText =
+          (textBlock?.type === "text" ? textBlock.text : undefined) ??
+          "Tool returned an error";
+        setState((prev) => ({ ...prev, status: "error", error: errorText }));
+        return;
+      }
+      setState((prev) => ({
+        ...prev,
+        status: "tool-result",
+        toolResult: result.structuredContent,
+      }));
+    };
+
+    app.ontoolcancelled = () => {
+      setState((prev) => ({ ...prev, status: "tool-cancelled" }));
+    };
+
+    app.onerror = (err) => {
+      console.error("MCP App error:", err);
+    };
+
+    app.onhostcontextchanged = (ctx) => {
+      setHostContext((prev) => ({ ...prev, ...ctx }));
+      const toolName = ctx.toolInfo?.tool.name;
+      if (toolName) {
+        setState((prev) => ({ ...prev, toolName }));
+      }
+    };
+  }, []);
+
+  const { app, isConnected } = useApp({
+    appInfo: { name: "VTEX MCP App", version: "1.0.0" },
+    capabilities: {},
+    onAppCreated,
+  });
+
+  useHostStyles(app, app?.getHostContext());
+
+  if (isConnected && state.status === "initializing") {
+    const ctx = app?.getHostContext();
+    if (ctx) setHostContext(ctx);
+    const toolName = ctx?.toolInfo?.tool.name;
+    setState({ status: "connected", toolName });
+  }
+
+  return (
+    <McpAppContext.Provider value={app}>
+      <McpHostContext.Provider value={hostContext}>
+        <McpStateContext.Provider value={state}>
+          {children}
+        </McpStateContext.Provider>
+      </McpHostContext.Provider>
+    </McpAppContext.Provider>
+  );
+}
+
+export function useMcpState<TInput = unknown, TResult = unknown>() {
+  return useContext(McpStateContext) as McpState<TInput, TResult>;
+}
+
+export function useMcpApp() {
+  return useContext(McpAppContext);
+}
+
+export function useMcpHostContext() {
+  return useContext(McpHostContext);
+}
+
+export { useDocumentTheme as useTheme } from "@modelcontextprotocol/ext-apps/react";

--- a/vtex/web/globals.css
+++ b/vtex/web/globals.css
@@ -1,0 +1,131 @@
+@import "tailwindcss";
+
+@custom-variant dark (&:is([data-theme="dark"] *));
+
+:root {
+	/* Host variable fallbacks (light) */
+	--color-background-primary: hsl(0 0% 100%);
+	--color-background-secondary: hsl(240 4.8% 95.9%);
+	--color-background-tertiary: hsl(240 4.8% 95.9%);
+	--color-background-danger: hsl(0 84.2% 60.2%);
+	--color-text-primary: hsl(240 10% 3.9%);
+	--color-text-secondary: hsl(240 3.8% 46.1%);
+	--color-border-primary: hsl(240 5.9% 90%);
+	--color-border-secondary: hsl(240 5.9% 90%);
+	--color-ring-primary: hsl(240 5.9% 10%);
+
+	/* VTEX brand */
+	--primary: #f71963;
+	--primary-foreground: #ffffff;
+	--color-ring-primary: #f71963;
+
+	/* Sidebar tokens (existing) */
+	--sidebar: hsl(0 0% 98%);
+	--sidebar-foreground: hsl(240 5.3% 26.1%);
+	--sidebar-primary: #f71963;
+	--sidebar-primary-foreground: #ffffff;
+	--sidebar-accent: hsl(240 4.8% 95.9%);
+	--sidebar-accent-foreground: hsl(240 5.9% 10%);
+	--sidebar-border: hsl(220 13% 91%);
+	--sidebar-ring: #f71963;
+}
+
+[data-theme="dark"] {
+	/* Host variable fallbacks (dark) */
+	--color-background-primary: hsl(240 10% 3.9%);
+	--color-background-secondary: hsl(240 3.7% 15.9%);
+	--color-background-tertiary: hsl(240 3.7% 15.9%);
+	--color-background-danger: hsl(0 62.8% 30.6%);
+	--color-text-primary: hsl(0 0% 98%);
+	--color-text-secondary: hsl(240 5% 64.9%);
+	--color-border-primary: hsl(240 3.7% 15.9%);
+	--color-border-secondary: hsl(240 3.7% 15.9%);
+	--color-ring-primary: hsl(240 4.9% 83.9%);
+
+	/* VTEX brand */
+	--primary: #f71963;
+	--primary-foreground: #ffffff;
+	--color-ring-primary: #f71963;
+
+	/* Sidebar tokens (existing) */
+	--sidebar: hsl(240 5.9% 10%);
+	--sidebar-foreground: hsl(240 4.8% 95.9%);
+	--sidebar-primary: #f71963;
+	--sidebar-primary-foreground: #ffffff;
+	--sidebar-accent: hsl(240 3.7% 15.9%);
+	--sidebar-accent-foreground: hsl(240 4.8% 95.9%);
+	--sidebar-border: hsl(240 3.7% 15.9%);
+	--sidebar-ring: #f71963;
+}
+
+@layer base {
+	html {
+		height: 100%;
+	}
+
+	body {
+		height: 100%;
+		margin: 0;
+		overflow: hidden;
+		@apply bg-background text-foreground;
+	}
+
+	#root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100dvh;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	button,
+	a,
+	select,
+	summary,
+	[role="button"],
+	[role="tab"],
+	[role="checkbox"],
+	[role="radio"],
+	[role="switch"],
+	[role="menuitem"],
+	[role="option"],
+	label[for] {
+		cursor: pointer;
+	}
+}
+
+@theme inline {
+	/* Core colors — mapped from host variables */
+	--color-background: var(--color-background-primary);
+	--color-foreground: var(--color-text-primary);
+	--color-card: var(--color-background-primary);
+	--color-card-foreground: var(--color-text-primary);
+	--color-popover: var(--color-background-primary);
+	--color-popover-foreground: var(--color-text-primary);
+	--color-primary: var(--primary);
+	--color-primary-foreground: var(--primary-foreground);
+	--color-secondary: var(--color-background-secondary);
+	--color-secondary-foreground: var(--color-text-primary);
+	--color-muted: var(--color-background-secondary);
+	--color-muted-foreground: var(--color-text-secondary);
+	--color-accent: var(--color-background-tertiary);
+	--color-accent-foreground: var(--color-text-primary);
+	--color-destructive: var(--color-background-danger);
+	--color-border: var(--color-border-primary);
+	--color-input: var(--color-border-secondary);
+	--color-ring: var(--color-ring-primary);
+
+	/* Layout */
+	--radius-DEFAULT: var(--border-radius-md, 0.375rem);
+
+	/* Sidebar (existing) */
+	--color-sidebar: var(--sidebar);
+	--color-sidebar-foreground: var(--sidebar-foreground);
+	--color-sidebar-primary: var(--sidebar-primary);
+	--color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+	--color-sidebar-accent: var(--sidebar-accent);
+	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+	--color-sidebar-border: var(--sidebar-border);
+	--color-sidebar-ring: var(--sidebar-ring);
+}

--- a/vtex/web/hooks/use-tool.ts
+++ b/vtex/web/hooks/use-tool.ts
@@ -1,0 +1,111 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMcpApp, useMcpState } from "@/context.tsx";
+
+interface ToolCallResult {
+  structuredContent?: unknown;
+  isError?: boolean;
+  content?: Array<{ type: string; text?: string }>;
+}
+
+interface UseToolResult<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+}
+
+function extractToolError(result: ToolCallResult): string | null {
+  if (!result.isError) return null;
+  const text = (result.content ?? [])
+    .filter((c) => c.type === "text" && typeof c.text === "string")
+    .map((c) => c.text ?? "")
+    .join("\n")
+    .trim();
+  return text || "Tool returned an error";
+}
+
+function stableArgsKey(args: Record<string, unknown>): string {
+  return JSON.stringify(args);
+}
+
+/**
+ * Fetch tool data for MCP App UIs.
+ *
+ * - Chat flow: uses `ontoolresult` when the host pushes structured content.
+ * - Home tiles: calls `app.callServerTool` directly (same pattern as system-health-agent).
+ */
+export function useTool<
+  T,
+  A extends Record<string, unknown> = Record<string, unknown>,
+>(name: string, args: A): UseToolResult<T> {
+  const app = useMcpApp();
+  const mcpState = useMcpState<A, T>();
+  const argsKey = useMemo(() => stableArgsKey(args), [args]);
+
+  const hostResult =
+    mcpState.status === "tool-result"
+      ? (mcpState.toolResult as T | undefined)
+      : undefined;
+  const hostError =
+    mcpState.status === "error" ? (mcpState.error ?? "Tool failed") : null;
+
+  const [fetched, setFetched] = useState<UseToolResult<T>>({
+    data: hostResult ?? null,
+    loading: !hostResult && !hostError,
+    error: hostError,
+  });
+
+  useEffect(() => {
+    if (hostResult) {
+      setFetched({ data: hostResult, loading: false, error: null });
+      return;
+    }
+    if (hostError) {
+      setFetched({ data: null, loading: false, error: hostError });
+      return;
+    }
+    if (!app?.callServerTool) {
+      setFetched((prev) => ({ ...prev, loading: true, error: null }));
+      return;
+    }
+
+    let cancelled = false;
+    setFetched({ data: null, loading: true, error: null });
+
+    app
+      .callServerTool({ name, arguments: args })
+      .then((result) => {
+        if (cancelled) return;
+        const toolResult = result as ToolCallResult;
+        const toolErr = extractToolError(toolResult);
+        if (toolErr) {
+          setFetched({ data: null, loading: false, error: toolErr });
+          return;
+        }
+        setFetched({
+          data: (toolResult.structuredContent as T) ?? null,
+          loading: false,
+          error: null,
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setFetched({
+          data: null,
+          loading: false,
+          error: err instanceof Error ? err.message : "Tool call failed",
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [app, args, argsKey, hostError, hostResult, name]);
+
+  if (hostResult) {
+    return { data: hostResult, loading: false, error: null };
+  }
+  if (hostError) {
+    return { data: null, loading: false, error: hostError };
+  }
+  return fetched;
+}

--- a/vtex/web/lib/utils.ts
+++ b/vtex/web/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/vtex/web/tools/orders-sales-card/index.tsx
+++ b/vtex/web/tools/orders-sales-card/index.tsx
@@ -1,0 +1,146 @@
+import { Clock, Timer, TrendingUp } from "lucide-react";
+import { StatusFrame } from "@/components/status-frame.tsx";
+import { VTEX_ACCENT_GREEN, VTEX_ICON_GREEN } from "@/constants.ts";
+import { useMcpState } from "@/context.tsx";
+import { useTool } from "@/hooks/use-tool.ts";
+import { cn } from "@/lib/utils.ts";
+
+const TOOL_NAME = "VTEX_ORDERS_SALES_CARD";
+
+type SalesPeriod = "today" | "last_1h" | "last_5min";
+
+interface SalesCard {
+  period: SalesPeriod;
+  orders: number;
+  totalValue: number;
+  date?: string;
+}
+
+interface SalesCardInput {
+  period?: SalesPeriod;
+}
+
+interface SalesCardOutput {
+  cards: SalesCard[];
+}
+
+const PERIOD_LABELS: Record<SalesPeriod, string> = {
+  today: "Vendas hoje",
+  last_1h: "Última 1h",
+  last_5min: "Últimos 5 min",
+};
+
+const PERIOD_ICONS: Record<SalesPeriod, React.ReactNode> = {
+  today: <TrendingUp className="w-5 h-5" />,
+  last_1h: <Clock className="w-5 h-5" />,
+  last_5min: <Timer className="w-5 h-5" />,
+};
+
+const PERIOD_ORDER: SalesPeriod[] = ["today", "last_1h", "last_5min"];
+
+function fmt(n: number | undefined) {
+  return new Intl.NumberFormat("pt-BR").format(n ?? 0);
+}
+
+function fmtCurrency(cents: number | undefined) {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  }).format((cents ?? 0) / 100);
+}
+
+function sortCards(cards: SalesCard[]): SalesCard[] {
+  const byPeriod = new Map(cards.map((card) => [card.period, card]));
+  return PERIOD_ORDER.flatMap((period) => {
+    const card = byPeriod.get(period);
+    return card ? [card] : [];
+  });
+}
+
+function SalesCardItem({ card }: { card: SalesCard }) {
+  const { period, orders, totalValue, date } = card;
+  const ordersLine =
+    period === "today" && date
+      ? `${fmt(orders)} pedidos · ${date}`
+      : `${fmt(orders)} pedidos`;
+
+  return (
+    <div className="@container flex h-full min-h-0 min-w-0 flex-col rounded-xl border-0 bg-card p-3 sm:p-4">
+      <div className="flex h-full min-h-0 flex-1 items-center gap-3">
+        <div className="flex shrink-0 items-center justify-center">
+          <div
+            className="flex h-9 w-9 items-center justify-center rounded-md sm:h-10 sm:w-10"
+            style={{
+              backgroundColor: `${VTEX_ACCENT_GREEN}33`,
+              color: VTEX_ICON_GREEN,
+            }}
+          >
+            {PERIOD_ICONS[period]}
+          </div>
+        </div>
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col justify-center gap-0.5">
+          <p className="text-[11px] text-muted-foreground sm:text-xs">
+            {PERIOD_LABELS[period]}
+          </p>
+          <p className="text-base font-semibold tabular-nums truncate @sm:text-lg @md:text-xl">
+            {fmtCurrency(totalValue)}
+          </p>
+          <p className="text-[11px] text-muted-foreground line-clamp-2 sm:text-xs">
+            {ordersLine}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function OrdersSalesCardPage() {
+  const { toolInput } = useMcpState<SalesCardInput, SalesCardOutput>();
+  const args: Record<string, unknown> = toolInput?.period
+    ? { period: toolInput.period }
+    : {};
+  const { data, loading, error } = useTool<SalesCardOutput>(TOOL_NAME, args);
+
+  if (error) {
+    return <StatusFrame status="error" error={error} />;
+  }
+
+  if (loading || !data) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center bg-card">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <span className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
+          <span className="text-sm">Waiting for VTEX response…</span>
+        </div>
+      </div>
+    );
+  }
+
+  const cards = sortCards(data.cards ?? []);
+  const equalSize = cards.length === 3;
+
+  return (
+    <div className="box-border flex min-h-0 w-full flex-1 flex-col overflow-hidden bg-card">
+      <div
+        className={cn(
+          "min-h-0 w-full flex-1 gap-6",
+          equalSize
+            ? "grid grid-cols-3 grid-rows-[minmax(0,1fr)]"
+            : "flex min-h-0 flex-row",
+        )}
+      >
+        {cards.map((card) => (
+          <div
+            key={card.period}
+            className={cn(
+              "flex min-h-0 min-w-0 flex-col",
+              equalSize ? "h-full" : "flex-1",
+            )}
+          >
+            <SalesCardItem card={card} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/vtex/web/tools/orders-sales-card/main.tsx
+++ b/vtex/web/tools/orders-sales-card/main.tsx
@@ -1,0 +1,4 @@
+import { mountMcpApp } from "@/bootstrap.tsx";
+import OrdersSalesCardPage from "./index.tsx";
+
+mountMcpApp(OrdersSalesCardPage);

--- a/vtex/web/tools/orders-timeline/index.tsx
+++ b/vtex/web/tools/orders-timeline/index.tsx
@@ -1,0 +1,88 @@
+import { DollarSign } from "lucide-react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { StatusFrame } from "@/components/status-frame.tsx";
+import { VTEX_ACCENT_GREEN } from "@/constants.ts";
+import { useTool } from "@/hooks/use-tool.ts";
+
+const TOOL_NAME = "VTEX_ORDERS_TIMELINE";
+
+interface HourBucket {
+  hour: string;
+  count: number;
+  totalValue: number;
+}
+
+interface OrdersTimelineOutput {
+  hours: HourBucket[];
+  date: string;
+}
+
+function fmt(n: number | undefined) {
+  return new Intl.NumberFormat("pt-BR").format(n ?? 0);
+}
+
+export default function OrdersTimelinePage() {
+  const { data, loading, error } = useTool<
+    OrdersTimelineOutput,
+    Record<string, never>
+  >(TOOL_NAME, {});
+
+  if (error) {
+    return <StatusFrame status="error" error={error} />;
+  }
+
+  if (loading || !data) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <span className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
+          <span className="text-sm">Waiting for VTEX response…</span>
+        </div>
+      </div>
+    );
+  }
+
+  const { hours } = data;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-2 pt-2 pb-1">
+      <p className="mb-3 shrink-0 text-base flex items-center gap-2">
+        <DollarSign className="w-4 h-4" />
+        Pedidos por hora
+      </p>
+      {hours.every((bucket) => bucket.count === 0) ? (
+        <p className="text-sm text-muted-foreground">
+          Nenhum pedido encontrado hoje.
+        </p>
+      ) : (
+        <div className="min-h-0 flex-1">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={hours}
+              margin={{ top: 8, right: 8, bottom: 0, left: 4 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+              <XAxis dataKey="hour" tick={{ fontSize: 11 }} interval={1} />
+              <YAxis tick={{ fontSize: 11 }} allowDecimals={false} />
+              <Tooltip formatter={(value: number) => [fmt(value), "Pedidos"]} />
+              <Bar
+                dataKey="count"
+                fill={VTEX_ACCENT_GREEN}
+                radius={[4, 4, 0, 0]}
+                name="count"
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/vtex/web/tools/orders-timeline/main.tsx
+++ b/vtex/web/tools/orders-timeline/main.tsx
@@ -1,0 +1,4 @@
+import { mountMcpApp } from "@/bootstrap.tsx";
+import OrdersTimelinePage from "./index.tsx";
+
+mountMcpApp(OrdersTimelinePage);

--- a/vtex/web/types.ts
+++ b/vtex/web/types.ts
@@ -1,0 +1,17 @@
+export type McpStatus =
+  | "initializing"
+  | "connected"
+  | "tool-input"
+  | "tool-result"
+  | "tool-cancelled"
+  | "error";
+
+export interface McpState<TInput = unknown, TResult = unknown> {
+  status: McpStatus;
+  toolName?: string;
+  error?: string;
+  toolInput?: TInput;
+  toolResult?: TResult;
+}
+
+export const INITIAL_STATE: McpState = { status: "initializing" };


### PR DESCRIPTION
Reverts decocms/mcps#460

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an MCP App UI for VTEX orders (hourly timeline and sales summary cards) and restores the shared server so production MCP routes work correctly.

- **New Features**
  - `VTEX_ORDERS_TIMELINE` tool + MCP resource `ui://vtex/orders-timeline`; today’s hourly orders bar chart from admin analytics trend.
  - `VTEX_ORDERS_SALES_CARD` tool + MCP resource `ui://vtex/orders-sales-card`; sales cards for `today`, `last_1h`, and `last_5min` (or a single period via input).
  - Single-file web bundles with React 19 + Tailwind via `vite`/`vite-plugin-singlefile`; scripts: `dev`, `dev:web`, `build:web` (adds `@modelcontextprotocol/ext-apps`, `@vitejs/plugin-react`, `@tailwindcss/vite`).
  - Public resources serve `dist/client/*.html`; added optional `currency` in state. Introduced `vtexIdAuthHeaders()` and centralized analytics calls with `fetchAnalyticsConsumption`; improved trend parsing and hourly bucket mapping with tests.

- **Bug Fixes**
  - Restored shared `serve()` and default `/mcp` routing (platform port) to fix the broken production MCP endpoint.

<sup>Written for commit a818bd4aca39bf8b36364720a2cc8648cfe5269b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

