### PR TITLE
feat(google-calendar): meeting notifications via Apps Script → deco triggers

### DIFF
--- a/apps-script/calendar-notifier.gs
+++ b/apps-script/calendar-notifier.gs
@@ -1,0 +1,186 @@
+/**
+ * Google Calendar → deco MCP notifier (per-user).
+ *
+ * Runs in YOUR Google account. A time-driven trigger polls your calendar and
+ * POSTs "upcoming meeting" events to the deco Google Calendar MCP, which
+ * forwards them to your studio automation. An installable onEventUpdated
+ * trigger reports created/updated/deleted events.
+ *
+ * SETUP
+ *   1. https://script.google.com → New project, paste this file.
+ *   2. Replace the CONFIG block below with the values from the MCP tool
+ *      `get_apps_script_config` (run it after configuring the trigger in the
+ *      studio so this connection has a delivery callback).
+ *   3. Run `setup` once and authorize the script.
+ *
+ * Quotas (Apps Script): UrlFetchApp ~20k calls/day (consumer), trigger total
+ * runtime 90 min/day (consumer) / 6 h/day (Workspace). A 5-min poll is well
+ * within these.
+ */
+
+// ============================ CONFIG (replace) ============================
+const WEBHOOK_URL =
+  "https://sites-google-calendar.deco.site/calendar/events/REPLACE_CONNECTION_ID";
+const WEBHOOK_TOKEN = "REPLACE_TOKEN";
+const LEAD_MINUTES = 10; // notify this many minutes before an event
+const POLL_WINDOW_MIN = 15; // how far ahead each poll scans (>= LEAD_MINUTES)
+const CALENDAR_ID = "primary"; // "primary" or a specific calendar id
+// =========================================================================
+
+/** Create the time-driven + onEventUpdated triggers. Run once. */
+function setup() {
+  // Clear any existing triggers for these handlers to avoid duplicates.
+  const handlers = ["checkUpcoming", "onCalendarChange"];
+  ScriptApp.getProjectTriggers().forEach(function (t) {
+    if (handlers.indexOf(t.getHandlerFunction()) !== -1) {
+      ScriptApp.deleteTrigger(t);
+    }
+  });
+
+  ScriptApp.newTrigger("checkUpcoming").timeBased().everyMinutes(5).create();
+
+  ScriptApp.newTrigger("onCalendarChange")
+    .forUserCalendar(Session.getEffectiveUser().getEmail())
+    .onEventUpdated()
+    .create();
+
+  Logger.log("Triggers created: checkUpcoming (5 min) + onCalendarChange.");
+}
+
+/** Time-driven: notify for events starting within LEAD_MINUTES. */
+function checkUpcoming() {
+  const cal =
+    CALENDAR_ID === "primary"
+      ? CalendarApp.getDefaultCalendar()
+      : CalendarApp.getCalendarById(CALENDAR_ID);
+  if (!cal) {
+    Logger.log("Calendar not found: " + CALENDAR_ID);
+    return;
+  }
+
+  const now = new Date();
+  const ahead = new Date(now.getTime() + POLL_WINDOW_MIN * 60 * 1000);
+  const events = cal.getEvents(now, ahead);
+  const props = PropertiesService.getScriptProperties();
+
+  events.forEach(function (ev) {
+    const start = ev.getStartTime();
+    const minutesUntilStart = Math.round(
+      (start.getTime() - now.getTime()) / 60000,
+    );
+    if (minutesUntilStart > LEAD_MINUTES) return;
+
+    // Dedup: notify each occurrence once. Key includes the start time so
+    // recurring instances each notify, but the same instance never twice.
+    const key = "upcoming:" + ev.getId() + ":" + start.getTime();
+    if (props.getProperty(key)) return;
+
+    post("google-calendar.event.upcoming", {
+      event_id: ev.getId(),
+      calendar_id: CALENDAR_ID,
+      summary: ev.getTitle(),
+      description: ev.getDescription(),
+      location: ev.getLocation(),
+      start: start.toISOString(),
+      end: ev.getEndTime().toISOString(),
+      minutes_until_start: minutesUntilStart,
+      attendees: ev.getGuestList().map(function (g) {
+        return { email: g.getEmail(), status: String(g.getGuestStatus()) };
+      }),
+      html_link: null,
+    });
+
+    props.setProperty(key, "1");
+  });
+
+  cleanupOldKeys_(props, now);
+}
+
+/**
+ * Installable onEventUpdated trigger: report created/updated/deleted events.
+ * The event object only carries the calendarId, so we rescan the recent window
+ * and emit changes. We keep a snapshot of known event ids to classify changes.
+ */
+function onCalendarChange(e) {
+  const cal =
+    CALENDAR_ID === "primary"
+      ? CalendarApp.getDefaultCalendar()
+      : CalendarApp.getCalendarById(CALENDAR_ID);
+  if (!cal) return;
+
+  const props = PropertiesService.getScriptProperties();
+  const now = new Date();
+  // Look at a window around now for changed events (past 1h .. next 30 days).
+  const from = new Date(now.getTime() - 60 * 60 * 1000);
+  const to = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+  const events = cal.getEvents(from, to);
+
+  const prevRaw = props.getProperty("known_ids");
+  const prev = prevRaw ? JSON.parse(prevRaw) : {};
+  const current = {};
+
+  events.forEach(function (ev) {
+    const id = ev.getId();
+    const fingerprint =
+      ev.getLastUpdated().getTime() + "|" + ev.getStartTime().getTime();
+    current[id] = fingerprint;
+
+    if (!prev[id]) {
+      emitChange_("google-calendar.event.created", ev);
+    } else if (prev[id] !== fingerprint) {
+      emitChange_("google-calendar.event.updated", ev);
+    }
+  });
+
+  // Deleted: present before, gone now.
+  Object.keys(prev).forEach(function (id) {
+    if (!current[id]) {
+      post("google-calendar.event.deleted", {
+        event_id: id,
+        calendar_id: CALENDAR_ID,
+      });
+    }
+  });
+
+  props.setProperty("known_ids", JSON.stringify(current));
+}
+
+function emitChange_(type, ev) {
+  post(type, {
+    event_id: ev.getId(),
+    calendar_id: CALENDAR_ID,
+    summary: ev.getTitle(),
+    description: ev.getDescription(),
+    location: ev.getLocation(),
+    start: ev.getStartTime().toISOString(),
+    end: ev.getEndTime().toISOString(),
+  });
+}
+
+/** POST {type, data} to the MCP webhook with the bearer token. */
+function post(type, data) {
+  try {
+    UrlFetchApp.fetch(WEBHOOK_URL, {
+      method: "post",
+      contentType: "application/json",
+      headers: { Authorization: "Bearer " + WEBHOOK_TOKEN },
+      payload: JSON.stringify({ type: type, data: data }),
+      muteHttpExceptions: true,
+    });
+  } catch (err) {
+    Logger.log("POST failed (" + type + "): " + err);
+  }
+}
+
+/** Drop dedup keys for events that already started (keep props small). */
+function cleanupOldKeys_(props, now) {
+  const all = props.getProperties();
+  Object.keys(all).forEach(function (key) {
+    if (key.indexOf("upcoming:") !== 0) return;
+    const parts = key.split(":");
+    const startMs = Number(parts[parts.length - 1]);
+    if (startMs && startMs < now.getTime() - 60 * 60 * 1000) {
+      props.deleteProperty(key);
+    }
+  });
+}

