### PR TITLE
feat(google-analytics, google-search-console): configurable default property fallback

### DIFF
--- a/google-analytics/server/lib/env.ts
+++ b/google-analytics/server/lib/env.ts
@@ -9,3 +9,19 @@ export const getGoogleAccessToken = (env: Env): string => {
   }
   return authorization.replace(/^Bearer\s+/i, "");
 };
+
+/**
+ * Resolves the GA4 property to use for a request.
+ *
+ * Prefers the `property` passed to the tool; when omitted, falls back to the
+ * `propertyId` configured on the MCP installation state.
+ */
+export const resolveProperty = (env: Env, property?: string | null): string => {
+  const resolved = property ?? env.MESH_REQUEST_CONTEXT?.state?.propertyId;
+  if (!resolved) {
+    throw new Error(
+      "No GA4 property provided. Pass a `property` argument or configure a default `propertyId` in this integration's settings.",
+    );
+  }
+  return resolved;
+};

--- a/google-analytics/server/main.ts
+++ b/google-analytics/server/main.ts
@@ -4,11 +4,14 @@ import { createGoogleOAuth } from "@decocms/mcps-shared/google-oauth";
 
 import { tools } from "./tools/index.ts";
 import { GOOGLE_SCOPES } from "./constants.ts";
-import type { Env } from "../shared/deco.gen.ts";
+import { type Env, StateSchema } from "../shared/deco.gen.ts";
 
 export type { Env };
 
