### PR TITLE
fix(google-calendar-sa): skip past events in scheduler

### DIFF
--- a/google-calendar-sa/server/lib/scheduler.ts
+++ b/google-calendar-sa/server/lib/scheduler.ts
@@ -117,7 +117,8 @@ async function scanConnection(conn: CachedConnection): Promise<void> {
       const minutesUntilStart = Math.round(
         (new Date(startTime).getTime() - now.getTime()) / 60000,
       );
-      if (minutesUntilStart > conn.leadMinutes) continue;
+      if (minutesUntilStart < 0 || minutesUntilStart > conn.leadMinutes)
+        continue;
 
       const dedupKey = `${conn.connectionId}:${email}:${event.id}:${startTime}`;
       if (notified.has(dedupKey)) continue;


### PR DESCRIPTION
Events with negative minutesUntilStart were not filtered, causing past meetings to trigger notifications on the first scheduler tick after deploy/restart.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip events that already started in the Google Calendar scheduler to prevent past meetings from triggering notifications on the first tick after deploy/restart.

- **Bug Fixes**
  - Added a guard to ignore events with minutesUntilStart < 0 while keeping the existing leadMinutes window.

<sup>Written for commit 44bcaa99cae29445ab222501393a3669f850bf92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