--- a/bun.lock
+++ b/bun.lock
@@ -387,7 +387,9 @@
       "name": "google-calendar",
       "version": "1.0.0",
       "dependencies": {
-        "@decocms/runtime": "^1.2.6",
+        "@decocms/runtime": "^1.3.0",
+        "@supabase/supabase-js": "^2.47.10",
+        "hono": "^4.7.4",
         "zod": "^4.0.0",
       },
       "devDependencies": {
@@ -4198,7 +4200,7 @@
 
     "google-big-query/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "google-calendar/@decocms/runtime": ["@decocms/runtime@1.3.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-xRFTV9gqrdsUCAkJ3xoBOeDGXps6moZeZB/NNL+XZ7LNa4qzfmL3BGWG42n8xbFyEpprfEfOtOD+tVgWhkPDxQ=="],
+    "google-calendar/@decocms/runtime": ["@decocms/runtime@1.6.2", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-Z38pLHDoJOfiZVOfQgnfyK24vVV/m8MOm8dXB0dvkIM6yp31JNmW88t3d5hw6P5FYr9TvpvKxQE9uWEeCeN8QQ=="],
 
     "google-calendar/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 

--- a/google-calendar/app.json
+++ b/google-calendar/app.json
@@ -12,7 +12,7 @@
   "metadata": {
     "categories": ["Productivity"],
     "official": false,
-    "tags": ["google", "calendar", "scheduling", "events", "meetings", "productivity", "time-management"],
+    "tags": ["google", "calendar", "scheduling", "events", "meetings", "productivity", "time-management", "triggers", "notifications"],
     "short_description": "Integrate and manage your Google Calendar. Create, edit and delete events, check availability and sync your calendars.",
     "mesh_description": "The Google Calendar MCP provides comprehensive integration with Google Calendar, enabling full programmatic control over calendar events, schedules, and availability management. This MCP allows AI agents to create, read, update, and delete calendar events, check user availability across multiple calendars, manage event attendees and invitations, set up recurring events, and configure event reminders and notifications. It supports advanced scheduling features including finding optimal meeting times, managing calendar sharing and permissions, handling multiple calendars, and synchronizing events across different time zones. The integration is perfect for building intelligent scheduling assistants, automated meeting coordinators, calendar-based workflow triggers, and personal productivity tools. Ideal for teams and individuals who need to automate calendar management, integrate scheduling into business processes, or build calendar-aware applications. Provides secure OAuth-based authentication for calendar access."
   }

--- a/google-calendar/package.json
+++ b/google-calendar/package.json
@@ -17,7 +17,9 @@
     "./constants": "./server/constants.ts"
   },
   "dependencies": {
-    "@decocms/runtime": "^1.2.6",
+    "@decocms/runtime": "^1.3.0",
+    "@supabase/supabase-js": "^2.47.10",
+    "hono": "^4.7.4",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/google-calendar/server/constants.ts
+++ b/google-calendar/server/constants.ts
@@ -26,6 +26,14 @@ export const ENDPOINTS = {
 // Default calendar ID
 export const PRIMARY_CALENDAR = "primary";
 
+// Public base URL of this MCP (used to build the Apps Script webhook URL).
+// Override with SERVER_PUBLIC_URL in non-production environments.
+export const WEBHOOK_BASE_URL =
+  process.env.SERVER_PUBLIC_URL ?? "https://sites-google-calendar.deco.site";
+
+// Default lead time (minutes before an event) suggested to the Apps Script.
+export const DEFAULT_LEAD_MINUTES = 10;
+
 // Default pagination
 export const DEFAULT_MAX_RESULTS = 50;
 

--- a/google-calendar/server/lib/supabase-client.ts
+++ b/google-calendar/server/lib/supabase-client.ts
@@ -1,0 +1,171 @@
+/**
+ * Supabase Client for Google Calendar MCP
+ *
+ * Backs the trigger credentials store (callbackUrl/callbackToken per
+ * connection). Mirrors the slack-mcp pattern: a singleton client reading
+ * SUPABASE_URL / SUPABASE_ANON_KEY from the environment.
+ *
+ * Why persistence is required: the runtime only hands us the trigger
+ * callbackUrl/callbackToken once, inside TRIGGER_CONFIGURE. It never replays
+ * them on restart. Without a persistent store, every inbound webhook from
+ * Google Apps Script would have nowhere to forward to after a redeploy.
+ */
+
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const TABLE = "calendar_trigger_credentials";
+
+interface TriggerCredentialsRow {
+  connection_id: string;
+  callback_url: string;
+  callback_token: string;
+  active_trigger_types: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TriggerState {
+  credentials: { callbackUrl: string; callbackToken: string };
+  activeTriggerTypes: string[];
+}
+
+let supabaseClient: SupabaseClient | null = null;
+
+export function getSupabaseClient(): SupabaseClient | null {
+  if (supabaseClient) {
+    return supabaseClient;
+  }
+
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    return null;
+  }
+
+  try {
+    supabaseClient = createClient(supabaseUrl, supabaseKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+    console.log("[Supabase] ✅ Client initialized successfully");
+    return supabaseClient;
+  } catch (error) {
+    console.error("[Supabase] ❌ Failed to initialize client:", error);
+    return null;
+  }
+}
+
+export function isSupabaseConfigured(): boolean {
+  return !!process.env.SUPABASE_URL && !!process.env.SUPABASE_ANON_KEY;
+}
+
+export async function saveTriggerCredentials(
+  connectionId: string,
+  state: TriggerState,
+): Promise<void> {
+  const client = getSupabaseClient();
+  if (!client) {
+    throw new Error("Supabase client not initialized");
+  }
+
+  const { error } = await client.from(TABLE).upsert(
+    {
+      connection_id: connectionId,
+      callback_url: state.credentials.callbackUrl,
+      callback_token: state.credentials.callbackToken,
+      active_trigger_types: state.activeTriggerTypes,
+      updated_at: new Date().toISOString(),
+    } as never,
+    { onConflict: "connection_id" },
+  );
+
+  if (error) {
+    throw new Error(`Failed to save trigger credentials: ${error.message}`);
+  }
+
+  console.log(
+    `[Supabase] Saved trigger credentials for ${connectionId} (${state.activeTriggerTypes.length} types)`,
+  );
+}
+
+export async function loadTriggerCredentials(
+  connectionId: string,
+): Promise<TriggerState | null> {
+  const client = getSupabaseClient();
+  if (!client) {
+    throw new Error("Supabase client not initialized");
+  }
+
+  const { data, error } = await client
+    .from(TABLE)
+    .select("*")
+    .eq("connection_id", connectionId)
+    .single();
+
+  if (error) {
+    // PGRST116 = no rows found
+    if (error.code === "PGRST116") {
+      return null;
+    }
+    throw new Error(`Failed to load trigger credentials: ${error.message}`);
+  }
+
+  const row = data as TriggerCredentialsRow;
+  return {
+    credentials: {
+      callbackUrl: row.callback_url,
+      callbackToken: row.callback_token,
+    },
+    activeTriggerTypes: row.active_trigger_types,
+  };
+}
+
+export async function deleteTriggerCredentials(
+  connectionId: string,
+): Promise<void> {
+  const client = getSupabaseClient();
+  if (!client) {
+    throw new Error("Supabase client not initialized");
+  }
+
+  const { error } = await client
+    .from(TABLE)
+    .delete()
+    .eq("connection_id", connectionId);
+
+  if (error) {
+    throw new Error(`Failed to delete trigger credentials: ${error.message}`);
+  }
+
+  console.log(`[Supabase] Deleted trigger credentials for ${connectionId}`);
+}
+
+/**
+ * Load all trigger credentials (bootstrap on startup — warms the store and
+ * surfaces how many connections have active triggers).
+ */
+export async function loadAllTriggerCredentials(): Promise<
+  Array<{ connectionId: string; state: TriggerState }>
+> {
+  const client = getSupabaseClient();
+  if (!client) {
+    throw new Error("Supabase client not initialized");
+  }
+
+  const { data, error } = await client.from(TABLE).select("*");
+
+  if (error) {
+    throw new Error(`Failed to load trigger credentials: ${error.message}`);
+  }
+
+  return ((data || []) as TriggerCredentialsRow[]).map((row) => ({
+    connectionId: row.connection_id,
+    state: {
+      credentials: {
+        callbackUrl: row.callback_url,
+        callbackToken: row.callback_token,
+      },
+      activeTriggerTypes: row.active_trigger_types,
+    },
+  }));
+}

--- a/google-calendar/server/lib/trigger-store.ts
+++ b/google-calendar/server/lib/trigger-store.ts
@@ -1,0 +1,104 @@
+/**
+ * Trigger definitions + Supabase-backed storage for Google Calendar.
+ *
+ * Events are fed in by a per-user Google Apps Script (time-driven trigger for
+ * `event.upcoming`, installable `onEventUpdated` for created/updated/deleted)
+ * that POSTs to /calendar/events/:connectionId. The router validates the
+ * request and calls `triggers.notify()`, which reads the callbackUrl/token
+ * from the store below and forwards the event to the studio automation.
+ */
+
+import { createTriggers, type TriggerStorage } from "@decocms/runtime/triggers";
+import {
+  saveTriggerCredentials,
+  loadTriggerCredentials,
+  deleteTriggerCredentials,
+} from "./supabase-client.ts";
+import { z } from "zod";
+
+/**
+ * Supabase-backed trigger storage.
+ * Uses static SUPABASE_URL / SUPABASE_ANON_KEY env vars (never expire).
+ */
+class SupabaseTriggerStorage implements TriggerStorage {
+  async get(connectionId: string) {
+    const result = await loadTriggerCredentials(connectionId);
+    console.log(
+      `[TriggerStorage] GET ${connectionId}: ${result ? "found credentials" : "empty"}`,
+    );
+    return result;
+  }
+
+  // deno-lint-ignore no-explicit-any
+  async set(connectionId: string, state: any) {
+    console.log(`[TriggerStorage] SET ${connectionId}: saving credentials`);
+    await saveTriggerCredentials(connectionId, state);
+  }
+
+  async delete(connectionId: string) {
+    try {
+      console.log(`[TriggerStorage] DELETE ${connectionId}`);
+      await deleteTriggerCredentials(connectionId);
+    } catch (error) {
+      console.error(
+        `[TriggerStorage] DELETE ${connectionId} failed:`,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+}
+
+const storage = new SupabaseTriggerStorage();
+
+/** Trigger types the calendar MCP can emit (also the inbound webhook allow-list). */
+export const CALENDAR_TRIGGER_TYPES = [
+  "google-calendar.event.upcoming",
+  "google-calendar.event.created",
+  "google-calendar.event.updated",
+  "google-calendar.event.deleted",
+] as const;
+
+const calendarIdParam = z.object({
+  calendar_id: z
+    .string()
+    .optional()
+    .describe("Filter by calendar ID. Leave empty for all calendars."),
+});
+
+export const triggers = createTriggers({
+  definitions: [
+    {
+      type: "google-calendar.event.upcoming",
+      description:
+        "Triggered shortly before an event starts. Fired by the user's Google " +
+        "Apps Script when an upcoming event falls within its configured lead " +
+        "time (LEAD_MINUTES). Payload carries: `event_id`, `summary`, `start`, " +
+        "`end`, `minutes_until_start`, `location`, `hangout_link`, `html_link`, " +
+        "`attendees`. Use it to notify the user that a meeting is about to begin.",
+      params: calendarIdParam,
+    },
+    {
+      type: "google-calendar.event.created",
+      description:
+        "Triggered when a new event is added to the calendar (detected by the " +
+        "Apps Script `onEventUpdated` installable trigger). Payload carries the " +
+        "event details (`event_id`, `summary`, `start`, `end`, etc.).",
+      params: calendarIdParam,
+    },
+    {
+      type: "google-calendar.event.updated",
+      description:
+        "Triggered when an existing event is modified. Payload carries the " +
+        "updated event details.",
+      params: calendarIdParam,
+    },
+    {
+      type: "google-calendar.event.deleted",
+      description:
+        "Triggered when an event is removed/cancelled. Payload carries at least " +
+        "`event_id` and `calendar_id`.",
+      params: calendarIdParam,
+    },
+  ],
+  storage,
+});

--- a/google-calendar/server/main.ts
+++ b/google-calendar/server/main.ts
@@ -4,6 +4,13 @@ import { serve } from "@decocms/mcps-shared/serve";
 import { createGoogleOAuth } from "@decocms/mcps-shared/google-oauth";
 
 import { tools } from "./tools/index.ts";
+import { createGetAppsScriptConfigTool } from "./tools/apps-script.ts";
+import { triggers } from "./lib/trigger-store.ts";
+import {
+  isSupabaseConfigured,
+  loadAllTriggerCredentials,
+} from "./lib/supabase-client.ts";
+import { app as webhookRouter } from "./router.ts";
 import { GOOGLE_SCOPES } from "./constants.ts";
 import { type Env, StateSchema } from "../shared/deco.gen.ts";
 
@@ -36,10 +43,43 @@ const runtime = withRuntime<Env, typeof StateSchema, Registry>({
       },
     },
   },
-  tools: (env: Env) => tools.map((createTool) => createTool(env)),
+  tools: (env: Env) => [
+    ...tools.map((createTool) => createTool(env)),
+    // Trigger config tools (TRIGGER_CONFIGURE / TRIGGER_UNCONFIGURE) and the
+    // Apps Script setup helper — only on the OAuth app, not the shared index.
+    ...triggers.tools(),
+    createGetAppsScriptConfigTool(env),
+  ],
   oauth: createGoogleOAuth({
     scopes: [GOOGLE_SCOPES.CALENDAR, GOOGLE_SCOPES.CALENDAR_EVENTS],
   }),
 });
 
-serve(runtime.fetch);
+// Bootstrap: warm trigger credentials from Supabase so they survive restarts.
+// The runtime never replays TRIGGER_CONFIGURE, so this store is the source of
+// truth for where to forward inbound Apps Script events.
+if (isSupabaseConfigured()) {
+  try {
+    const allCreds = await loadAllTriggerCredentials();
+    console.log(
+      `[BOOTSTRAP] Loaded trigger credentials for ${allCreds.length} connection(s)`,
+    );
+  } catch (error) {
+    console.error("[BOOTSTRAP] Failed to load trigger credentials:", error);
+  }
+} else {
+  console.warn(
+    "[BOOTSTRAP] Supabase not configured — calendar triggers will not persist. " +
+      "Set SUPABASE_URL / SUPABASE_ANON_KEY.",
+  );
+}
+
+// Webhook routes (/health, /calendar/events/:connectionId) are handled by the
+// Hono router. A 404 means "not a webhook route" — fall through to /mcp.
+serve(async (req, env, ctx) => {
+  const webhookResponse = await webhookRouter.fetch(req, env, ctx);
+  if (webhookResponse.status !== 404) {
+    return webhookResponse;
+  }
+  return runtime.fetch(req, env, ctx);
+});

--- a/google-calendar/server/router.ts
+++ b/google-calendar/server/router.ts
@@ -1,0 +1,87 @@
+/**
+ * HTTP Router for the Google Calendar MCP webhook bridge.
+ *
+ * Primary route: POST /calendar/events/:connectionId
+ *   - Receives events from the user's Google Apps Script.
+ *   - Verifies the per-connection HMAC token.
+ *   - Forwards the event to the studio via triggers.notify(), which reads the
+ *     callbackUrl/token persisted in Supabase by TRIGGER_CONFIGURE.
+ *
+ * A 404 from this router means "not a webhook route" — main.ts then falls
+ * through to runtime.fetch (the /mcp endpoint).
+ */
+
+import { Hono } from "hono";
+import { triggers, CALENDAR_TRIGGER_TYPES } from "./lib/trigger-store.ts";
+import { verifyWebhookToken, bearerToken } from "./webhook.ts";
+
+type CalendarTriggerType = (typeof CALENDAR_TRIGGER_TYPES)[number];
+
+const ALLOWED_TYPES = new Set<string>(CALENDAR_TRIGGER_TYPES);
+
+function isCalendarTriggerType(t: string): t is CalendarTriggerType {
+  return ALLOWED_TYPES.has(t);
+}
+
+interface CalendarWebhookPayload {
+  type?: string;
+  data?: Record<string, unknown>;
+}
+
+export const app = new Hono();
+
+app.get("/health", (c) =>
+  c.json({
+    status: "ok",
+    service: "google-calendar-mcp",
+    ts: new Date().toISOString(),
+  }),
+);
+
+app.post("/calendar/events/:connectionId", async (c) => {
+  const connectionId = c.req.param("connectionId");
+  const token = bearerToken(c.req.header("authorization"));
+
+  const verified = await verifyWebhookToken(connectionId, token);
+  if (!verified) {
+    console.error(`[Calendar Webhook] Invalid token for ${connectionId}`);
+    return c.json({ error: "Invalid token" }, 401);
+  }
+
+  let payload: CalendarWebhookPayload;
+  try {
+    payload = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON" }, 400);
+  }
+
+  const type = payload.type;
+  if (!type || !isCalendarTriggerType(type)) {
+    return c.json(
+      {
+        error: "Unknown event type",
+        allowed: [...ALLOWED_TYPES],
+      },
+      400,
+    );
+  }
+
+  const data = payload.data ?? {};
+
+  try {
+    // Fire-and-forget on a persistent process: the notify promise survives
+    // without ctx.waitUntil() (unlike Cloudflare Workers). Awaited here so a
+    // delivery error surfaces in logs and the response.
+    await triggers.notify(connectionId, type, data);
+  } catch (error) {
+    console.error(
+      `[Calendar Webhook] notify failed for ${connectionId} (${type}):`,
+      error instanceof Error ? error.message : String(error),
+    );
+    // 200 anyway: the GAS dedup already marked this event as notified, and a
+    // retry storm wouldn't help (likely a missing trigger config, not transient).
+    return c.json({ ok: true, delivered: false });
+  }
+
+  return c.json({ ok: true, delivered: true });
+});

--- a/google-calendar/server/tools/apps-script.ts
+++ b/google-calendar/server/tools/apps-script.ts
@@ -1,0 +1,80 @@
+/**
+ * get_apps_script_config tool
+ *
+ * Returns everything a user needs to wire up the Google Apps Script notifier
+ * for THIS connection: the webhook URL (with the connectionId baked in), the
+ * per-connection HMAC token, and a ready-to-paste config block for the
+ * `apps-script/calendar-notifier.gs` template.
+ */
+
+import { createPrivateTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import type { Env } from "../main.ts";
+import { computeWebhookToken } from "../webhook.ts";
+import { WEBHOOK_BASE_URL, DEFAULT_LEAD_MINUTES } from "../constants.ts";
+
+export const createGetAppsScriptConfigTool = (env: Env) =>
+  createPrivateTool({
+    id: "get_apps_script_config",
+    description:
+      "Get the configuration to set up the Google Apps Script that notifies " +
+      "you before upcoming meetings (and on event changes). Returns the webhook " +
+      "URL, the auth token for this connection, and a config snippet to paste " +
+      "into the calendar-notifier.gs template. Each user runs the script in " +
+      "their own Google account; it polls their calendar and posts events here.",
+    inputSchema: z.object({
+      leadMinutes: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(120)
+        .optional()
+        .describe(
+          `Minutes before an event to notify (default: ${DEFAULT_LEAD_MINUTES}). Lives in the Apps Script.`,
+        ),
+    }),
+    outputSchema: z.object({
+      webhookUrl: z.string().describe("URL the Apps Script posts events to"),
+      webhookToken: z
+        .string()
+        .describe("Bearer token for this connection (paste into the script)"),
+      leadMinutes: z.number().describe("Configured lead time in minutes"),
+      snippet: z
+        .string()
+        .describe("Config block to paste at the top of calendar-notifier.gs"),
+      instructions: z.string().describe("Setup steps"),
+    }),
+    execute: async ({ context }) => {
+      const connectionId = env.MESH_REQUEST_CONTEXT?.connectionId;
+      if (!connectionId) {
+        throw new Error(
+          "No connectionId in request context — open this from a configured connection.",
+        );
+      }
+
+      const webhookToken = await computeWebhookToken(connectionId);
+      const webhookUrl = `${WEBHOOK_BASE_URL}/calendar/events/${connectionId}`;
+      const leadMinutes = context.leadMinutes ?? DEFAULT_LEAD_MINUTES;
+
+      const snippet = [
+        `const WEBHOOK_URL = ${JSON.stringify(webhookUrl)};`,
+        `const WEBHOOK_TOKEN = ${JSON.stringify(webhookToken)};`,
+        `const LEAD_MINUTES = ${leadMinutes};`,
+        `const POLL_WINDOW_MIN = ${leadMinutes + 5};`,
+        `const CALENDAR_ID = "primary";`,
+      ].join("\n");
+
+      const instructions = [
+        "1. Open https://script.google.com and create a new project.",
+        "2. Paste the contents of calendar-notifier.gs.",
+        "3. Replace the config block at the top with the `snippet` below.",
+        "4. Run the `setup` function once and authorize the script.",
+        "5. The time-driven trigger (every 5 min) will notify you before events;",
+        "   the onEventUpdated trigger will report created/updated/deleted events.",
+        "Before configuring the script, configure the trigger(s) in the studio",
+        "(TRIGGER_CONFIGURE) so this connection has a delivery callback.",
+      ].join("\n");
+
+      return { webhookUrl, webhookToken, leadMinutes, snippet, instructions };
+    },
+  });

--- a/google-calendar/server/webhook.ts
+++ b/google-calendar/server/webhook.ts
@@ -1,0 +1,69 @@
+/**
+ * Webhook auth for the Google Apps Script → calendar bridge.
+ *
+ * The Apps Script (running in each user's Google account) has no Google-issued
+ * signing secret — it's our own script. So we mint a per-connection token by
+ * HMAC-ing the connectionId with a server-wide secret (SERVER_SECRET). The
+ * `get_apps_script_config` tool hands this token to the user; the router below
+ * recomputes it and compares constant-time. No extra storage for the token.
+ */
+
+function getServerSecret(): string {
+  const secret = process.env.SERVER_SECRET;
+  if (!secret) {
+    throw new Error(
+      "SERVER_SECRET is not set — cannot mint/verify webhook tokens",
+    );
+  }
+  return secret;
+}
+
+async function hmacHex(message: string, secret: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(message));
+  return Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** Deterministic per-connection webhook token (hex HMAC of the connectionId). */
+export function computeWebhookToken(connectionId: string): Promise<string> {
+  return hmacHex(connectionId, getServerSecret());
+}
+
+/** Constant-time verification of a presented token for a connection. */
+export async function verifyWebhookToken(
+  connectionId: string,
+  presented: string | null,
+): Promise<boolean> {
+  if (!presented) return false;
+
+  let expected: string;
+  try {
+    expected = await computeWebhookToken(connectionId);
+  } catch (error) {
+    console.error("[Calendar Webhook] Cannot verify token:", error);
+    return false;
+  }
+
+  if (expected.length !== presented.length) return false;
+
+  let result = 0;
+  for (let i = 0; i < expected.length; i++) {
+    result |= expected.charCodeAt(i) ^ presented.charCodeAt(i);
+  }
+  return result === 0;
+}
+
+/** Extract a bearer token from the Authorization header. */
+export function bearerToken(header: string | null | undefined): string | null {
+  if (!header) return null;
+  return header.startsWith("Bearer ") ? header.slice(7) : header;
+}

--- a/google-calendar/shared/deco.gen.ts
+++ b/google-calendar/shared/deco.gen.ts
@@ -4,6 +4,19 @@ import { z } from "zod";
 
 export const StateSchema = z.object({
   EVENT_BUS: BindingOf("@deco/event-bus"),
+
+  // Read-only template shown in the connection UI. Replace {connectionId} with
+  // your connection ID (visible in the browser URL), or call
+  // get_apps_script_config to get the full URL + token for the Apps Script.
+  WEBHOOK_URL: z
+    .string()
+    .default(
+      "https://sites-google-calendar.deco.site/calendar/events/{connectionId}",
+    )
+    .readonly()
+    .describe(
+      "Webhook URL the Google Apps Script posts events to. Use get_apps_script_config to get the URL + token for this connection.",
+    ),
 });
 
 export type Env = DefaultEnv<typeof StateSchema, Registry>;


### PR DESCRIPTION
Adds a per-user "notify before a meeting" path to the **google-calendar** MCP: a Google Apps Script (`apps-script/calendar-notifier.gs`) runs in the user's own account, polls their calendar on a time-driven trigger, and POSTs upcoming/created/updated/deleted events to a new webhook (`POST /calendar/events/:connectionId`), which forwards them to the studio via `triggers.notify()` — the Slack/kubernetes-bun pattern. Inbound requests are authenticated with a per-connection HMAC token (`webhook.ts`), and trigger credentials are persisted in Supabase (`supabase-client.ts`, `trigger-store.ts`) because the runtime never replays them on restart. A new `get_apps_script_config` tool returns the webhook URL + token + a ready-to-paste config snippet; `main.ts` wires the Hono router around `runtime.fetch`, registers `triggers.tools()`, and bootstraps creds at startup. The existing EVENT_BUS plumbing and shared write tools are untouched, so the `google-calendar-sa` app is unaffected.

**Ops before deploy:** create the `calendar_trigger_credentials` Supabase table and set `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SERVER_SECRET` on the google-calendar deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-user meeting notifications for Google Calendar using a Google Apps Script that posts events to a new webhook, which forwards them to studio triggers. Trigger credentials are persisted in Supabase so deliveries survive restarts and redeploys.

- **New Features**
  - Google Apps Script template posts `event.upcoming`, `event.created`, `event.updated`, and `event.deleted` with dedup and configurable lead time.
  - New webhook: POST `/calendar/events/:connectionId` (Hono router); bearer token is per-connection HMAC of `connectionId` using `SERVER_SECRET`.
  - Supabase-backed trigger storage for callback URL/token; warm-loaded on startup; `triggers.tools()` registered alongside a `get_apps_script_config` tool.
  - Config helpers and defaults: `WEBHOOK_BASE_URL`, `DEFAULT_LEAD_MINUTES`, `/health` route; deps added `@supabase/supabase-js`, `hono`, and bumped `@decocms/runtime`.

- **Migration**
  - Create Supabase table `calendar_trigger_credentials`.
  - Set env vars: `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SERVER_SECRET` (and `SERVER_PUBLIC_URL` if not using the default base URL).
  - Redeploy, then configure triggers in the studio (TRIGGER_CONFIGURE).
  - For each user: run `get_apps_script_config`, paste the snippet into `apps-script/calendar-notifier.gs`, run `setup`, and authorize the script.
  - Note: without Supabase configured, trigger configs won’t persist across restarts.

<sup>Written for commit cbd251bf3565561334d8b7ddc6ca998aa2ff6b56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