-const runtime = withRuntime<Env>({
+const runtime = withRuntime<Env, typeof StateSchema>({
+  configuration: {
+    state: StateSchema,
+  },
   tools: (env: Env) => tools.map((createTool) => createTool(env)),
   oauth: createGoogleOAuth({
     scopes: [GOOGLE_SCOPES.ANALYTICS_READONLY],

--- a/google-analytics/server/tools/ads.ts
+++ b/google-analytics/server/tools/ads.ts
@@ -2,14 +2,17 @@ import { z } from "zod";
 import { createPrivateTool } from "@decocms/runtime/tools";
 import type { Env } from "../../shared/deco.gen.ts";
 import { GaClient } from "../lib/ga-client.ts";
+import { resolveProperty } from "../lib/env.ts";
 import { GoogleAdsLinksResponseSchema } from "../lib/schemas.ts";
 
 const propertySchema = z
 
   .string()
 
+  .optional()
+
   .describe(
-    "GA4 Property identifier — 'properties/1234567' or just '1234567'.",
+    "GA4 Property identifier — 'properties/1234567' or just '1234567'. Falls back to the default propertyId configured for this integration when omitted.",
   );
 
 export const listGoogleAdsLinksTool = (env: Env) =>
@@ -22,7 +25,9 @@ export const listGoogleAdsLinksTool = (env: Env) =>
     execute: async ({ context: args }) => {
       const client = GaClient.fromEnv(env);
       try {
-        const result = await client.listGoogleAdsLinks(args.property);
+        const result = await client.listGoogleAdsLinks(
+          resolveProperty(env, args.property),
+        );
         return GoogleAdsLinksResponseSchema.parse({ response: result });
       } catch (error) {
         throw new Error(

--- a/google-analytics/server/tools/annotations.ts
+++ b/google-analytics/server/tools/annotations.ts
@@ -2,14 +2,17 @@ import { z } from "zod";
 import { createPrivateTool } from "@decocms/runtime/tools";
 import type { Env } from "../../shared/deco.gen.ts";
 import { GaClient } from "../lib/ga-client.ts";
+import { resolveProperty } from "../lib/env.ts";
 import { PropertyAnnotationsResponseSchema } from "../lib/schemas.ts";
 
 const propertySchema = z
 
   .string()
 
+  .optional()
+
   .describe(
-    "GA4 Property identifier — 'properties/1234567' or just '1234567'.",
+    "GA4 Property identifier — 'properties/1234567' or just '1234567'. Falls back to the default propertyId configured for this integration when omitted.",
   );
 
 export const listPropertyAnnotationsTool = (env: Env) =>
@@ -22,7 +25,9 @@ export const listPropertyAnnotationsTool = (env: Env) =>
     execute: async ({ context: args }) => {
       const client = GaClient.fromEnv(env);
       try {
-        const result = await client.listPropertyAnnotations(args.property);
+        const result = await client.listPropertyAnnotations(
+          resolveProperty(env, args.property),
+        );
         return PropertyAnnotationsResponseSchema.parse({ response: result });
       } catch (error) {
         throw new Error(

--- a/google-analytics/server/tools/properties.ts
+++ b/google-analytics/server/tools/properties.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { createPrivateTool } from "@decocms/runtime/tools";
 import type { Env } from "../../shared/deco.gen.ts";
 import { GaClient } from "../lib/ga-client.ts";
+import { resolveProperty } from "../lib/env.ts";
 import {
   PropertyResponseSchema,
   CustomDimensionsAndMetricsResponseSchema,
@@ -11,8 +12,10 @@ const propertySchema = z
 
   .string()
 
+  .optional()
+
   .describe(
-    "GA4 Property identifier — 'properties/1234567' or just '1234567'.",
+    "GA4 Property identifier — 'properties/1234567' or just '1234567'. Falls back to the default propertyId configured for this integration when omitted.",
   );
 
 export const getPropertyDetailsTool = (env: Env) =>
@@ -25,7 +28,9 @@ export const getPropertyDetailsTool = (env: Env) =>
     execute: async ({ context: args }) => {
       const client = GaClient.fromEnv(env);
       try {
-        const result = await client.getProperty(args.property);
+        const result = await client.getProperty(
+          resolveProperty(env, args.property),
+        );
         return PropertyResponseSchema.parse({ response: result });
       } catch (error) {
         throw new Error(
@@ -45,10 +50,11 @@ export const getCustomDimensionsAndMetricsTool = (env: Env) =>
     execute: async ({ context: args }) => {
       const client = GaClient.fromEnv(env);
       try {
+        const property = resolveProperty(env, args.property);
         // Both calls are independent — run in parallel to halve latency.
         const [dimensions, metrics] = await Promise.all([
-          client.listCustomDimensions(args.property),
-          client.listCustomMetrics(args.property),
+          client.listCustomDimensions(property),
+          client.listCustomMetrics(property),
         ]);
 
         return CustomDimensionsAndMetricsResponseSchema.parse({

--- a/google-analytics/server/tools/reports.ts
+++ b/google-analytics/server/tools/reports.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { createPrivateTool } from "@decocms/runtime/tools";
 import type { Env } from "../../shared/deco.gen.ts";
 import { GaClient } from "../lib/ga-client.ts";
+import { resolveProperty } from "../lib/env.ts";
 import {
   RunReportOutputSchema,
   RunFunnelReportOutputSchema,
@@ -55,8 +56,10 @@ export const runReportTool = (env: Env) =>
 
         .string()
 
+        .optional()
+
         .describe(
-          "GA4 Property identifier — 'properties/1234567' or just '1234567'.",
+          "GA4 Property identifier — 'properties/1234567' or just '1234567'. Falls back to the default propertyId configured for this integration when omitted.",
         ),
       dateRanges: z
 
@@ -160,7 +163,10 @@ export const runReportTool = (env: Env) =>
         if (args.returnPropertyQuota !== undefined) {
           body.returnPropertyQuota = args.returnPropertyQuota;
         }
-        const response = await client.runReport(args.property, body);
+        const response = await client.runReport(
+          resolveProperty(env, args.property),
+          body,
+        );
 
         return RunReportOutputSchema.parse({ response });
       } catch (error) {
@@ -214,8 +220,10 @@ export const runFunnelReportTool = (env: Env) =>
 
         .string()
 
+        .optional()
+
         .describe(
-          "GA4 Property identifier — 'properties/1234567' or just '1234567'.",
+          "GA4 Property identifier — 'properties/1234567' or just '1234567'. Falls back to the default propertyId configured for this integration when omitted.",
         ),
       funnelSteps: z
 
@@ -297,7 +305,10 @@ export const runFunnelReportTool = (env: Env) =>
         if (args.offset !== undefined) body.offset = args.offset;
         if (args.returnPropertyQuota !== undefined)
           body.returnPropertyQuota = args.returnPropertyQuota;
-        const response = await client.runFunnelReport(args.property, body);
+        const response = await client.runFunnelReport(
+          resolveProperty(env, args.property),
+          body,
+        );
 
         return RunFunnelReportOutputSchema.parse({ response });
       } catch (error) {
@@ -318,8 +329,10 @@ export const runRealtimeReportTool = (env: Env) =>
 
         .string()
 
+        .optional()
+
         .describe(
-          "GA4 Property identifier — 'properties/1234567' or just '1234567'.",
+          "GA4 Property identifier — 'properties/1234567' or just '1234567'. Falls back to the default propertyId configured for this integration when omitted.",
         ),
       dimensions: z
 
@@ -390,7 +403,10 @@ export const runRealtimeReportTool = (env: Env) =>
         if (args.returnPropertyQuota !== undefined) {
           body.returnPropertyQuota = args.returnPropertyQuota;
         }
-        const response = await client.runRealtimeReport(args.property, body);
+        const response = await client.runRealtimeReport(
+          resolveProperty(env, args.property),
+          body,
+        );
 
         return RunRealtimeReportOutputSchema.parse({ response });
       } catch (error) {

--- a/google-analytics/shared/deco.gen.ts
+++ b/google-analytics/shared/deco.gen.ts
@@ -1,8 +1,17 @@
 import { z } from "zod";
 
+export const StateSchema = z.object({
+  propertyId: z
+    .string()
+    .nullish()
+    .describe(
+      "Default GA4 Property identifier — 'properties/1234567' or just '1234567'. Used as a fallback for tools when their `property` argument is omitted.",
+    ),
+});
+
 export interface MeshRequestContext {
   authorization?: string;
-  state?: string;
+  state?: z.infer<typeof StateSchema>;
   token?: string;
   meshUrl?: string;
   connectionId?: string;
@@ -16,5 +25,3 @@ export interface Env {
   SELF?: unknown;
   IS_LOCAL?: boolean;
 }
-
-export const StateSchema = z.object({});

--- a/google-search-console/server/lib/env.ts
+++ b/google-search-console/server/lib/env.ts
@@ -15,3 +15,24 @@ export const getGoogleAccessToken = (env: Env): string => {
   }
   return authorization.replace(/^Bearer\s+/i, "");
 };
+
+/**
+ * Resolves the site URL to use for a request.
+ *
+ * Prefers the `siteUrl` passed to the tool; when omitted, falls back to the
+ * default `siteUrl` configured on the MCP installation state.
+ *
+ * @param env - The environment containing the mesh request context
+ * @param siteUrl - The site URL passed to the tool, if any
+ * @returns The resolved site URL
+ * @throws Error if neither a passed nor a configured site URL is available
+ */
+export const resolveSiteUrl = (env: Env, siteUrl?: string | null): string => {
+  const resolved = siteUrl ?? env.MESH_REQUEST_CONTEXT?.state?.siteUrl;
+  if (!resolved) {
+    throw new Error(
+      "No site URL provided. Pass a `siteUrl` argument or configure a default `siteUrl` in this integration's settings.",
+    );
+  }
+  return resolved;
+};

--- a/google-search-console/server/lib/search-console-client.ts
+++ b/google-search-console/server/lib/search-console-client.ts
@@ -157,3 +157,4 @@ export class SearchConsoleClient {
 
 // Re-export getGoogleAccessToken from env.ts for convenience
 export { getGoogleAccessToken as getAccessToken } from "./env.ts";
+export { resolveSiteUrl } from "./env.ts";

--- a/google-search-console/server/main.ts
+++ b/google-search-console/server/main.ts
@@ -10,7 +10,7 @@ import { createGoogleOAuth } from "@decocms/mcps-shared/google-oauth";
 
 import { tools } from "./tools/index.ts";
 import { GOOGLE_SCOPES } from "./constants.ts";
-import type { Env } from "../shared/deco.gen.ts";
+import { type Env, StateSchema } from "../shared/deco.gen.ts";
 
 export type { Env };
 
@@ -21,7 +21,10 @@ export type { Env };
  * - OAuth configuration for Google Search Console
  * - Tools (from ./tools/index.ts)
  */
-const runtime = withRuntime<Env>({
+const runtime = withRuntime<Env, typeof StateSchema>({
+  configuration: {
+    state: StateSchema,
+  },
   tools: (env: Env) => tools.map((createTool) => createTool(env)),
   oauth: createGoogleOAuth({
     scopes: [GOOGLE_SCOPES.WEBMASTERS],

--- a/google-search-console/server/tools/search-analytics.ts
+++ b/google-search-console/server/tools/search-analytics.ts
@@ -10,6 +10,7 @@ import type { Env } from "../main.ts";
 import {
   SearchConsoleClient,
   getAccessToken,
+  resolveSiteUrl,
 } from "../lib/search-console-client.ts";
 import {
   SEARCH_ANALYTICS_DIMENSIONS,
@@ -41,8 +42,9 @@ export const createQuerySearchAnalyticsTool = (env: Env) =>
     inputSchema: z.object({
       siteUrl: z
         .string()
+        .optional()
         .describe(
-          "Site URL (e.g., 'sc-domain:example.com' or 'https://example.com/')",
+          "Site URL (e.g., 'sc-domain:example.com' or 'https://example.com/'). Falls back to the default siteUrl configured for this integration when omitted.",
         ),
       startDate: z
         .string()
@@ -153,7 +155,7 @@ export const createQuerySearchAnalyticsTool = (env: Env) =>
       };
 
       const response = await client.querySearchAnalytics(
-        context.siteUrl,
+        resolveSiteUrl(env, context.siteUrl),
         request,
       );
 

--- a/google-search-console/server/tools/sitemaps.ts
+++ b/google-search-console/server/tools/sitemaps.ts
@@ -10,6 +10,7 @@ import type { Env } from "../main.ts";
 import {
   SearchConsoleClient,
   getAccessToken,
+  resolveSiteUrl,
 } from "../lib/search-console-client.ts";
 
 // ============================================================================
@@ -49,8 +50,9 @@ export const createListSitemapsTool = (env: Env) =>
     inputSchema: z.object({
       siteUrl: z
         .string()
+        .optional()
         .describe(
-          "Site URL (e.g., 'sc-domain:example.com' or 'https://example.com/')",
+          "Site URL (e.g., 'sc-domain:example.com' or 'https://example.com/'). Falls back to the default siteUrl configured for this integration when omitted.",
         ),
     }),
     outputSchema: z.object({
@@ -61,7 +63,9 @@ export const createListSitemapsTool = (env: Env) =>
         accessToken: getAccessToken(env),
       });
 
-      const response = await client.listSitemaps(context.siteUrl);
+      const response = await client.listSitemaps(
+        resolveSiteUrl(env, context.siteUrl),
+      );
       const sitemaps = response.sitemap || [];
 
       return {
@@ -93,8 +97,9 @@ export const createGetSitemapTool = (env: Env) =>
     inputSchema: z.object({
       siteUrl: z
         .string()
+        .optional()
         .describe(
-          "Site URL (e.g., 'sc-domain:example.com' or 'https://example.com/')",
+          "Site URL (e.g., 'sc-domain:example.com' or 'https://example.com/'). Falls back to the default siteUrl configured for this integration when omitted.",
         ),
       feedpath: z.string().describe("Sitemap feedpath/URL"),
     }),
@@ -107,7 +112,7 @@ export const createGetSitemapTool = (env: Env) =>
       });
 
       const sitemap = await client.getSitemap(
-        context.siteUrl,
+        resolveSiteUrl(env, context.siteUrl),
         context.feedpath,
       );
 
@@ -140,8 +145,9 @@ export const createSubmitSitemapTool = (env: Env) =>
     inputSchema: z.object({
       siteUrl: z
         .string()
+        .optional()
         .describe(
-          "Site URL (e.g., 'sc-domain:example.com' or 'https://example.com/')",
+          "Site URL (e.g., 'sc-domain:example.com' or 'https://example.com/'). Falls back to the default siteUrl configured for this integration when omitted.",
         ),
       feedpath: z.string().describe("Sitemap feedpath/URL to submit"),
     }),
@@ -157,11 +163,12 @@ export const createSubmitSitemapTool = (env: Env) =>
         accessToken: getAccessToken(env),
       });
 
-      await client.submitSitemap(context.siteUrl, context.feedpath);
+      const siteUrl = resolveSiteUrl(env, context.siteUrl);
+      await client.submitSitemap(siteUrl, context.feedpath);
 
       return {
         success: true,
-        siteUrl: context.siteUrl,
+        siteUrl,
         feedpath: context.feedpath,
       };
     },
@@ -178,8 +185,9 @@ export const createDeleteSitemapTool = (env: Env) =>
     inputSchema: z.object({
       siteUrl: z
         .string()
+        .optional()
         .describe(
-          "Site URL (e.g., 'sc-domain:example.com' or 'https://example.com/')",
+          "Site URL (e.g., 'sc-domain:example.com' or 'https://example.com/'). Falls back to the default siteUrl configured for this integration when omitted.",
         ),
       feedpath: z.string().describe("Sitemap feedpath/URL to delete"),
     }),
@@ -195,11 +203,12 @@ export const createDeleteSitemapTool = (env: Env) =>
         accessToken: getAccessToken(env),
       });
 
-      await client.deleteSitemap(context.siteUrl, context.feedpath);
+      const siteUrl = resolveSiteUrl(env, context.siteUrl);
+      await client.deleteSitemap(siteUrl, context.feedpath);
 
       return {
         success: true,
-        siteUrl: context.siteUrl,
+        siteUrl,
         feedpath: context.feedpath,
       };
     },

--- a/google-search-console/server/tools/sites.ts
+++ b/google-search-console/server/tools/sites.ts
@@ -10,6 +10,7 @@ import type { Env } from "../main.ts";
 import {
   SearchConsoleClient,
   getAccessToken,
+  resolveSiteUrl,
 } from "../lib/search-console-client.ts";
 
 // ============================================================================
@@ -69,8 +70,9 @@ export const createGetSiteTool = (env: Env) =>
     inputSchema: z.object({
       siteUrl: z
         .string()
+        .optional()
         .describe(
-          "Site URL (e.g., 'sc-domain:example.com' or 'https://example.com/')",
+          "Site URL (e.g., 'sc-domain:example.com' or 'https://example.com/'). Falls back to the default siteUrl configured for this integration when omitted.",
         ),
     }),
     outputSchema: z.object({
@@ -81,7 +83,7 @@ export const createGetSiteTool = (env: Env) =>
         accessToken: getAccessToken(env),
       });
 
-      const site = await client.getSite(context.siteUrl);
+      const site = await client.getSite(resolveSiteUrl(env, context.siteUrl));
 
       return {
         site: {
@@ -103,8 +105,9 @@ export const createAddSiteTool = (env: Env) =>
     inputSchema: z.object({
       siteUrl: z
         .string()
+        .optional()
         .describe(
-          "Site URL to add (e.g., 'sc-domain:example.com' or 'https://example.com/')",
+          "Site URL to add (e.g., 'sc-domain:example.com' or 'https://example.com/'). Falls back to the default siteUrl configured for this integration when omitted.",
         ),
     }),
     outputSchema: z.object({
@@ -116,11 +119,12 @@ export const createAddSiteTool = (env: Env) =>
         accessToken: getAccessToken(env),
       });
 
-      await client.addSite(context.siteUrl);
+      const siteUrl = resolveSiteUrl(env, context.siteUrl);
+      await client.addSite(siteUrl);
 
       return {
         success: true,
-        siteUrl: context.siteUrl,
+        siteUrl,
       };
     },
   });
@@ -136,8 +140,9 @@ export const createRemoveSiteTool = (env: Env) =>
     inputSchema: z.object({
       siteUrl: z
         .string()
+        .optional()
         .describe(
-          "Site URL to remove (e.g., 'sc-domain:example.com' or 'https://example.com/')",
+          "Site URL to remove (e.g., 'sc-domain:example.com' or 'https://example.com/'). Falls back to the default siteUrl configured for this integration when omitted.",
         ),
     }),
     outputSchema: z.object({
@@ -151,11 +156,12 @@ export const createRemoveSiteTool = (env: Env) =>
         accessToken: getAccessToken(env),
       });
 
-      await client.removeSite(context.siteUrl);
+      const siteUrl = resolveSiteUrl(env, context.siteUrl);
+      await client.removeSite(siteUrl);
 
       return {
         success: true,
-        siteUrl: context.siteUrl,
+        siteUrl,
       };
     },
   });

--- a/google-search-console/server/tools/url-inspection.ts
+++ b/google-search-console/server/tools/url-inspection.ts
@@ -10,6 +10,7 @@ import type { Env } from "../main.ts";
 import {
   SearchConsoleClient,
   getAccessToken,
+  resolveSiteUrl,
 } from "../lib/search-console-client.ts";
 
 // ============================================================================
@@ -145,8 +146,9 @@ export const createInspectUrlTool = (env: Env) =>
     inputSchema: z.object({
       siteUrl: z
         .string()
+        .optional()
         .describe(
-          "Site URL (e.g., 'sc-domain:example.com' or 'https://example.com/')",
+          "Site URL (e.g., 'sc-domain:example.com' or 'https://example.com/'). Falls back to the default siteUrl configured for this integration when omitted.",
         ),
       inspectionUrl: z.string().url().describe("URL to inspect (full URL)"),
       languageCode: z
@@ -163,7 +165,7 @@ export const createInspectUrlTool = (env: Env) =>
       });
 
       const result = await client.inspectUrl({
-        siteUrl: context.siteUrl,
+        siteUrl: resolveSiteUrl(env, context.siteUrl),
         inspectionUrl: context.inspectionUrl,
         languageCode: context.languageCode,
       });

--- a/google-search-console/shared/deco.gen.ts
+++ b/google-search-console/shared/deco.gen.ts
@@ -1,8 +1,17 @@
 import { z } from "zod";
 
+export const StateSchema = z.object({
+  siteUrl: z
+    .string()
+    .nullish()
+    .describe(
+      "Default site URL (e.g., 'sc-domain:example.com' or 'https://example.com/'). Used as a fallback for tools when their `siteUrl` argument is omitted.",
+    ),
+});
+
 export interface MeshRequestContext {
   authorization?: string;
-  state?: string;
+  state?: z.infer<typeof StateSchema>;
   token?: string;
   meshUrl?: string;
   connectionId?: string;
@@ -16,5 +25,3 @@ export interface Env {
   SELF?: unknown;
   IS_LOCAL?: boolean;
 }
-
-export const StateSchema = z.object({});


### PR DESCRIPTION
## What

Extend `configuration.state` (the Zod schema passed to `withRuntime`) with an optional default identifier that the MCP's tools fall back to when their per-call identifier is omitted.

- **google-analytics** — new state field `propertyId: z.string().nullish()`. The `property` argument on every property-scoped tool (`run-report`, `run-funnel-report`, `run-realtime-report`, `get-property-details`, `get-custom-dimensions-and-metrics`, `list-property-annotations`, `list-google-ads-links`) is now optional and resolves to the configured default when not provided.
- **google-search-console** — new state field `siteUrl: z.string().nullish()` (Search Console's "property" is the site). The `siteUrl` argument on every site-scoped tool (`get_site`, `add_site`, `remove_site`, `list_sitemaps`, `get_sitemap`, `submit_sitemap`, `delete_sitemap`, `inspect_url`, search analytics query) is now optional and resolves to the configured default when not provided.

## How

Adds `resolveProperty(env, property)` / `resolveSiteUrl(env, siteUrl)` helpers that prefer the value passed to the tool, fall back to `MESH_REQUEST_CONTEXT.state`, and throw a clear error when neither is available. The state schema is wired via `configuration: { state: StateSchema }` and typed through `deco.gen.ts`.

## Note

The GSC fallback is applied uniformly, including the mutating tools (`add_site`, `remove_site`, `submit_sitemap`, `delete_sitemap`) — calling them without an explicit `siteUrl` targets the configured default. Happy to keep those required instead if preferred.

## Verification

- `tsc --noEmit` clean on both packages (pre-existing zod v3/v4 mismatch inside `@decocms/runtime` is untouched).
- `bun run build` succeeds for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable default identifiers for `google-analytics` and `google-search-console` so tools can omit per-call IDs. Tools now fall back to a default `propertyId` or `siteUrl` from runtime state and throw a clear error if none is set.

- **New Features**
  - `google-analytics`: `configuration.state.propertyId`; all property-scoped tools accept optional `property` and use the default when omitted.
  - `google-search-console`: `configuration.state.siteUrl`; all site-scoped tools accept optional `siteUrl` and use the default when omitted (including mutating tools).
  - Runtime wiring via `StateSchema` and `withRuntime` configuration; added `resolveProperty`/`resolveSiteUrl` helpers for consistent fallback and errors.

- **Migration**
  - Optionally set a default `propertyId`/`siteUrl` in integration settings.
  - If a call omits `property`/`siteUrl` and no default is configured, the tool returns a clear error.

<sup>Written for commit 7c3ca98a92df9bc9f82b1ceb1ada88ff2f64ff34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

