### PR TITLE
feat(github): add GitHub's official remote MCP to the catalog

### DIFF
--- a/github-official/README.md
+++ b/github-official/README.md
@@ -1,0 +1,9 @@
+# GitHub (Official)
+
+GitHub's official remote MCP server, hosted at `https://api.githubcopilot.com/mcp/`.
+
+This is a catalog entry (app.json only) for the first-party `registry.json` — it
+points at GitHub's hosted endpoint, there is no server to deploy here.
+
+Distinct from the deco-hosted `github` entry (`github-mcp.decocms.com`); this is
+GitHub's own remote MCP, which several orgs install directly.

--- a/github-official/app.json
+++ b/github-official/app.json
@@ -1,0 +1,20 @@
+{
+  "scopeName": "github",
+  "name": "github-mcp-server",
+  "friendlyName": "GitHub (Official)",
+  "connection": {
+    "type": "HTTP",
+    "url": "https://api.githubcopilot.com/mcp/"
+  },
+  "description": "GitHub's official remote MCP server — manage repositories, issues, pull requests, Actions, and code from AI agents.",
+  "icon": "https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png",
+  "unlisted": false,
+  "official": true,
+  "metadata": {
+    "categories": ["Developer Tools"],
+    "official": true,
+    "tags": ["github", "git", "repositories", "issues", "pull-requests", "actions", "code"],
+    "short_description": "GitHub's official remote MCP server for repos, issues, PRs, and Actions",
+    "mesh_description": "GitHub's official remote MCP server. Connect AI agents directly to GitHub to manage repositories, browse and edit code, open and review pull requests, triage issues, and work with GitHub Actions and workflows. Served over GitHub's hosted endpoint (api.githubcopilot.com), it covers the full GitHub developer surface so agents can automate engineering workflows end to end. Ideal for code review, repository management, release automation, and developer productivity."
+  }
+}

--- a/registry.json
+++ b/registry.json
@@ -3549,6 +3549,54 @@
     }
   },
   {
+    "id": "github/github-mcp-server",
+    "title": "GitHub (Official)",
+    "description": "GitHub's official remote MCP server — manage repositories, issues, pull requests, Actions, and code from AI agents.",
+    "is_public": true,
+    "_meta": {
+      "mcp.mesh": {
+        "verified": true,
+        "friendly_name": "GitHub (Official)",
+        "short_description": "GitHub's official remote MCP server for repos, issues, PRs, and Actions",
+        "owner": "github",
+        "has_remote": true,
+        "has_oauth": false,
+        "tags": [
+          "github",
+          "git",
+          "repositories",
+          "issues",
+          "pull-requests",
+          "actions",
+          "code"
+        ],
+        "categories": [
+          "Developer Tools"
+        ],
+        "readme": "GitHub's official remote MCP server. Connect AI agents directly to GitHub to manage repositories, browse and edit code, open and review pull requests, triage issues, and work with GitHub Actions and workflows. Served over GitHub's hosted endpoint (api.githubcopilot.com), it covers the full GitHub developer surface so agents can automate engineering workflows end to end. Ideal for code review, repository management, release automation, and developer productivity."
+      }
+    },
+    "server": {
+      "name": "github-mcp-server",
+      "title": "GitHub (Official)",
+      "description": "GitHub's official remote MCP server — manage repositories, issues, pull requests, Actions, and code from AI agents.",
+      "icons": [
+        {
+          "src": "https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "HTTP",
+          "url": "https://api.githubcopilot.com/mcp/",
+          "name": "github-mcp-server",
+          "title": "GitHub (Official)",
+          "description": "GitHub's official remote MCP server — manage repositories, issues, pull requests, Actions, and code from AI agents."
+        }
+      ]
+    }
+  },
+  {
     "id": "google/google-bigquery-mcp",
     "title": "Google BigQuery",
     "description": "Analyze massive datasets with Google BigQuery serverless data warehouse. Run SQL queries, manage datasets, and perform analytics through natural language.",


### PR DESCRIPTION
## What

Adds **GitHub's official remote MCP server** (`https://api.githubcopilot.com/mcp/`) to the first-party catalog and regenerates `registry.json` (111 → 112 items).

## Why

A sweep of **what users actually installed in prod** (Studio connections) found that `registry.json` already covers virtually every community MCP people use — except GitHub's official remote MCP, which **6+ orgs installed directly** (it's distinct from the deco-hosted `github` entry at `github-mcp.decocms.com`). This adds it so it's discoverable in the store.

## Changes

- `github-official/app.json` (new) — catalog entry pointing at GitHub's hosted endpoint (app.json only, no server to deploy; same pattern as `atlassian-rovo`, `amplitude`, …).
- `github-official/README.md` (new).
- `registry.json` — regenerated (+1 item: `github/github-mcp-server`).

The rest of the prod-install gap was a long tail of 1-org experiments and customer-custom MCPs — intentionally left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add GitHub’s official remote MCP server to the first‑party catalog so users can discover and connect to `https://api.githubcopilot.com/mcp/`. Regenerates `registry.json` to include the new `GitHub (Official)` entry.

- **New Features**
  - Added `github-official/app.json` pointing to `https://api.githubcopilot.com/mcp/` (no server to deploy).
  - Added `github-official/README.md`.
  - Updated `registry.json` with `github/github-mcp-server` (public, official, with icon/tags); distinct from the deco-hosted `github` at `github-mcp.decocms.com`.

<sup>Written for commit cb8a65f16bcc703988e9cac67cd748bf671347b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

