### PR TITLE
fix(google-calendar-sa): deduplicate events across impersonated emails

### DIFF
--- a/google-calendar-sa/server/lib/scheduler.ts
+++ b/google-calendar-sa/server/lib/scheduler.ts
@@ -120,7 +120,7 @@ async function scanConnection(conn: CachedConnection): Promise<void> {
       if (minutesUntilStart < 0 || minutesUntilStart > conn.leadMinutes)
         continue;
 
-      const dedupKey = `${conn.connectionId}:${email}:${event.id}:${startTime}`;
+      const dedupKey = `${conn.connectionId}:${event.id}:${startTime}`;
       if (notified.has(dedupKey)) continue;
 
       try {

--- a/google-calendar-sa/server/lib/scheduler.ts
+++ b/google-calendar-sa/server/lib/scheduler.ts
@@ -117,7 +117,8 @@ async function scanConnection(conn: CachedConnection): Promise<void> {
       const minutesUntilStart = Math.round(
         (new Date(startTime).getTime() - now.getTime()) / 60000,
       );
-      if (minutesUntilStart > conn.leadMinutes) continue;
+      if (minutesUntilStart < 0 || minutesUntilStart > conn.leadMinutes)
+        continue;
 
       const dedupKey = `${conn.connectionId}:${email}:${event.id}:${startTime}`;
       if (notified.has(dedupKey)) continue;


### PR DESCRIPTION
Same meeting visible to multiple impersonated emails caused duplicate notifications. Dedup key now excludes email.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate notifications in `google-calendar-sa` when the same meeting appears under multiple impersonated emails, and stops notifying for meetings that already started.

- **Bug Fixes**
  - Deduplicate by `${connectionId}:${eventId}:${startTime}` (removed email) to avoid cross-email duplicates.
  - Skip events with minutesUntilStart < 0; only notify when 0 <= minutesUntilStart <= leadMinutes.

<sup>Written for commit d0c06ca8d049c553c769fad01e418a15192c7798. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

