### PR TITLE
fix(google-calendar-sa): remove Apps Script tool from SA

### DIFF
--- a/google-calendar-sa/server/main.ts
+++ b/google-calendar-sa/server/main.ts
@@ -10,7 +10,6 @@ import {
   loadAllTriggerCredentials,
 } from "google-calendar/supabase";
 import { app as webhookRouter } from "google-calendar/router";
-import { createGetAppsScriptConfigTool } from "google-calendar/tools/apps-script";
 
 import { type Env, StateSchema } from "../shared/deco.gen.ts";
 import { getServiceAccountAccessToken } from "./lib/service-account.ts";
@@ -192,8 +191,6 @@ const runtime = withRuntime<Env, typeof StateSchema, Registry>({
     }),
     // Trigger tools (TRIGGER_CONFIGURE / TRIGGER_UNCONFIGURE) — no SA auth needed
     ...triggers.tools(),
-    // Apps Script setup helper — no SA auth needed
-    createGetAppsScriptConfigTool(env),
   ],
 });
 

--- a/google-calendar-sa/shared/deco.gen.ts
+++ b/google-calendar-sa/shared/deco.gen.ts
@@ -14,16 +14,6 @@ export const StateSchema = z.object({
       "Emails of Google Workspace users to impersonate. Events from all users are merged and deduplicated.",
     ),
   EVENT_BUS: BindingOf("@deco/event-bus").optional(),
-
-  WEBHOOK_URL: z
-    .string()
-    .default(
-      "https://sites-google-calendar-sa.deco.site/calendar/events/{connectionId}",
-    )
-    .readonly()
-    .describe(
-      "Webhook URL the Google Apps Script posts events to. Use get_apps_script_config to get the URL + token for this connection.",
-    ),
 });
 
 export type Env = DefaultEnv<typeof StateSchema, Registry>;


### PR DESCRIPTION
Removes `get_apps_script_config` tool and `WEBHOOK_URL` StateSchema field from the SA app — the SA uses an in-process scheduler, not Google Apps Script.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed leftover Google Apps Script wiring from the Google Calendar SA. Deleted the `get_apps_script_config` tool and the `WEBHOOK_URL` field, since the SA uses an in-process scheduler.

<sup>Written for commit 79cf168110dc148bc098956f617216fe4ca14554. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

