### PR TITLE
fix(vtex): update VTEX app icon URL

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -3195,7 +3195,7 @@
       "description": "MCP for interacting with VTEX Commerce APIs - Catalog, Orders, and Logistics/Inventory.",
       "icons": [
         {
-          "src": "https://assets.decocache.com/decocms/d08dbe46-1ce2-4e3a-a99b-d2d0e7de7e61/vtex-logo.png"
+          "src": "https://decoims.com/decocms/f17166ef-59c9-4691-975b-c46461b3a782/vtex.png"
         }
       ],
       "remotes": [

--- a/vtex/app.json
+++ b/vtex/app.json
@@ -29,7 +29,7 @@
     }
   },
   "description": "MCP for interacting with VTEX Commerce APIs - Catalog, Orders, and Logistics/Inventory.",
-  "icon": "https://assets.decocache.com/decocms/d08dbe46-1ce2-4e3a-a99b-d2d0e7de7e61/vtex-logo.png",
+  "icon": "https://decoims.com/decocms/f17166ef-59c9-4691-975b-c46461b3a782/vtex.png",
   "unlisted": false,
   "metadata": {
     "categories": ["E-commerce", "Developer Tools"],


### PR DESCRIPTION
## Summary
- Update the VTEX app icon URL in `vtex/app.json` and `registry.json` to the new asset.

## Test plan
- [x] Verified icon URL is consistent across both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the VTEX app icon to a new asset URL so the icon renders correctly across the app and registry. Replaced the icon in `vtex/app.json` and `registry.json` with https://decoims.com/decocms/f17166ef-59c9-4691-975b-c46461b3a782/vtex.png.

<sup>Written for commit 70c421ff75260e59a3820b8dc127580b8f85fb23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

