### PR TITLE
fix(vtex): responsive layout for orders sales card

### DIFF
--- a/vtex/web/tools/orders-sales-card/index.tsx
+++ b/vtex/web/tools/orders-sales-card/index.tsx
@@ -120,13 +120,13 @@ export default function OrdersSalesCardPage() {
   const equalSize = cards.length === 3;
 
   return (
-    <div className="box-border flex min-h-0 w-full flex-1 flex-col overflow-hidden bg-card">
+    <div className="@container box-border flex min-h-0 w-full flex-1 flex-col overflow-hidden bg-card">
       <div
         className={cn(
-          "min-h-0 w-full flex-1 gap-6",
+          "min-h-0 w-full gap-3 @md:gap-6",
           equalSize
-            ? "grid grid-cols-3 grid-rows-[minmax(0,1fr)]"
-            : "flex min-h-0 flex-row",
+            ? "grid grid-cols-1 @sm:grid-cols-3 @sm:grid-rows-[minmax(0,1fr)] @sm:flex-1"
+            : "flex min-h-0 flex-col @sm:flex-row @sm:flex-1",
         )}
       >
         {cards.map((card) => (
@@ -134,7 +134,7 @@ export default function OrdersSalesCardPage() {
             key={card.period}
             className={cn(
               "flex min-h-0 min-w-0 flex-col",
-              equalSize ? "h-full" : "flex-1",
+              equalSize ? "@sm:h-full" : "@sm:flex-1",
             )}
           >
             <SalesCardItem card={card} />


### PR DESCRIPTION
## Summary
- Uses container queries (`@container`) to stack score cards vertically in narrow containers instead of forcing a 3-column grid that overflows
- Cards only stretch to fill height in the horizontal (wide) layout; in vertical mode each card takes only the space it needs

## Test plan
- [ ] Verify cards render side-by-side in wide containers (desktop)
- [ ] Verify cards stack vertically in narrow containers (mobile / small widget)
- [ ] Confirm no text truncation in either layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the VTEX Orders Sales card responsive using `@container` queries, stacking cards vertically in narrow containers and keeping the 3-column layout when wide. This prevents overflow and text truncation; cards only stretch to full height on wide screens, while stacked cards use natural height.

<sup>Written for commit ad2789c41a58d4547bcf95d11452cdd5682fcc5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

