### PR TITLE
fix(google-analytics): remove redundant auth field from app.json

### DIFF
--- a/google-analytics/app.json
+++ b/google-analytics/app.json
@@ -9,9 +9,6 @@
   "description": "Integrate with Google Analytics 4 (GA4) to query reports, fetch realtime data, and manage analytics properties.",
   "icon": "https://www.gstatic.com/analytics-suite/header/suite/v2/ic_analytics.svg",
   "unlisted": false,
-  "auth": {
-    "type": "oauth2"
-  },
   "metadata": {
     "categories": [
       "Analytics",


### PR DESCRIPTION
## Summary

- Removes the `"auth": {"type": "oauth2"}` field from `google-analytics/app.json`
- Google Analytics was the **only** Google MCP with this explicit auth field — all others (calendar, docs, meet, sheets, slides, search-console, gmail) have no `auth` field
- Local testing confirmed the MCP works correctly: OAuth flow completes, tool calls return real GA4 data

## Test plan

- [x] Local OAuth tested — access token and refresh token returned correctly
- [x] `get-account-summaries` tool call returned real GA4 account data locally
- [ ] Verify production 401 error is resolved after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the redundant OAuth config from `google-analytics/app.json` so it uses the default OAuth behavior. This aligns the Google Analytics MCP with other Google MCPs and should resolve unexpected 401s.

- **Bug Fixes**
  - Removed `"auth": {"type": "oauth2"}` from `google-analytics/app.json`.
  - Verified local OAuth and GA4 tool calls work with the default config.

<sup>Written for commit 882c181303a01b966136701537efde5e1fd69059. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

