### PR TITLE
feat(vtex): always request _stats on VTEX_LIST_ORDERS

### DIFF
--- a/vtex/server/lib/tool-adapter.ts
+++ b/vtex/server/lib/tool-adapter.ts
@@ -282,6 +282,12 @@ export interface ToolFromOperationConfig {
   ) => Promise<SdkResult>;
   /** Optional factory to create the HTTP client. Defaults to createVtexClient. */
   clientFactory?: (credentials: VTEXCredentials) => Client;
+  /**
+   * Query params always sent to the SDK, merged as a base under the caller's
+   * input (caller values win). Use for operation-level constants that aren't
+   * worth exposing as tool inputs — e.g. `_stats: "1"` on List Orders.
+   */
+  defaultQuery?: Record<string, unknown>;
 }
 
 /**
@@ -315,6 +321,9 @@ export function createToolFromOperation(config: ToolFromOperationConfig) {
           context as Record<string, unknown>,
           config.requestSchema,
         );
+        if (config.defaultQuery) {
+          structured.query = { ...config.defaultQuery, ...structured.query };
+        }
         const result = await withRetry(() =>
           config.sdkFn({ client, ...structured } as any),
         );

--- a/vtex/server/tools/registry.test.ts
+++ b/vtex/server/tools/registry.test.ts
@@ -1094,6 +1094,31 @@ describe("VTEX_LIST_ORDERS", () => {
     );
   });
 
+  test("defaultQuery: merged into query with caller values taking precedence", async () => {
+    const fixture = { list: [], paging: { total: 0 } };
+    const sdkFn = mock(() => Promise.resolve({ data: fixture }));
+
+    const tool = createToolFromOperation({
+      id: "VTEX_LIST_ORDERS",
+      description: "List orders with optional filters.",
+      annotations: { readOnlyHint: true },
+      requestSchema: ordersZod.zListOrdersData,
+      sdkFn: sdkFn as any,
+      defaultQuery: { _stats: "1", per_page: 1 },
+    })(mockEnv);
+
+    await tool.execute({
+      runtimeContext: mockRuntimeContext,
+      context: { page: 2, per_page: 15 },
+    });
+
+    expect(sdkFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: { _stats: "1", page: 2, per_page: 15 },
+      }),
+    );
+  });
+
   test("error path: throws when sdkFn returns error", async () => {
     const sdkFn = mock(() =>
       Promise.resolve({

--- a/vtex/server/tools/registry.ts
+++ b/vtex/server/tools/registry.ts
@@ -285,6 +285,8 @@ export const orderTools = [
     annotations: { readOnlyHint: true },
     requestSchema: ordersZod.zListOrdersData,
     sdkFn: ordersSdk.listOrders as any,
+    // Always request aggregated stats (totalValue Sum, etc.) alongside the page.
+    defaultQuery: { _stats: "1" },
   }),
   createToolFromOperation({
     id: "VTEX_CANCEL_ORDER",


### PR DESCRIPTION
## What

Makes `VTEX_LIST_ORDERS` always send `_stats=1` to the VTEX OMS List Orders endpoint, so the aggregated `stats` block (order count, `totalValue.Sum`, etc.) is returned alongside the page — without exposing `_stats` as a tool input or editing any generated file.

## Why

`_stats=1` is a native VTEX OMS param that returns aggregated metrics for the filtered order set. Today it's only used internally by `fetchRangeStats` (sales cards / hourly buckets) via a hand-built `fetch`. The generic `VTEX_LIST_ORDERS` tool goes through the generated SDK, whose OpenAPI schema (`zListOrdersData`) doesn't include `_stats`, so callers never got the aggregates.

## How

Added an optional `defaultQuery` seam to the tool adapter (`createToolFromOperation`). Query params in `defaultQuery` are merged as a **base** under the caller's input (caller values win), then passed to the SDK — which forwards the whole `query` object to the fetch client. This keeps generated files untouched (survives regeneration) and doesn't pollute the tool's input schema.

```ts
// registry.ts
createToolFromOperation({
  id: "VTEX_LIST_ORDERS",
  ...
  defaultQuery: { _stats: "1" },
})
```

The seam is generic and reusable for any operation-level constant query param.

## Notes

- The tool returns raw VTEX `data`, so the `stats` block now appears in the output but isn't yet extracted/formatted into a summary. Follow-up if we want a clean count + sum in the tool result.

## Test plan

- New test in `registry.test.ts` asserts `defaultQuery` is merged and caller values take precedence.
- Full vtex suite: 51/51 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always request VTEX OMS aggregated stats when listing orders. Adds a `defaultQuery` seam and uses `_stats=1` on `VTEX_LIST_ORDERS` so responses include the `stats` block (counts and totals).

- **New Features**
  - Added `defaultQuery` to `createToolFromOperation` to inject constant query params; merged under caller input (caller values win).
  - Applied `defaultQuery: { _stats: "1" }` to `VTEX_LIST_ORDERS`; added a test to verify merge and precedence.

<sup>Written for commit c9f1e32e61c9538b83ea4edf105ad3e894094791. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

