### PR TITLE
hotfix(google-analytics): improve outputSchema and zod validations

### DIFF
--- a/google-analytics/server/lib/schemas.ts
+++ b/google-analytics/server/lib/schemas.ts
@@ -1,0 +1,286 @@
+/**
+ * Zod output schemas for all GA4 API responses.
+ *
+ * Sources:
+ *  - Data API:  https://developers.google.com/analytics/devguides/reporting/data/v1/rest
+ *  - Admin API: https://developers.google.com/analytics/devguides/config/admin/v1/rest
+ */
+
+import { z } from "zod";
+
+// ── Shared primitives ────────────────────────────────────────────────────────
+
+/** ISO-8601 timestamp string (e.g. "2024-01-15T10:30:00Z"). */
+const Timestamp = z.string();
+
+/** Represents a date used in annotation. */
+const DateSchema = z.object({
+  year: z.number().int().optional(),
+  month: z.number().int().optional(),
+  day: z.number().int().optional(),
+});
+
+// ── Admin API — Account Summaries ────────────────────────────────────────────
+
+export const PropertySummarySchema = z.object({
+  /** Resource name, e.g. "properties/123456". */
+  property: z.string(),
+  displayName: z.string(),
+  /** e.g. "PROPERTY_TYPE_ORDINARY" | "PROPERTY_TYPE_ROLLUP" | "PROPERTY_TYPE_SUBPROPERTY" */
+  propertyType: z.string().optional(),
+  /** Parent resource name, e.g. "accounts/123456". */
+  parent: z.string().optional(),
+});
+
+export const AccountSummarySchema = z.object({
+  /** Resource name, e.g. "accountSummaries/123456". */
+  name: z.string(),
+  /** Account resource name, e.g. "accounts/123456". */
+  account: z.string().optional(),
+  displayName: z.string().optional(),
+  propertySummaries: z.array(PropertySummarySchema).optional(),
+});
+
+export const AccountSummariesResponseSchema = z.object({
+  response: z.object({
+    accountSummaries: z.array(AccountSummarySchema).optional(),
+  }),
+});
+
+// ── Admin API — Property ─────────────────────────────────────────────────────
+
+export const PropertySchema = z.object({
+  /** Resource name, e.g. "properties/123456". */
+  name: z.string().optional(),
+  /** Parent resource, e.g. "accounts/123456" or "properties/123" for sub-properties. */
+  parent: z.string().optional(),
+  createTime: Timestamp.optional(),
+  updateTime: Timestamp.optional(),
+  displayName: z.string().optional(),
+  industryCategory: z.string().optional(),
+  timeZone: z.string().optional(),
+  currencyCode: z.string().optional(),
+  /** e.g. "GOOGLE_ANALYTICS_STANDARD" | "GOOGLE_ANALYTICS_360" */
+  serviceLevel: z.string().optional(),
+  /** e.g. "PROPERTY_TYPE_ORDINARY" | "PROPERTY_TYPE_ROLLUP" | "PROPERTY_TYPE_SUBPROPERTY" */
+  propertyType: z.string().optional(),
+  account: z.string().optional(),
+  deleteTime: Timestamp.optional(),
+  expireTime: Timestamp.optional(),
+});
+
+export const PropertyResponseSchema = z.object({
+  response: PropertySchema,
+});
+
+// ── Admin API — Custom Dimensions & Metrics ──────────────────────────────────
+
+export const CustomDimensionSchema = z.object({
+  /** Resource name, e.g. "properties/123/customDimensions/456". */
+  name: z.string().optional(),
+  /** The parameter name used in events / user properties. */
+  parameterName: z.string(),
+  displayName: z.string().optional(),
+  description: z.string().optional(),
+  /** "EVENT" | "USER" | "ITEM" */
+  scope: z.string().optional(),
+  disallowAdsPersonalization: z.boolean().optional(),
+});
+
+export const CustomMetricSchema = z.object({
+  /** Resource name. */
+  name: z.string().optional(),
+  parameterName: z.string(),
+  displayName: z.string().optional(),
+  description: z.string().optional(),
+  /** e.g. "STANDARD" | "CURRENCY" | "FEET" | "METERS" | "KILOMETERS" | "MILES" | "MILLISECONDS" | "SECONDS" | "MINUTES" | "HOURS" */
+  measurementUnit: z.string().optional(),
+  /** "EVENT" | "ITEM" */
+  scope: z.string().optional(),
+  /** e.g. ["COST_DATA", "REVENUE_DATA"] */
+  restrictedMetricType: z.array(z.string()).optional(),
+});
+
+export const CustomDimensionsListSchema = z.object({
+  customDimensions: z.array(CustomDimensionSchema).optional(),
+});
+
+export const CustomMetricsListSchema = z.object({
+  customMetrics: z.array(CustomMetricSchema).optional(),
+});
+
+export const CustomDimensionsAndMetricsResponseSchema = z.object({
+  /** Result of listCustomDimensions — `{ customDimensions: [...] }` */
+  dimensions: CustomDimensionsListSchema,
+  /** Result of listCustomMetrics — `{ customMetrics: [...] }` */
+  metrics: CustomMetricsListSchema,
+});
+
+// ── Admin API — Google Ads Links ─────────────────────────────────────────────
+
+export const GoogleAdsLinkSchema = z.object({
+  /** Resource name. */
+  name: z.string().optional(),
+  /** Google Ads Customer ID (without hyphens). */
+  customerId: z.string().optional(),
+  canManageClients: z.boolean().optional(),
+  adsPersonalizationEnabled: z.boolean().optional(),
+  creatorEmailAddress: z.string().optional(),
+  createTime: Timestamp.optional(),
+  updateTime: Timestamp.optional(),
+});
+
+export const GoogleAdsLinksResponseSchema = z.object({
+  response: z.object({
+    googleAdsLinks: z.array(GoogleAdsLinkSchema).optional(),
+  }),
+});
+
+// ── Admin API — Property Annotations ─────────────────────────────────────────
+
+export const ReportingDataAnnotationSchema = z.object({
+  /** Resource name. */
+  name: z.string().optional(),
+  annotationDate: DateSchema.optional(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  systemGenerated: z.boolean().optional(),
+  /** "RED" | "ORANGE" | "YELLOW" | "GREEN" | "BLUE" | "PURPLE" | "PINK" */
+  color: z.string().optional(),
+});
+
+export const PropertyAnnotationsResponseSchema = z.object({
+  response: z.object({
+    reportingDataAnnotations: z.array(ReportingDataAnnotationSchema).optional(),
+  }),
+});
+
+// ── Data API — shared building blocks ────────────────────────────────────────
+
+export const DimensionHeaderSchema = z.object({
+  name: z.string(),
+});
+
+export const MetricHeaderSchema = z.object({
+  name: z.string(),
+  /** e.g. "TYPE_INTEGER" | "TYPE_FLOAT" | "TYPE_SECONDS" | "TYPE_MILLISECONDS" | "TYPE_MINUTES" | "TYPE_HOURS" | "TYPE_STANDARD" | "TYPE_CURRENCY" | "TYPE_FEET" | "TYPE_MILES" | "TYPE_METERS" | "TYPE_KILOMETERS" */
+  type: z.string().optional(),
+});
+
+export const DimensionValueSchema = z.object({
+  value: z.string().optional(),
+});
+
+export const MetricValueSchema = z.object({
+  value: z.string().optional(),
+});
+
+export const RowSchema = z.object({
+  dimensionValues: z.array(DimensionValueSchema).optional(),
+  metricValues: z.array(MetricValueSchema).optional(),
+});
+
+export const ResponseMetaDataSchema = z.object({
+  currencyCode: z.string().optional(),
+  timeZone: z.string().optional(),
+  schemaRestrictionResponse: z.unknown().optional(),
+  subjectToThresholding: z.boolean().optional(),
+  samplingMetadatas: z.array(z.unknown()).optional(),
+});
+
+/** Quota state returned when `returnPropertyQuota: true`. */
+export const PropertyQuotaSchema = z
+  .object({
+    tokensPerDay: z
+      .object({ consumed: z.number(), remaining: z.number() })
+      .optional(),
+    tokensPerHour: z
+      .object({ consumed: z.number(), remaining: z.number() })
+      .optional(),
+    concurrentRequests: z
+      .object({ consumed: z.number(), remaining: z.number() })
+      .optional(),
+    serverErrorsPerProjectPerHour: z
+      .object({ consumed: z.number(), remaining: z.number() })
+      .optional(),
+    potentiallyThresholdedRequestsPerHour: z
+      .object({ consumed: z.number(), remaining: z.number() })
+      .optional(),
+    tokensPerProjectPerDay: z
+      .object({ consumed: z.number(), remaining: z.number() })
+      .optional(),
+  })
+  .optional();
+
+// ── Data API — runReport ──────────────────────────────────────────────────────
+
+export const RunReportResponseSchema = z.object({
+  dimensionHeaders: z.array(DimensionHeaderSchema).optional(),
+  metricHeaders: z.array(MetricHeaderSchema).optional(),
+  rows: z.array(RowSchema).optional(),
+  totals: z.array(RowSchema).optional(),
+  maximums: z.array(RowSchema).optional(),
+  minimums: z.array(RowSchema).optional(),
+  rowCount: z.number().optional(),
+  metadata: ResponseMetaDataSchema.optional(),
+  propertyQuota: PropertyQuotaSchema.optional(),
+  /** Always "analyticsData#runReport". */
+  kind: z.string().optional(),
+});
+
+export const RunReportOutputSchema = z.object({
+  response: RunReportResponseSchema,
+});
+
+// ── Data API — runRealtimeReport ─────────────────────────────────────────────
+
+export const RunRealtimeReportResponseSchema = z.object({
+  dimensionHeaders: z.array(DimensionHeaderSchema).optional(),
+  metricHeaders: z.array(MetricHeaderSchema).optional(),
+  rows: z.array(RowSchema).optional(),
+  totals: z.array(RowSchema).optional(),
+  maximums: z.array(RowSchema).optional(),
+  minimums: z.array(RowSchema).optional(),
+  rowCount: z.number().optional(),
+  propertyQuota: PropertyQuotaSchema.optional(),
+  /** Always "analyticsData#runRealtimeReport". */
+  kind: z.string().optional(),
+});
+
+export const RunRealtimeReportOutputSchema = z.object({
+  response: RunRealtimeReportResponseSchema,
+});
+
+// ── Data API — runFunnelReport ────────────────────────────────────────────────
+
+export const FunnelResponseMetaDataSchema = z.object({
+  samplingMetadatas: z.array(z.unknown()).optional(),
+  schemaRestrictionResponse: z.unknown().optional(),
+});
+
+/**
+ * Funnel response rows share the same Row structure (dimensionValues +
+ * metricValues), grouped in funnelTable and funnelVisualization sub-objects.
+ */
+export const FunnelSubReportSchema = z.object({
+  dimensionHeaders: z.array(DimensionHeaderSchema).optional(),
+  metricHeaders: z.array(MetricHeaderSchema).optional(),
+  rows: z.array(RowSchema).optional(),
+  totals: z.array(RowSchema).optional(),
+  maximums: z.array(RowSchema).optional(),
+  minimums: z.array(RowSchema).optional(),
+  rowCount: z.number().optional(),
+  metadata: FunnelResponseMetaDataSchema.optional(),
+});
+
+export const RunFunnelReportResponseSchema = z.object({
+  funnelTable: FunnelSubReportSchema.optional(),
+  funnelVisualization: FunnelSubReportSchema.optional(),
+  propertyQuota: PropertyQuotaSchema.optional(),
+  /** Always "analyticsData#runFunnelReport". */
+  kind: z.string().optional(),
+});
+
+export const RunFunnelReportOutputSchema = z.object({
+  response: RunFunnelReportResponseSchema,
+});

--- a/google-analytics/server/tools/accounts.ts
+++ b/google-analytics/server/tools/accounts.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { createPrivateTool } from "@decocms/runtime/tools";
 import type { Env } from "../../shared/deco.gen.ts";
 import { GaClient } from "../lib/ga-client.ts";
+import { AccountSummariesResponseSchema } from "../lib/schemas.ts";
 
 export const getAccountSummariesTool = (env: Env) =>
   createPrivateTool({
@@ -9,13 +10,13 @@ export const getAccountSummariesTool = (env: Env) =>
     description:
       "Retrieves information about the user's Google Analytics accounts and properties.",
     inputSchema: z.object({}),
+    outputSchema: AccountSummariesResponseSchema,
     execute: async () => {
       const client = GaClient.fromEnv(env);
 
       try {
-        const response = await client.listAccountSummaries();
-
-        return { response };
+        const result = await client.listAccountSummaries();
+        return AccountSummariesResponseSchema.parse({ response: result });
       } catch (error) {
         throw new Error(
           `Failed to retrieve account summaries: ${error instanceof Error ? error.message : String(error)}`,

--- a/google-analytics/server/tools/ads.ts
+++ b/google-analytics/server/tools/ads.ts
@@ -2,9 +2,12 @@ import { z } from "zod";
 import { createPrivateTool } from "@decocms/runtime/tools";
 import type { Env } from "../../shared/deco.gen.ts";
 import { GaClient } from "../lib/ga-client.ts";
+import { GoogleAdsLinksResponseSchema } from "../lib/schemas.ts";
 
 const propertySchema = z
+
   .string()
+
   .describe(
     "GA4 Property identifier — 'properties/1234567' or just '1234567'.",
   );
@@ -15,11 +18,12 @@ export const listGoogleAdsLinksTool = (env: Env) =>
     description:
       "Returns a list of links to Google Ads accounts for a GA4 property.",
     inputSchema: z.object({ property: propertySchema }),
+    outputSchema: GoogleAdsLinksResponseSchema,
     execute: async ({ context: args }) => {
       const client = GaClient.fromEnv(env);
       try {
-        const response = await client.listGoogleAdsLinks(args.property);
-        return { response };
+        const result = await client.listGoogleAdsLinks(args.property);
+        return GoogleAdsLinksResponseSchema.parse({ response: result });
       } catch (error) {
         throw new Error(
           `Failed to retrieve Google Ads links: ${error instanceof Error ? error.message : String(error)}`,

--- a/google-analytics/server/tools/annotations.ts
+++ b/google-analytics/server/tools/annotations.ts
@@ -2,9 +2,12 @@ import { z } from "zod";
 import { createPrivateTool } from "@decocms/runtime/tools";
 import type { Env } from "../../shared/deco.gen.ts";
 import { GaClient } from "../lib/ga-client.ts";
+import { PropertyAnnotationsResponseSchema } from "../lib/schemas.ts";
 
 const propertySchema = z
+
   .string()
+
   .describe(
     "GA4 Property identifier — 'properties/1234567' or just '1234567'.",
   );
@@ -15,11 +18,12 @@ export const listPropertyAnnotationsTool = (env: Env) =>
     description:
       "Returns timestamped annotations for a GA4 property — useful for correlating traffic changes with events like campaign launches, site releases, or data collection changes.",
     inputSchema: z.object({ property: propertySchema }),
+    outputSchema: PropertyAnnotationsResponseSchema,
     execute: async ({ context: args }) => {
       const client = GaClient.fromEnv(env);
       try {
-        const response = await client.listPropertyAnnotations(args.property);
-        return { response };
+        const result = await client.listPropertyAnnotations(args.property);
+        return PropertyAnnotationsResponseSchema.parse({ response: result });
       } catch (error) {
         throw new Error(
           `Failed to retrieve property annotations: ${error instanceof Error ? error.message : String(error)}`,

--- a/google-analytics/server/tools/properties.ts
+++ b/google-analytics/server/tools/properties.ts
@@ -2,9 +2,15 @@ import { z } from "zod";
 import { createPrivateTool } from "@decocms/runtime/tools";
 import type { Env } from "../../shared/deco.gen.ts";
 import { GaClient } from "../lib/ga-client.ts";
+import {
+  PropertyResponseSchema,
+  CustomDimensionsAndMetricsResponseSchema,
+} from "../lib/schemas.ts";
 
 const propertySchema = z
+
   .string()
+
   .describe(
     "GA4 Property identifier — 'properties/1234567' or just '1234567'.",
   );
@@ -15,11 +21,12 @@ export const getPropertyDetailsTool = (env: Env) =>
     description:
       "Returns metadata and configuration details about a GA4 property.",
     inputSchema: z.object({ property: propertySchema }),
+    outputSchema: PropertyResponseSchema,
     execute: async ({ context: args }) => {
       const client = GaClient.fromEnv(env);
       try {
-        const response = await client.getProperty(args.property);
-        return { response };
+        const result = await client.getProperty(args.property);
+        return PropertyResponseSchema.parse({ response: result });
       } catch (error) {
         throw new Error(
           `Failed to retrieve property details: ${error instanceof Error ? error.message : String(error)}`,
@@ -34,6 +41,7 @@ export const getCustomDimensionsAndMetricsTool = (env: Env) =>
     description:
       "Retrieves the custom dimensions and custom metrics configured for a GA4 property.",
     inputSchema: z.object({ property: propertySchema }),
+    outputSchema: CustomDimensionsAndMetricsResponseSchema,
     execute: async ({ context: args }) => {
       const client = GaClient.fromEnv(env);
       try {
@@ -42,7 +50,11 @@ export const getCustomDimensionsAndMetricsTool = (env: Env) =>
           client.listCustomDimensions(args.property),
           client.listCustomMetrics(args.property),
         ]);
-        return { dimensions, metrics };
+
+        return CustomDimensionsAndMetricsResponseSchema.parse({
+          dimensions,
+          metrics,
+        });
       } catch (error) {
         throw new Error(
           `Failed to retrieve custom dimensions/metrics: ${error instanceof Error ? error.message : String(error)}`,

--- a/google-analytics/server/tools/reports.ts
+++ b/google-analytics/server/tools/reports.ts
@@ -2,15 +2,24 @@ import { z } from "zod";
 import { createPrivateTool } from "@decocms/runtime/tools";
 import type { Env } from "../../shared/deco.gen.ts";
 import { GaClient } from "../lib/ga-client.ts";
+import {
+  RunReportOutputSchema,
+  RunFunnelReportOutputSchema,
+  RunRealtimeReportOutputSchema,
+} from "../lib/schemas.ts";
 
 const DateRangeSchema = z.object({
   startDate: z
+
     .string()
+
     .describe(
       "Inclusive start date in YYYY-MM-DD format, or relative values: 'today', 'yesterday', 'NdaysAgo'.",
     ),
   endDate: z
+
     .string()
+
     .describe(
       "Inclusive end date in YYYY-MM-DD format, or relative values: 'today', 'yesterday'.",
     ),
@@ -21,13 +30,17 @@ const MetricSchema = z.object({ name: z.string() });
 
 // FilterExpression and OrderBy are passed as raw JSON objects matching the GA4 REST API schema.
 const FilterExpressionSchema = z
+
   .record(z.string(), z.unknown())
+
   .describe(
     "GA4 FilterExpression object. See https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/FilterExpression",
   );
 
 const OrderBySchema = z
+
   .record(z.string(), z.unknown())
+
   .describe(
     "GA4 OrderBy object. See https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/OrderBy",
   );
@@ -39,23 +52,34 @@ export const runReportTool = (env: Env) =>
       "Runs a Google Analytics 4 report using the Data API. Returns dimensions, metrics, and row data for the specified property and date range.",
     inputSchema: z.object({
       property: z
+
         .string()
+
         .describe(
           "GA4 Property identifier — 'properties/1234567' or just '1234567'.",
         ),
       dateRanges: z
+
         .array(DateRangeSchema)
+
         .min(1)
+
         .describe("One or more date ranges to include in the report."),
       dimensions: z
+
         .array(DimensionSchema)
+
         .optional()
+
         .describe(
           "Dimensions to group results by, e.g. [{ name: 'sessionSource' }].",
         ),
       metrics: z
+
         .array(MetricSchema)
+
         .min(1)
+
         .describe("Metrics to aggregate, e.g. [{ name: 'activeUsers' }]."),
       dimensionFilter: FilterExpressionSchema.optional().describe(
         "Optional filter to restrict dimension values.",
@@ -64,38 +88,58 @@ export const runReportTool = (env: Env) =>
         "Optional filter to restrict metric values.",
       ),
       orderBys: z
+
         .array(OrderBySchema)
+
         .optional()
+
         .describe("Optional ordering for returned rows."),
       limit: z
+
         .number()
+
         .int()
+
         .positive()
+
         .optional()
+
         .describe(
           "Maximum number of rows to return. Defaults to 10,000; max 250,000.",
         ),
       offset: z
+
         .number()
+
         .int()
+
         .nonnegative()
+
         .optional()
+
         .describe(
           "Row offset for pagination (0-based). Use with limit to page through results.",
         ),
       currencyCode: z
+
         .string()
+
         .optional()
+
         .describe(
           "Optional ISO 4217 currency code for revenue metrics, e.g. 'USD'.",
         ),
       returnPropertyQuota: z
+
         .boolean()
+
         .optional()
+
         .describe(
           "If true, includes the current GA4 property quota state in the response.",
         ),
     }),
+    outputSchema: RunReportOutputSchema,
     execute: async ({ context: args }) => {
       const client = GaClient.fromEnv(env);
       try {
@@ -117,7 +161,8 @@ export const runReportTool = (env: Env) =>
           body.returnPropertyQuota = args.returnPropertyQuota;
         }
         const response = await client.runReport(args.property, body);
-        return { response };
+
+        return RunReportOutputSchema.parse({ response });
       } catch (error) {
         throw new Error(
           `Failed to run report: ${error instanceof Error ? error.message : String(error)}`,
@@ -128,22 +173,32 @@ export const runReportTool = (env: Env) =>
 
 const FunnelStepSchema = z.object({
   name: z
+
     .string()
+
     .describe("Display name for this funnel step (shown in reports)."),
   filterExpression: z
+
     .record(z.string(), z.unknown())
+
     .describe(
       "Required. Condition that qualifies users for this step. See https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/FunnelStep#FunnelFilterExpression",
     ),
   isDirectlyFollowedBy: z
+
     .boolean()
+
     .optional()
+
     .describe(
       "If true, this step must immediately follow the previous step (no intervening events). Defaults to false.",
     ),
   withinDurationFromPriorStep: z
+
     .string()
+
     .optional()
+
     .describe(
       "Time window within which this step must occur after the prior step, e.g. '3600s' for 1 hour.",
     ),
@@ -156,49 +211,77 @@ export const runFunnelReportTool = (env: Env) =>
       "Runs a Google Analytics 4 funnel report. Analyzes how users progress through a sequence of steps (e.g. landing page → product page → checkout → purchase). Returns per-step completion counts and drop-off rates.",
     inputSchema: z.object({
       property: z
+
         .string()
+
         .describe(
           "GA4 Property identifier — 'properties/1234567' or just '1234567'.",
         ),
       funnelSteps: z
+
         .array(FunnelStepSchema)
+
         .min(2)
+
         .describe(
           "Ordered list of funnel steps. Each step is a GA4 FunnelStep object with a name and filterExpression.",
         ),
       dateRanges: z
+
         .array(DateRangeSchema)
+
         .min(1)
+
         .describe("One or more date ranges to include in the report."),
       funnelBreakdown: z
+
         .record(z.string(), z.unknown())
+
         .optional()
+
         .describe(
           "Optional FunnelBreakdown — adds a sub-dimension to the funnel table rows.",
         ),
       funnelNextAction: z
+
         .record(z.string(), z.unknown())
+
         .optional()
+
         .describe(
           "Optional FunnelNextAction — adds a next-action dimension showing what users do after abandoning a step.",
         ),
       limit: z
+
         .number()
+
         .int()
+
         .positive()
+
         .optional()
+
         .describe("Maximum number of rows to return."),
       offset: z
+
         .number()
+
         .int()
+
         .nonnegative()
+
         .optional()
+
         .describe("Row offset for pagination."),
       returnPropertyQuota: z
+
         .boolean()
+
         .optional()
+
         .describe("If true, includes current GA4 property quota in response."),
     }),
+    outputSchema: RunFunnelReportOutputSchema,
     execute: async ({ context: args }) => {
       const client = GaClient.fromEnv(env);
       try {
@@ -215,7 +298,8 @@ export const runFunnelReportTool = (env: Env) =>
         if (args.returnPropertyQuota !== undefined)
           body.returnPropertyQuota = args.returnPropertyQuota;
         const response = await client.runFunnelReport(args.property, body);
-        return { response };
+
+        return RunFunnelReportOutputSchema.parse({ response });
       } catch (error) {
         throw new Error(
           `Failed to run funnel report: ${error instanceof Error ? error.message : String(error)}`,
@@ -231,13 +315,18 @@ export const runRealtimeReportTool = (env: Env) =>
       "Runs a Google Analytics 4 realtime report. Returns live data from the last 30 minutes.",
     inputSchema: z.object({
       property: z
+
         .string()
+
         .describe(
           "GA4 Property identifier — 'properties/1234567' or just '1234567'.",
         ),
       dimensions: z
+
         .array(DimensionSchema)
+
         .optional()
+
         .describe("Dimensions to group results by."),
       metrics: z.array(MetricSchema).min(1).describe("Metrics to aggregate."),
       dimensionFilter: FilterExpressionSchema.optional().describe(
@@ -247,26 +336,43 @@ export const runRealtimeReportTool = (env: Env) =>
         "Optional filter to restrict metric values.",
       ),
       orderBys: z
+
         .array(OrderBySchema)
+
         .optional()
+
         .describe("Optional ordering for returned rows."),
       limit: z
+
         .number()
+
         .int()
+
         .positive()
+
         .optional()
+
         .describe("Maximum number of rows to return."),
       offset: z
+
         .number()
+
         .int()
+
         .nonnegative()
+
         .optional()
+
         .describe("Row offset for pagination."),
       returnPropertyQuota: z
+
         .boolean()
+
         .optional()
+
         .describe("If true, includes quota state in the response."),
     }),
+    outputSchema: RunRealtimeReportOutputSchema,
     execute: async ({ context: args }) => {
       const client = GaClient.fromEnv(env);
       try {
@@ -285,7 +391,8 @@ export const runRealtimeReportTool = (env: Env) =>
           body.returnPropertyQuota = args.returnPropertyQuota;
         }
         const response = await client.runRealtimeReport(args.property, body);
-        return { response };
+
+        return RunRealtimeReportOutputSchema.parse({ response });
       } catch (error) {
         throw new Error(
           `Failed to run realtime report: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds strict `zod` output schemas for all GA4 tools and validates API responses at the boundary. Outputs are now consistent, typed, and produce clearer errors.

- **Refactors**
  - Introduced `google-analytics/server/lib/schemas.ts` with output schemas for Admin and Data APIs (accounts, properties, custom dimensions/metrics, Google Ads links, annotations, runReport, runRealtimeReport, runFunnelReport, shared types).
  - Updated tools to declare `outputSchema` and parse results before returning (accounts, ads, annotations, properties, reports) using `zod` with `@decocms/runtime/tools`.
  - Preserved output shapes: most tools return `{ response: ... }`; custom dimensions/metrics returns `{ dimensions, metrics }`.
  - Better runtime errors when GA responses don’t match expected types.

<sup>Written for commit 03d36170f499d83ccfa13532bc3f66fce1b623a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

