### PR TITLE
feat(magento): Magento 2 MCP with sales dashboard widgets

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -619,6 +619,38 @@
         "typescript": "^5.7.2",
       },
     },
+    "magento": {
+      "name": "magento",
+      "version": "1.0.0",
+      "dependencies": {
+        "@decocms/runtime": "^1.6.2",
+        "@modelcontextprotocol/ext-apps": "^1.1.2",
+        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@tailwindcss/vite": "^4.2.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.576.0",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "recharts": "2.15.4",
+        "tailwind-merge": "^3.5.0",
+        "tailwindcss": "^4.2.1",
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260206.0",
+        "@decocms/mcps-shared": "1.0.0",
+        "@types/bun": "^1.2.14",
+        "@types/react": "^19.2.2",
+        "@types/react-dom": "^19.2.2",
+        "@vitejs/plugin-react": "^5.0.4",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "concurrently": "^9.2.1",
+        "deco-cli": "^0.28.0",
+        "typescript": "^5.7.2",
+        "vite": "^7.3.1",
+        "vite-plugin-singlefile": "^2.3.0",
+      },
+    },
     "mcp-studio": {
       "name": "mcp-studio",
       "version": "1.0.0",
@@ -3080,6 +3112,8 @@
 
     "lucide-react": ["lucide-react@0.576.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-koNxU14BXrxUfZQ9cUaP0ES1uyPZKYDjk31FQZB6dQ/x+tXk979sVAn9ppZ/pVeJJyOxVM8j1E+8QEuSc02Vug=="],
 
+    "magento": ["magento@workspace:magento"],
+
     "magic-bytes.js": ["magic-bytes.js@1.13.0", "", {}, "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
@@ -4280,6 +4314,14 @@
 
     "log-symbols/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "magento/@decocms/runtime": ["@decocms/runtime@1.6.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.10", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.29.0", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-r6O4z+ISJpBnhDw4x1K8IYNqfQ+xdwSjNcg6vDqU42I6x82H8snfAg/E6u9WfcMClap7sXxMAdKuDcEMxPq55A=="],
+
+    "magento/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "magento/vite": ["vite@7.3.5", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww=="],
+
+    "magento/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
     "mcp-studio/@decocms/bindings": ["@decocms/bindings@1.4.9", "", { "dependencies": { "@decocms/mcp-utils": "^1.0.5", "@modelcontextprotocol/sdk": "1.29.0", "@tanstack/react-router": "1.169.2", "react": "^19.2.6", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-NvhuHsKL0YpSUaAZqEe0PAzF41/JJSi+H0X7HpMBScOVpALcGqAC+DaJvcKeo3aRXXW7z6du0oCdkhLf2A6Vjw=="],
 
     "mcp-studio/@decocms/runtime": ["@decocms/runtime@1.2.8", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.3", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-AG0nqc7ofe7oGeqQpqoqsmSo2t9bZ+xEVnhHDXKQqwmGgXHwRhfVTzROqUq0rasTGnrnTKKSRVLgsHWUgfCaxA=="],
@@ -4876,6 +4918,12 @@
 
     "log-symbols/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "magento/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.4.9", "", { "dependencies": { "@decocms/mcp-utils": "^1.0.5", "@modelcontextprotocol/sdk": "1.29.0", "@tanstack/react-router": "1.169.2", "react": "^19.2.6", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-NvhuHsKL0YpSUaAZqEe0PAzF41/JJSi+H0X7HpMBScOVpALcGqAC+DaJvcKeo3aRXXW7z6du0oCdkhLf2A6Vjw=="],
+
+    "magento/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
+
+    "magento/vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
     "mcp-studio/@decocms/bindings/@tanstack/react-router": ["@tanstack/react-router@1.169.2", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.169.2", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-OJM7Kguc7ERnweaNRWsyWgIKcl3z23rD1B4jaxjzd9RGdnzpt2HfrWa9rggbT0Hfzhfo4D2ZmsfoTme035tniQ=="],
 
     "mcp-studio/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.3", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ=="],
@@ -5437,6 +5485,60 @@
     "inquirer-search-list/inquirer/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@2.0.0", "", {}, "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w=="],
 
     "inquirer-search-list/inquirer/strip-ansi/ansi-regex": ["ansi-regex@3.0.1", "", {}, "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="],
+
+    "magento/@decocms/runtime/@decocms/bindings/@tanstack/react-router": ["@tanstack/react-router@1.169.2", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.169.2", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-OJM7Kguc7ERnweaNRWsyWgIKcl3z23rD1B4jaxjzd9RGdnzpt2HfrWa9rggbT0Hfzhfo4D2ZmsfoTme035tniQ=="],
+
+    "magento/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "magento/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "magento/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "magento/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "magento/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "magento/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "magento/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "magento/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "magento/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "magento/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "magento/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "magento/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "magento/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "magento/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "magento/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "magento/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "magento/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "magento/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "magento/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "magento/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "magento/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "magento/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "magento/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "magento/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "magento/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "magento/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
     "mcp-studio/@decocms/bindings/@tanstack/react-router/@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
 
@@ -6071,6 +6173,10 @@
     "inquirer-search-list/inquirer/cli-cursor/restore-cursor/onetime": ["onetime@2.0.1", "", { "dependencies": { "mimic-fn": "^1.0.0" } }, "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ=="],
 
     "inquirer-search-list/inquirer/cli-cursor/restore-cursor/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "magento/@decocms/runtime/@decocms/bindings/@tanstack/react-router/@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
+
+    "magento/@decocms/runtime/@decocms/bindings/@tanstack/react-router/@tanstack/router-core": ["@tanstack/router-core@1.169.2", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-5sm0DJF1A7Mz+9gy4Gz/lLovNailK3yot4vYvz9MkBUPw26uLnhQiR8hSCYxucjE0wD6Mdlc5l+Z0/XTlZ7xHw=="],
 
     "mcp-template-minimal/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 

--- a/deploy.json
+++ b/deploy.json
@@ -466,5 +466,14 @@
       "google-analytics/**",
       "shared/**"
     ]
+  },
+  "magento": {
+    "site": "magento",
+    "entrypoint": "./dist/server/main.js",
+    "platformName": "kubernetes-bun",
+    "watch": [
+      "magento/**",
+      "shared/**"
+    ]
   }
 }

--- a/magento/app.json
+++ b/magento/app.json
@@ -39,6 +39,14 @@
           "title": "Origin Header",
           "description": "Secret value sent as the x-origin-header on every request (required by WAF-protected stores)",
           "format": "password"
+        },
+        "extraHeaders": {
+          "type": "object",
+          "title": "Extra Headers",
+          "description": "Additional headers sent on every Magento request",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "required": ["baseUrl", "apiToken"]

--- a/magento/app.json
+++ b/magento/app.json
@@ -1,0 +1,57 @@
+{
+  "scopeName": "deco",
+  "name": "magento",
+  "friendlyName": "Magento Commerce",
+  "connection": {
+    "type": "HTTP",
+    "url": "https://sites-magento.deco.site/mcp",
+    "configSchema": {
+      "type": "object",
+      "properties": {
+        "baseUrl": {
+          "type": "string",
+          "title": "Base URL",
+          "description": "Magento store base URL, e.g. https://loja.granado.com.br (no trailing slash, no /rest)"
+        },
+        "apiToken": {
+          "type": "string",
+          "title": "API Token",
+          "description": "Magento integration access token (sent as Authorization: Bearer)",
+          "format": "password"
+        },
+        "storeCode": {
+          "type": "string",
+          "title": "Store Code",
+          "description": "REST store code path segment, e.g. \"granado\" (default \"all\")"
+        },
+        "currencyCode": {
+          "type": "string",
+          "title": "Currency Code",
+          "description": "Currency for money values, e.g. BRL (default BRL)"
+        },
+        "timezone": {
+          "type": "string",
+          "title": "Timezone",
+          "description": "Store timezone — IANA name like America/Sao_Paulo or ±HH:MM offset (default America/Sao_Paulo)"
+        },
+        "originHeader": {
+          "type": "string",
+          "title": "Origin Header",
+          "description": "Secret value sent as the x-origin-header on every request (required by WAF-protected stores)",
+          "format": "password"
+        }
+      },
+      "required": ["baseUrl", "apiToken"]
+    }
+  },
+  "description": "MCP for Magento 2 REST APIs — live sales dashboard widgets (orders per hour, sales cards, cancellation rate, top products, status breakdown) plus curated tools for orders, catalog, customers, inventory and CMS.",
+  "icon": "https://github.com/magento.png",
+  "unlisted": false,
+  "metadata": {
+    "categories": ["E-commerce", "Developer Tools"],
+    "official": false,
+    "tags": ["magento", "adobe-commerce", "ecommerce", "orders", "catalog", "analytics", "dashboard", "api"],
+    "short_description": "Manage Magento 2 stores and get live sales insights with dashboard widgets.",
+    "mesh_description": "The Magento Commerce MCP provides direct access to Magento 2 (Adobe Commerce) REST APIs for e-commerce operations, plus live analytics widgets for the studio home. It enables AI agents to search and inspect orders, invoices, shipments and credit memos, browse products and categories, look up customers and stock, and read CMS pages/blocks. Analytics tools aggregate the orders API into hourly sales timelines, revenue summary cards, cancellation rates, top selling products and status breakdowns — each with a rich UI widget. Works with any Magento 2 store via an integration token, including WAF-protected stores through a configurable origin header."
+  }
+}

--- a/magento/cancellation-rate.html
+++ b/magento/cancellation-rate.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Magento Cancellation Rate</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./web/tools/cancellation-rate/main.tsx"></script>
+	</body>
+</html>

--- a/magento/orders-sales-card.html
+++ b/magento/orders-sales-card.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Magento Orders Sales Card</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./web/tools/orders-sales-card/main.tsx"></script>
+	</body>
+</html>

--- a/magento/orders-timeline.html
+++ b/magento/orders-timeline.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Magento Orders Timeline</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./web/tools/orders-timeline/main.tsx"></script>
+	</body>
+</html>

--- a/magento/package.json
+++ b/magento/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "magento",
+  "version": "1.0.0",
+  "description": "MCP for Magento 2 REST APIs - sales analytics widgets, orders, catalog, customers, inventory and CMS",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "concurrently -k -n api,web -c magenta,cyan \"bun run dev:api\" \"bun run dev:web\"",
+    "dev:api": "bun run --hot server/main.ts",
+    "dev:web": "bun run build:web && concurrently -n timeline,sales,cancel,top,status \"MCP_APP_ENTRY=orders-timeline MCP_APP_EMPTY_OUTDIR=false vite build --watch\" \"MCP_APP_ENTRY=orders-sales-card MCP_APP_EMPTY_OUTDIR=false vite build --watch\" \"MCP_APP_ENTRY=cancellation-rate MCP_APP_EMPTY_OUTDIR=false vite build --watch\" \"MCP_APP_ENTRY=top-products MCP_APP_EMPTY_OUTDIR=false vite build --watch\" \"MCP_APP_ENTRY=status-breakdown MCP_APP_EMPTY_OUTDIR=false vite build --watch\"",
+    "configure": "deco configure",
+    "deploy": "npm run build && deco deploy ./dist/server",
+    "check": "tsc --noEmit",
+    "build:web": "MCP_APP_ENTRY=orders-timeline MCP_APP_EMPTY_OUTDIR=true vite build && MCP_APP_ENTRY=orders-sales-card MCP_APP_EMPTY_OUTDIR=false vite build && MCP_APP_ENTRY=cancellation-rate MCP_APP_EMPTY_OUTDIR=false vite build && MCP_APP_ENTRY=top-products MCP_APP_EMPTY_OUTDIR=false vite build && MCP_APP_ENTRY=status-breakdown MCP_APP_EMPTY_OUTDIR=false vite build",
+    "build:server": "NODE_ENV=production bun build server/main.ts --target=bun --outfile=dist/server/main.js",
+    "build": "bun run build:web && bun run build:server",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@decocms/runtime": "^1.6.2",
+    "@modelcontextprotocol/ext-apps": "^1.1.2",
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@tailwindcss/vite": "^4.2.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.576.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "recharts": "2.15.4",
+    "tailwind-merge": "^3.5.0",
+    "tailwindcss": "^4.2.1",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260206.0",
+    "@decocms/mcps-shared": "1.0.0",
+    "@types/bun": "^1.2.14",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.2",
+    "@vitejs/plugin-react": "^5.0.4",
+    "babel-plugin-react-compiler": "^1.0.0",
+    "concurrently": "^9.2.1",
+    "deco-cli": "^0.28.0",
+    "typescript": "^5.7.2",
+    "vite": "^7.3.1",
+    "vite-plugin-singlefile": "^2.3.0"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/magento/server/constants.ts
+++ b/magento/server/constants.ts
@@ -1,0 +1,12 @@
+/**
+ * MCP App resource URIs — one exclusive URI per web tool page.
+ */
+export const MAGENTO_ORDERS_TIMELINE_RESOURCE_URI =
+  "ui://magento/orders-timeline";
+export const MAGENTO_ORDERS_SALES_CARD_RESOURCE_URI =
+  "ui://magento/orders-sales-card";
+export const MAGENTO_CANCELLATION_RATE_RESOURCE_URI =
+  "ui://magento/cancellation-rate";
+export const MAGENTO_TOP_PRODUCTS_RESOURCE_URI = "ui://magento/top-products";
+export const MAGENTO_STATUS_BREAKDOWN_RESOURCE_URI =
+  "ui://magento/status-breakdown";

--- a/magento/server/lib/client.ts
+++ b/magento/server/lib/client.ts
@@ -1,0 +1,207 @@
+/**
+ * Magento REST client — credential resolution, URL/header building and a
+ * retrying fetch wrapper. Mirrors vtex/server/lib/client-factory.ts +
+ * the withRetry logic from vtex/server/lib/tool-adapter.ts.
+ */
+import type { MagentoCredentials } from "../types/env.ts";
+
+export type { MagentoCredentials };
+
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_RETRIES = 3;
+const INITIAL_RETRY_DELAY_MS = 500;
+
+export const DEFAULT_STORE_CODE = "all";
+export const DEFAULT_CURRENCY = "BRL";
+
+type CredentialSource = "state" | "env" | "missing";
+
+export interface ResolvedCredentials extends MagentoCredentials {
+  /** Where each credential value came from — useful for diagnosing missing config. */
+  sources: {
+    baseUrl: CredentialSource;
+    apiToken: CredentialSource;
+    storeCode: CredentialSource;
+    originHeader: CredentialSource;
+  };
+}
+
+function pickSource(
+  fromState: string | undefined,
+  fromEnv: string | undefined,
+): { value: string; source: CredentialSource } {
+  if (fromState) return { value: fromState, source: "state" };
+  if (fromEnv) return { value: fromEnv, source: "env" };
+  return { value: "", source: "missing" };
+}
+
+export function resolveCredentials(
+  state: Partial<MagentoCredentials> | undefined,
+): ResolvedCredentials {
+  const safeState = state ?? {};
+  const baseUrl = pickSource(safeState.baseUrl, process.env.MAGENTO_BASE_URL);
+  const apiToken = pickSource(
+    safeState.apiToken,
+    process.env.MAGENTO_API_TOKEN,
+  );
+  const storeCode = pickSource(
+    safeState.storeCode,
+    process.env.MAGENTO_STORE_CODE,
+  );
+  const originHeader = pickSource(
+    safeState.originHeader,
+    process.env.MAGENTO_ORIGIN_HEADER,
+  );
+
+  if (baseUrl.source === "missing") {
+    const stateKeys = state ? Object.keys(state) : [];
+    console.warn(
+      "[Magento] resolveCredentials: baseUrl is missing — neither MESH_REQUEST_CONTEXT.state.baseUrl nor process.env.MAGENTO_BASE_URL is set.",
+      JSON.stringify({
+        receivedStateType: state === undefined ? "undefined" : typeof state,
+        receivedStateKeys: stateKeys,
+        envMagentoBaseUrlSet: Boolean(process.env.MAGENTO_BASE_URL),
+      }),
+    );
+  }
+
+  return {
+    baseUrl: baseUrl.value,
+    apiToken: apiToken.value,
+    storeCode: storeCode.value || undefined,
+    currencyCode: safeState.currencyCode,
+    timezone: safeState.timezone,
+    originHeader: originHeader.value || undefined,
+    extraHeaders: safeState.extraHeaders,
+    sources: {
+      baseUrl: baseUrl.source,
+      apiToken: apiToken.source,
+      storeCode: storeCode.source,
+      originHeader: originHeader.source,
+    },
+  };
+}
+
+export function assertValidCredentials(
+  creds: ResolvedCredentials,
+  toolId?: string,
+): void {
+  const where = toolId ? ` (tool=${toolId})` : "";
+  if (!creds.baseUrl) {
+    throw new Error(
+      `Magento baseUrl is missing${where} — set MESH_REQUEST_CONTEXT.state.baseUrl or the MAGENTO_BASE_URL env var (e.g. https://loja.granado.com.br).`,
+    );
+  }
+  if (!creds.apiToken) {
+    throw new Error(
+      `Magento apiToken is missing${where} — set MESH_REQUEST_CONTEXT.state.apiToken or the MAGENTO_API_TOKEN env var (integration access token).`,
+    );
+  }
+}
+
+export function buildMagentoHeaders(
+  creds: MagentoCredentials,
+): Record<string, string> {
+  return {
+    Authorization: `Bearer ${creds.apiToken}`,
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    ...(creds.originHeader ? { "x-origin-header": creds.originHeader } : {}),
+    ...creds.extraHeaders,
+  };
+}
+
+export function buildRestUrl(
+  creds: MagentoCredentials,
+  path: string,
+  params?: URLSearchParams,
+): string {
+  const base = creds.baseUrl.replace(/\/+$/, "");
+  const storeCode = creds.storeCode || DEFAULT_STORE_CODE;
+  const query = params ? `?${params.toString()}` : "";
+  return `${base}/rest/${storeCode}/V1${path}${query}`;
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export interface MagentoFetchOptions {
+  params?: URLSearchParams;
+  method?: "GET" | "POST" | "PUT" | "DELETE";
+  body?: unknown;
+  toolId?: string;
+}
+
+/**
+ * Fetch a Magento REST endpoint with timeout + retry (429/5xx/network).
+ * Throws a descriptive error on failure; 403 responses get a WAF hint since
+ * some stores (e.g. Granado) sit behind a Cloudflare rule that requires the
+ * x-origin-header secret.
+ */
+export async function magentoFetch<T = unknown>(
+  creds: MagentoCredentials,
+  path: string,
+  options: MagentoFetchOptions = {},
+): Promise<T> {
+  const url = buildRestUrl(creds, path, options.params);
+  const headers = buildMagentoHeaders(creds);
+  const method = options.method ?? "GET";
+
+  if (process.env.DEBUG) {
+    console.log("[Magento]", method, url);
+  }
+
+  let lastError: Error | null = null;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method,
+        headers,
+        ...(options.body !== undefined
+          ? { body: JSON.stringify(options.body) }
+          : {}),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+    } catch (err) {
+      lastError =
+        err instanceof Error ? err : new Error("Magento request failed");
+      if (attempt < MAX_RETRIES) {
+        await sleep(
+          INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200,
+        );
+        continue;
+      }
+      break;
+    }
+
+    if (response.ok) {
+      return (await response.json()) as T;
+    }
+
+    const bodyText = await response.text();
+    const where = options.toolId ? ` [tool=${options.toolId}]` : "";
+    const wafHint =
+      response.status === 403
+        ? " Hint: a 403 may come from a WAF in front of the store — configure the originHeader (x-origin-header secret) or extraHeaders in the MCP state."
+        : "";
+    lastError = new Error(
+      `Magento API Error: ${response.status} ${method} ${path}${where} — ${bodyText.slice(0, 500)}${wafHint}`,
+    );
+
+    if (attempt < MAX_RETRIES && isRetryableStatus(response.status)) {
+      await sleep(
+        INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200,
+      );
+      continue;
+    }
+    break;
+  }
+
+  throw lastError ?? new Error("Magento request failed");
+}

--- a/magento/server/lib/search-criteria.test.ts
+++ b/magento/server/lib/search-criteria.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { buildSearchCriteriaParams } from "./search-criteria.ts";
+
+describe("buildSearchCriteriaParams", () => {
+  test("always emits at least searchCriteria[pageSize]", () => {
+    const params = buildSearchCriteriaParams();
+    expect(params.get("searchCriteria[pageSize]")).toBe("20");
+  });
+
+  test("each filter becomes its own AND filter group", () => {
+    const params = buildSearchCriteriaParams({
+      filters: [
+        {
+          field: "created_at",
+          value: "2026-07-03 03:00:00",
+          conditionType: "gteq",
+        },
+        { field: "status", value: "canceled" },
+      ],
+    });
+    expect(
+      params.get("searchCriteria[filter_groups][0][filters][0][field]"),
+    ).toBe("created_at");
+    expect(
+      params.get("searchCriteria[filter_groups][0][filters][0][value]"),
+    ).toBe("2026-07-03 03:00:00");
+    expect(
+      params.get(
+        "searchCriteria[filter_groups][0][filters][0][condition_type]",
+      ),
+    ).toBe("gteq");
+    expect(
+      params.get("searchCriteria[filter_groups][1][filters][0][field]"),
+    ).toBe("status");
+    expect(
+      params.get(
+        "searchCriteria[filter_groups][1][filters][0][condition_type]",
+      ),
+    ).toBe("eq");
+  });
+
+  test("sort orders, pagination and fields", () => {
+    const params = buildSearchCriteriaParams({
+      sortOrders: [{ field: "created_at", direction: "ASC" }],
+      pageSize: 500,
+      currentPage: 3,
+      fields: "total_count,items[status]",
+    });
+    expect(params.get("searchCriteria[sortOrders][0][field]")).toBe(
+      "created_at",
+    );
+    expect(params.get("searchCriteria[sortOrders][0][direction]")).toBe("ASC");
+    expect(params.get("searchCriteria[pageSize]")).toBe("500");
+    expect(params.get("searchCriteria[currentPage]")).toBe("3");
+    expect(params.get("fields")).toBe("total_count,items[status]");
+  });
+});

--- a/magento/server/lib/search-criteria.ts
+++ b/magento/server/lib/search-criteria.ts
@@ -1,0 +1,97 @@
+/**
+ * Magento searchCriteria helpers.
+ *
+ * Magento list endpoints take filters as bracket-indexed query params
+ * (`searchCriteria[filter_groups][0][filters][0][field]=...`). Tools expose a
+ * clean `filters` array instead and this module translates it. Filters are
+ * combined with AND (each filter becomes its own filter group); filters inside
+ * the same group would be OR — not needed for v1.
+ */
+import { z } from "zod";
+
+export const CONDITION_TYPES = [
+  "eq",
+  "neq",
+  "gt",
+  "gteq",
+  "lt",
+  "lteq",
+  "like",
+  "in",
+  "nin",
+  "null",
+  "notnull",
+] as const;
+
+export const filterSchema = z.object({
+  field: z
+    .string()
+    .describe(
+      'Order/entity attribute to filter on, e.g. "created_at", "status", "sku"',
+    ),
+  value: z
+    .string()
+    .describe(
+      'Filter value. Dates are UTC "YYYY-MM-DD HH:MM:SS". For "in"/"nin" use a comma-separated list. For "like" include % wildcards.',
+    ),
+  conditionType: z
+    .enum(CONDITION_TYPES)
+    .optional()
+    .describe('Magento condition type (default "eq")'),
+});
+
+export type SearchFilter = z.infer<typeof filterSchema>;
+
+export const filtersSchema = z
+  .array(filterSchema)
+  .optional()
+  .describe("Filters combined with AND (each becomes its own filter group)");
+
+export interface SortOrder {
+  field: string;
+  direction: "ASC" | "DESC";
+}
+
+export interface SearchCriteriaOptions {
+  filters?: SearchFilter[];
+  sortOrders?: SortOrder[];
+  pageSize?: number;
+  currentPage?: number;
+  /**
+   * Magento response field trimming, e.g.
+   * "total_count,items[increment_id,status,grand_total,created_at]".
+   */
+  fields?: string;
+}
+
+export function buildSearchCriteriaParams(
+  options: SearchCriteriaOptions = {},
+): URLSearchParams {
+  const params = new URLSearchParams();
+
+  (options.filters ?? []).forEach((filter, index) => {
+    const prefix = `searchCriteria[filter_groups][${index}][filters][0]`;
+    params.set(`${prefix}[field]`, filter.field);
+    params.set(`${prefix}[value]`, filter.value);
+    params.set(`${prefix}[condition_type]`, filter.conditionType ?? "eq");
+  });
+
+  (options.sortOrders ?? []).forEach((sort, index) => {
+    params.set(`searchCriteria[sortOrders][${index}][field]`, sort.field);
+    params.set(
+      `searchCriteria[sortOrders][${index}][direction]`,
+      sort.direction,
+    );
+  });
+
+  // Magento requires at least one searchCriteria param on search endpoints.
+  params.set("searchCriteria[pageSize]", String(options.pageSize ?? 20));
+  if (options.currentPage !== undefined) {
+    params.set("searchCriteria[currentPage]", String(options.currentPage));
+  }
+  if (options.fields) {
+    params.set("fields", options.fields);
+  }
+
+  return params;
+}

--- a/magento/server/lib/time.test.ts
+++ b/magento/server/lib/time.test.ts
@@ -93,6 +93,14 @@ describe("getRangeForPeriod", () => {
     const window = getRangeForPeriod("30d", "America/Sao_Paulo", now);
     expect(window.startUtc.toISOString()).toBe("2026-06-04T03:00:00.000Z");
   });
+
+  test("7d start is the true local midnight across a DST change", () => {
+    // US DST 2026 starts Mar 8. Mar 12 10:00 EDT (UTC-4) == 15:00 UTC;
+    // 7d window starts at Mar 6 midnight EST (UTC-5) == 05:00 UTC.
+    const dstNow = new Date("2026-03-12T15:00:00Z");
+    const window = getRangeForPeriod("7d", "America/New_York", dstNow);
+    expect(window.startUtc.toISOString()).toBe("2026-03-06T05:00:00.000Z");
+  });
 });
 
 describe("getRollingRange", () => {

--- a/magento/server/lib/time.test.ts
+++ b/magento/server/lib/time.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getHourIndex,
+  getOffsetMinutes,
+  getRangeForPeriod,
+  getRollingRange,
+  getTodayWindow,
+  parseMagentoUtc,
+  toMagentoUtc,
+} from "./time.ts";
+
+describe("getOffsetMinutes", () => {
+  test("parses fixed ±HH:MM offsets", () => {
+    expect(getOffsetMinutes("-03:00")).toBe(-180);
+    expect(getOffsetMinutes("+05:30")).toBe(330);
+  });
+
+  test("resolves IANA names via Intl", () => {
+    // Brazil abolished DST in 2019 — São Paulo is always -03:00.
+    expect(
+      getOffsetMinutes("America/Sao_Paulo", new Date("2026-07-03T12:00:00Z")),
+    ).toBe(-180);
+    expect(
+      getOffsetMinutes("America/Sao_Paulo", new Date("2026-01-15T12:00:00Z")),
+    ).toBe(-180);
+    expect(getOffsetMinutes("UTC")).toBe(0);
+  });
+
+  test("falls back to UTC for unknown timezones", () => {
+    expect(getOffsetMinutes("Not/AZone")).toBe(0);
+  });
+});
+
+describe("magento UTC format", () => {
+  test("toMagentoUtc emits MySQL format", () => {
+    expect(toMagentoUtc(new Date("2026-07-03T14:22:11.500Z"))).toBe(
+      "2026-07-03 14:22:11",
+    );
+  });
+
+  test("parseMagentoUtc round-trips", () => {
+    const ms = parseMagentoUtc("2026-07-03 14:22:11");
+    expect(ms).toBe(Date.parse("2026-07-03T14:22:11Z"));
+  });
+
+  test("parseMagentoUtc returns NaN for garbage", () => {
+    expect(Number.isNaN(parseMagentoUtc("not-a-date"))).toBe(true);
+  });
+});
+
+describe("getTodayWindow", () => {
+  test("day start is local midnight converted to UTC", () => {
+    // 2026-07-03 10:00 in São Paulo == 13:00 UTC.
+    const now = new Date("2026-07-03T13:00:00Z");
+    const window = getTodayWindow("America/Sao_Paulo", now);
+    expect(window.startUtc.toISOString()).toBe("2026-07-03T03:00:00.000Z");
+    expect(window.endUtc.toISOString()).toBe(now.toISOString());
+    expect(window.date).toBe("2026-07-03");
+  });
+
+  test("just after local midnight, today is nearly empty", () => {
+    // 00:10 local on Jul 4 == 03:10 UTC Jul 4.
+    const now = new Date("2026-07-04T03:10:00Z");
+    const window = getTodayWindow("America/Sao_Paulo", now);
+    expect(window.startUtc.toISOString()).toBe("2026-07-04T03:00:00.000Z");
+    expect(window.date).toBe("2026-07-04");
+  });
+
+  test("just before local midnight, date stays on the local day", () => {
+    // 23:59 local on Jul 3 == 02:59 UTC Jul 4.
+    const now = new Date("2026-07-04T02:59:00Z");
+    const window = getTodayWindow("America/Sao_Paulo", now);
+    expect(window.startUtc.toISOString()).toBe("2026-07-03T03:00:00.000Z");
+    expect(window.date).toBe("2026-07-03");
+  });
+});
+
+describe("getRangeForPeriod", () => {
+  const now = new Date("2026-07-03T13:00:00Z");
+
+  test("today delegates to getTodayWindow", () => {
+    const window = getRangeForPeriod("today", "America/Sao_Paulo", now);
+    expect(window.startUtc.toISOString()).toBe("2026-07-03T03:00:00.000Z");
+  });
+
+  test("7d includes today plus six prior local days", () => {
+    const window = getRangeForPeriod("7d", "America/Sao_Paulo", now);
+    expect(window.startUtc.toISOString()).toBe("2026-06-27T03:00:00.000Z");
+    expect(window.endUtc.toISOString()).toBe(now.toISOString());
+  });
+
+  test("30d includes today plus 29 prior local days", () => {
+    const window = getRangeForPeriod("30d", "America/Sao_Paulo", now);
+    expect(window.startUtc.toISOString()).toBe("2026-06-04T03:00:00.000Z");
+  });
+});
+
+describe("getRollingRange", () => {
+  test("returns now minus N minutes", () => {
+    const now = new Date("2026-07-03T13:00:00Z");
+    const range = getRollingRange(60, now);
+    expect(range.startUtc.toISOString()).toBe("2026-07-03T12:00:00.000Z");
+    expect(range.endUtc.toISOString()).toBe(now.toISOString());
+  });
+});
+
+describe("getHourIndex", () => {
+  const dayStart = Date.parse("2026-07-03T03:00:00Z"); // local midnight SP
+
+  test("buckets by local hour", () => {
+    expect(getHourIndex(Date.parse("2026-07-03T03:10:00Z"), dayStart)).toBe(0);
+    expect(getHourIndex(Date.parse("2026-07-03T13:59:00Z"), dayStart)).toBe(10);
+  });
+
+  test("clamps out-of-day values into 0..23", () => {
+    expect(getHourIndex(dayStart - 1, dayStart)).toBe(0);
+    expect(getHourIndex(dayStart + 25 * 3_600_000, dayStart)).toBe(23);
+  });
+});

--- a/magento/server/lib/time.ts
+++ b/magento/server/lib/time.ts
@@ -110,8 +110,15 @@ export function getRangeForPeriod(
   if (period === "today") return today;
 
   const days = period === "7d" ? 7 : 30;
+  // A fixed 24h*N subtraction drifts by an hour across DST changes. Step to
+  // midday of the target local day (safe against ±1h drift) and resolve that
+  // day's true local midnight with the offset in effect at that instant.
+  const targetMidday = new Date(
+    today.startUtc.getTime() - (days - 1) * DAY_MS + 12 * HOUR_MS,
+  );
+  const targetDay = getTodayWindow(timezone, targetMidday);
   return {
-    startUtc: new Date(today.startUtc.getTime() - (days - 1) * DAY_MS),
+    startUtc: targetDay.startUtc,
     endUtc: now,
     date: today.date,
   };

--- a/magento/server/lib/time.ts
+++ b/magento/server/lib/time.ts
@@ -1,0 +1,124 @@
+/**
+ * Timezone-safe window math for Magento reporting.
+ *
+ * Magento stores `created_at` in UTC using MySQL format
+ * ("YYYY-MM-DD HH:MM:SS", no zone suffix) and searchCriteria date filters
+ * expect the same format. "Today" must be computed in the store's local
+ * timezone and converted back to UTC. Ported from
+ * vtex/server/tools/custom/orders-oms.ts, with IANA support via Intl.
+ */
+import { z } from "zod";
+
+export const DEFAULT_STORE_TIMEZONE = "America/Sao_Paulo";
+
+export const salesPeriodSchema = z.enum(["today", "last_1h", "last_5min"]);
+export type SalesPeriod = z.infer<typeof salesPeriodSchema>;
+
+export const reportPeriodSchema = z.enum(["today", "7d", "30d"]);
+export type ReportPeriod = z.infer<typeof reportPeriodSchema>;
+
+const DAY_MS = 86_400_000;
+const HOUR_MS = 3_600_000;
+
+export function parseTimezoneOffsetMinutes(timezone: string): number | null {
+  const match = timezone.match(/^([+-])(\d{2}):(\d{2})$/);
+  if (!match) return null;
+  const sign = match[1] === "+" ? 1 : -1;
+  return (
+    sign * (Number.parseInt(match[2], 10) * 60 + Number.parseInt(match[3], 10))
+  );
+}
+
+/**
+ * UTC offset (minutes) of a timezone at a given instant. Accepts "±HH:MM"
+ * offsets or IANA names ("America/Sao_Paulo"). Falls back to 0 (UTC) for
+ * unknown values instead of throwing.
+ */
+export function getOffsetMinutes(timezone: string, at = new Date()): number {
+  const fixed = parseTimezoneOffsetMinutes(timezone);
+  if (fixed !== null) return fixed;
+
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      timeZoneName: "longOffset",
+    }).formatToParts(at);
+    const name = parts.find((part) => part.type === "timeZoneName")?.value;
+    // "GMT-03:00", "GMT+05:30" or plain "GMT" for UTC.
+    const match = name?.match(/^GMT(?:([+-])(\d{2}):(\d{2}))?$/);
+    if (!match || !match[1]) return 0;
+    const sign = match[1] === "+" ? 1 : -1;
+    return (
+      sign *
+      (Number.parseInt(match[2], 10) * 60 + Number.parseInt(match[3], 10))
+    );
+  } catch {
+    console.warn(
+      `[Magento] Unknown timezone "${timezone}" — falling back to UTC.`,
+    );
+    return 0;
+  }
+}
+
+/** Date → Magento UTC filter value ("YYYY-MM-DD HH:MM:SS"). */
+export function toMagentoUtc(date: Date): string {
+  return date.toISOString().slice(0, 19).replace("T", " ");
+}
+
+/** Magento UTC timestamp → epoch ms. Returns NaN for unparseable values. */
+export function parseMagentoUtc(value: string): number {
+  return Date.parse(`${value.replace(" ", "T")}Z`);
+}
+
+export interface TimeWindow {
+  startUtc: Date;
+  endUtc: Date;
+  /** Local calendar date ("YYYY-MM-DD") when the window is day-aligned. */
+  date?: string;
+}
+
+/** Start of the local calendar day through now. */
+export function getTodayWindow(timezone: string, now = new Date()): TimeWindow {
+  const offsetMinutes = getOffsetMinutes(timezone, now);
+  const shifted = new Date(now.getTime() + offsetMinutes * 60_000);
+  const year = shifted.getUTCFullYear();
+  const month = shifted.getUTCMonth();
+  const day = shifted.getUTCDate();
+  const startMs = Date.UTC(year, month, day) - offsetMinutes * 60_000;
+
+  return {
+    startUtc: new Date(startMs),
+    endUtc: now,
+    date: `${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`,
+  };
+}
+
+export function getRollingRange(minutes: number, now = new Date()): TimeWindow {
+  return {
+    startUtc: new Date(now.getTime() - minutes * 60_000),
+    endUtc: now,
+  };
+}
+
+/** "today" = local day so far; "7d"/"30d" = last N local days including today. */
+export function getRangeForPeriod(
+  period: ReportPeriod,
+  timezone: string,
+  now = new Date(),
+): TimeWindow {
+  const today = getTodayWindow(timezone, now);
+  if (period === "today") return today;
+
+  const days = period === "7d" ? 7 : 30;
+  return {
+    startUtc: new Date(today.startUtc.getTime() - (days - 1) * DAY_MS),
+    endUtc: now,
+    date: today.date,
+  };
+}
+
+/** Local hour bucket (0-23) of a UTC instant relative to the local day start. */
+export function getHourIndex(createdAtMs: number, dayStartMs: number): number {
+  const index = Math.floor((createdAtMs - dayStartMs) / HOUR_MS);
+  return Math.min(23, Math.max(0, index));
+}

--- a/magento/server/main.ts
+++ b/magento/server/main.ts
@@ -1,0 +1,39 @@
+/**
+ * Magento Commerce MCP
+ *
+ * MCP for Magento 2 REST APIs — sales analytics widgets plus curated tools for
+ * orders, catalog, customers, inventory and CMS.
+ */
+import { serve } from "@decocms/mcps-shared/serve";
+import { withRuntime } from "@decocms/runtime";
+import {
+  cancellationRateResource,
+  ordersSalesCardResource,
+  ordersTimelineResource,
+  statusBreakdownResource,
+  topProductsResource,
+} from "./resources/index.ts";
+import { tools } from "./tools/index.ts";
+import { type Env, StateSchema } from "./types/env.ts";
+import packageJson from "../package.json" with { type: "json" };
+
+console.log(`Magento Commerce MCP v${packageJson.version}`);
+
+export type { Env };
+export { StateSchema };
+
+const runtime = withRuntime<Env, typeof StateSchema>({
+  configuration: {
+    state: StateSchema,
+  },
+  tools,
+  resources: [
+    ordersTimelineResource,
+    ordersSalesCardResource,
+    cancellationRateResource,
+    topProductsResource,
+    statusBreakdownResource,
+  ],
+});
+
+serve(runtime.fetch);

--- a/magento/server/resources/index.ts
+++ b/magento/server/resources/index.ts
@@ -1,0 +1,46 @@
+import {
+  MAGENTO_CANCELLATION_RATE_RESOURCE_URI,
+  MAGENTO_ORDERS_SALES_CARD_RESOURCE_URI,
+  MAGENTO_ORDERS_TIMELINE_RESOURCE_URI,
+  MAGENTO_STATUS_BREAKDOWN_RESOURCE_URI,
+  MAGENTO_TOP_PRODUCTS_RESOURCE_URI,
+} from "../constants.ts";
+import { createMcpAppResource } from "./mcp-app-resource.ts";
+
+export const ordersTimelineResource = createMcpAppResource({
+  uri: MAGENTO_ORDERS_TIMELINE_RESOURCE_URI,
+  name: "Magento Orders Timeline",
+  description: "MCP App UI for today's hourly orders bar chart.",
+  htmlFile: "orders-timeline.html",
+});
+
+export const ordersSalesCardResource = createMcpAppResource({
+  uri: MAGENTO_ORDERS_SALES_CARD_RESOURCE_URI,
+  name: "Magento Orders Sales Card",
+  description:
+    "MCP App UI for sales summary cards (today, last hour, last 5 minutes).",
+  htmlFile: "orders-sales-card.html",
+});
+
+export const cancellationRateResource = createMcpAppResource({
+  uri: MAGENTO_CANCELLATION_RATE_RESOURCE_URI,
+  name: "Magento Cancellation Rate",
+  description:
+    "MCP App UI for the order cancellation rate card (today, 7d, 30d).",
+  htmlFile: "cancellation-rate.html",
+});
+
+export const topProductsResource = createMcpAppResource({
+  uri: MAGENTO_TOP_PRODUCTS_RESOURCE_URI,
+  name: "Magento Top Products",
+  description: "MCP App UI for the top selling products list (today, 7d, 30d).",
+  htmlFile: "top-products.html",
+});
+
+export const statusBreakdownResource = createMcpAppResource({
+  uri: MAGENTO_STATUS_BREAKDOWN_RESOURCE_URI,
+  name: "Magento Status Breakdown",
+  description:
+    "MCP App UI for the orders-by-status donut chart (today, 7d, 30d).",
+  htmlFile: "status-breakdown.html",
+});

--- a/magento/server/resources/mcp-app-resource.ts
+++ b/magento/server/resources/mcp-app-resource.ts
@@ -1,0 +1,45 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createPublicResource } from "@decocms/runtime/tools";
+import type { Env } from "../types/env.ts";
+
+const RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
+
+function getHtmlPath(filename: string): string {
+  const projectRoot = join(import.meta.dir, "../..");
+  return join(projectRoot, "dist", "client", filename);
+}
+
+export function createMcpAppResource(options: {
+  uri: string;
+  name: string;
+  description: string;
+  htmlFile: string;
+}) {
+  return (_env: Env) =>
+    createPublicResource({
+      uri: options.uri,
+      name: options.name,
+      description: options.description,
+      mimeType: RESOURCE_MIME_TYPE,
+      read: async () => {
+        const htmlPath = getHtmlPath(options.htmlFile);
+        try {
+          const html = await readFile(htmlPath, "utf-8");
+          return {
+            uri: options.uri,
+            mimeType: RESOURCE_MIME_TYPE,
+            text: html,
+          };
+        } catch (err) {
+          const message =
+            err instanceof Error && "code" in err && err.code === "ENOENT"
+              ? `MCP App bundle not found at ${htmlPath}. Run "bun run build:web" in the magento folder (or "bun run dev" to build and watch).`
+              : err instanceof Error
+                ? err.message
+                : "Failed to read MCP App bundle";
+          throw new Error(message);
+        }
+      },
+    });
+}

--- a/magento/server/tools/custom/cancellation-rate.ts
+++ b/magento/server/tools/custom/cancellation-rate.ts
@@ -1,0 +1,86 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { MAGENTO_CANCELLATION_RATE_RESOURCE_URI } from "../../constants.ts";
+import {
+  assertValidCredentials,
+  resolveCredentials,
+} from "../../lib/client.ts";
+import {
+  DEFAULT_STORE_TIMEZONE,
+  getRangeForPeriod,
+  reportPeriodSchema,
+  toMagentoUtc,
+} from "../../lib/time.ts";
+import type { Env } from "../../types/env.ts";
+import type { SearchFilter } from "../../lib/search-criteria.ts";
+import { countOrders } from "./orders-search.ts";
+
+const TOOL_ID = "MAGENTO_CANCELLATION_RATE";
+
+const outputSchema = z.object({
+  period: reportPeriodSchema,
+  canceled: z.number(),
+  total: z.number(),
+  /** 0-1 fraction (e.g. 0.031 = 3.1%). */
+  rate: z.number(),
+  startDate: z.string(),
+  endDate: z.string(),
+});
+
+export const cancellationRate = (_env: Env) =>
+  createTool({
+    id: TOOL_ID,
+    description:
+      "Order cancellation rate for a period (today, last 7 days, or last 30 days). Two cheap /V1/orders total_count queries: all orders vs status=canceled.",
+    inputSchema: z.object({
+      period: reportPeriodSchema
+        .optional()
+        .describe('Reporting window: "today", "7d" or "30d" (default "today")'),
+    }),
+    outputSchema,
+    _meta: { ui: { resourceUri: MAGENTO_CANCELLATION_RATE_RESOURCE_URI } },
+    annotations: { readOnlyHint: true },
+    execute: async ({ context, runtimeContext }) => {
+      const env = runtimeContext.env as Env;
+      const creds = resolveCredentials(env.MESH_REQUEST_CONTEXT?.state);
+      assertValidCredentials(creds, TOOL_ID);
+
+      const timezone = creds.timezone ?? DEFAULT_STORE_TIMEZONE;
+      const period = context.period ?? "today";
+      const window = getRangeForPeriod(period, timezone);
+
+      const rangeFilters: SearchFilter[] = [
+        {
+          field: "created_at",
+          value: toMagentoUtc(window.startUtc),
+          conditionType: "gteq",
+        },
+        {
+          field: "created_at",
+          value: toMagentoUtc(window.endUtc),
+          conditionType: "lteq",
+        },
+      ];
+
+      const [total, canceled] = await Promise.all([
+        countOrders(creds, rangeFilters, TOOL_ID),
+        countOrders(
+          creds,
+          [
+            ...rangeFilters,
+            { field: "status", value: "canceled", conditionType: "eq" },
+          ],
+          TOOL_ID,
+        ),
+      ]);
+
+      return {
+        period,
+        canceled,
+        total,
+        rate: canceled / Math.max(total, 1),
+        startDate: toMagentoUtc(window.startUtc),
+        endDate: toMagentoUtc(window.endUtc),
+      };
+    },
+  });

--- a/magento/server/tools/custom/orders-sales-card.ts
+++ b/magento/server/tools/custom/orders-sales-card.ts
@@ -1,0 +1,101 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { MAGENTO_ORDERS_SALES_CARD_RESOURCE_URI } from "../../constants.ts";
+import {
+  assertValidCredentials,
+  DEFAULT_CURRENCY,
+  resolveCredentials,
+} from "../../lib/client.ts";
+import {
+  DEFAULT_STORE_TIMEZONE,
+  getTodayWindow,
+  salesPeriodSchema,
+  type SalesPeriod,
+} from "../../lib/time.ts";
+import type { Env } from "../../types/env.ts";
+import { aggregateWindowStats, searchOrders } from "./orders-search.ts";
+
+const TOOL_ID = "MAGENTO_ORDERS_SALES_CARD";
+
+const ALL_SALES_PERIODS = ["today", "last_1h", "last_5min"] as const;
+
+/** Rolling window sizes (ms). last_1h uses 65min headroom absorbed at filter time. */
+const PERIOD_WINDOW_MS: Record<Exclude<SalesPeriod, "today">, number> = {
+  last_1h: 60 * 60_000,
+  last_5min: 5 * 60_000,
+};
+
+const salesCardSchema = z.object({
+  period: salesPeriodSchema,
+  orders: z.number(),
+  totalValue: z.number(),
+  date: z.string().optional(),
+});
+
+const outputSchema = z.object({
+  cards: z.array(salesCardSchema),
+  currency: z.string(),
+  truncated: z.boolean(),
+});
+
+export const ordersSalesCard = (_env: Env) =>
+  createTool({
+    id: TOOL_ID,
+    description:
+      "Sales summary cards for today, last hour, and last 5 minutes (default). Single /V1/orders query covering all windows, aggregated in memory. Pass an optional period to return a single card only.",
+    inputSchema: z.object({
+      period: salesPeriodSchema
+        .optional()
+        .describe(
+          'Optional single window: "today", "last_1h", or "last_5min". Omit to return all three.',
+        ),
+    }),
+    outputSchema,
+    _meta: { ui: { resourceUri: MAGENTO_ORDERS_SALES_CARD_RESOURCE_URI } },
+    annotations: { readOnlyHint: true },
+    execute: async ({ context, runtimeContext }) => {
+      const env = runtimeContext.env as Env;
+      const creds = resolveCredentials(env.MESH_REQUEST_CONTEXT?.state);
+      assertValidCredentials(creds, TOOL_ID);
+
+      const timezone = creds.timezone ?? DEFAULT_STORE_TIMEZONE;
+      const now = new Date();
+      const today = getTodayWindow(timezone, now);
+      // Just after local midnight "last_1h" reaches into yesterday — widen the
+      // fetch window so a single query covers every card.
+      const fetchStartMs = Math.min(
+        today.startUtc.getTime(),
+        now.getTime() - PERIOD_WINDOW_MS.last_1h - 5 * 60_000,
+      );
+
+      const result = await searchOrders({
+        creds,
+        window: { startUtc: new Date(fetchStartMs), endUtc: now },
+        toolId: TOOL_ID,
+      });
+
+      const periods = context.period
+        ? [context.period]
+        : [...ALL_SALES_PERIODS];
+
+      const cards = periods.map((period) => {
+        const startMs =
+          period === "today"
+            ? today.startUtc.getTime()
+            : now.getTime() - PERIOD_WINDOW_MS[period];
+        const stats = aggregateWindowStats(result.items, startMs);
+        return {
+          period,
+          orders: stats.orders,
+          totalValue: stats.totalValue,
+          ...(period === "today" && today.date ? { date: today.date } : {}),
+        };
+      });
+
+      return {
+        cards,
+        currency: creds.currencyCode ?? DEFAULT_CURRENCY,
+        truncated: result.truncated,
+      };
+    },
+  });

--- a/magento/server/tools/custom/orders-search.test.ts
+++ b/magento/server/tools/custom/orders-search.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  aggregateByStatus,
+  aggregateHourlyBuckets,
+  aggregateTopProducts,
+  aggregateWindowStats,
+  countOrders,
+  searchOrders,
+  type MagentoOrderSummary,
+} from "./orders-search.ts";
+import type { MagentoCredentials } from "../../lib/client.ts";
+
+const CREDS: MagentoCredentials = {
+  baseUrl: "https://example.com",
+  apiToken: "token",
+  storeCode: "granado",
+};
+
+const DAY_START = Date.parse("2026-07-03T03:00:00Z"); // local midnight SP
+
+function order(
+  createdAtUtc: string,
+  grandTotal: number,
+  status = "processing",
+  items?: MagentoOrderSummary["items"],
+): MagentoOrderSummary {
+  return {
+    increment_id: "000000001",
+    status,
+    grand_total: grandTotal,
+    created_at: createdAtUtc,
+    ...(items ? { items } : {}),
+  };
+}
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function mockFetchPages(
+  pages: Array<{ items: unknown[]; total_count: number }>,
+) {
+  const urls: string[] = [];
+  let call = 0;
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    urls.push(String(input));
+    const page = pages[Math.min(call, pages.length - 1)];
+    call++;
+    return Promise.resolve(
+      new Response(JSON.stringify(page), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  }) as typeof fetch;
+  return urls;
+}
+
+describe("searchOrders", () => {
+  test("paginates until total_count is reached", async () => {
+    const items = Array.from({ length: 3 }, (_, i) =>
+      order("2026-07-03 10:00:0" + i, 100),
+    );
+    const urls = mockFetchPages([
+      { items: items.slice(0, 2), total_count: 3 },
+      { items: items.slice(2), total_count: 3 },
+    ]);
+
+    const result = await searchOrders({
+      creds: CREDS,
+      window: {
+        startUtc: new Date("2026-07-03T03:00:00Z"),
+        endUtc: new Date("2026-07-03T13:00:00Z"),
+      },
+      pageSize: 2,
+    });
+
+    expect(result.items.length).toBe(3);
+    expect(result.totalCount).toBe(3);
+    expect(result.truncated).toBe(false);
+    expect(urls.length).toBe(2);
+    expect(urls[0]).toContain("/rest/granado/V1/orders?");
+    expect(urls[0]).toContain(
+      encodeURIComponent("searchCriteria[currentPage]"),
+    );
+    // created_at range filters present (URL-encoded brackets and space).
+    expect(decodeURIComponent(urls[0])).toContain(
+      "searchCriteria[filter_groups][0][filters][0][field]=created_at",
+    );
+  });
+
+  test("flags truncation when maxPages is hit", async () => {
+    mockFetchPages([
+      { items: [order("2026-07-03 10:00:00", 100)], total_count: 10 },
+    ]);
+
+    const result = await searchOrders({
+      creds: CREDS,
+      window: {
+        startUtc: new Date("2026-07-03T03:00:00Z"),
+        endUtc: new Date("2026-07-03T13:00:00Z"),
+      },
+      pageSize: 1,
+      maxPages: 2,
+    });
+
+    expect(result.items.length).toBe(2);
+    expect(result.totalCount).toBe(10);
+    expect(result.truncated).toBe(true);
+  });
+});
+
+describe("countOrders", () => {
+  test("uses pageSize=1 + total_count fields", async () => {
+    const urls = mockFetchPages([{ items: [], total_count: 42 }]);
+    const count = await countOrders(CREDS, [
+      { field: "status", value: "canceled", conditionType: "eq" },
+    ]);
+    expect(count).toBe(42);
+    const url = decodeURIComponent(urls[0]);
+    expect(url).toContain("searchCriteria[pageSize]=1");
+    expect(url).toContain("fields=total_count");
+  });
+});
+
+describe("aggregateHourlyBuckets", () => {
+  test("zero-fills 24 buckets and sums per local hour", () => {
+    const buckets = aggregateHourlyBuckets(
+      [
+        order("2026-07-03 03:10:00", 100), // 00:00 local
+        order("2026-07-03 13:30:00", 50), // 10:00 local
+        order("2026-07-03 13:45:00", 25), // 10:00 local
+      ],
+      DAY_START,
+    );
+    expect(buckets.length).toBe(24);
+    expect(buckets[0]).toEqual({ hour: "00:00", count: 1, totalValue: 100 });
+    expect(buckets[10]).toEqual({ hour: "10:00", count: 2, totalValue: 75 });
+    expect(buckets[23]).toEqual({ hour: "23:00", count: 0, totalValue: 0 });
+  });
+});
+
+describe("aggregateWindowStats", () => {
+  test("only counts orders at or after startMs", () => {
+    const stats = aggregateWindowStats(
+      [
+        order("2026-07-03 10:00:00", 100),
+        order("2026-07-03 12:59:00", 50),
+        order("2026-07-03 12:30:00", 25),
+      ],
+      Date.parse("2026-07-03T12:00:00Z"),
+    );
+    expect(stats.orders).toBe(2);
+    expect(stats.totalValue).toBe(75);
+  });
+});
+
+describe("aggregateByStatus", () => {
+  test("groups and sorts by count desc", () => {
+    const statuses = aggregateByStatus([
+      order("2026-07-03 10:00:00", 100, "processing"),
+      order("2026-07-03 10:01:00", 50, "processing"),
+      order("2026-07-03 10:02:00", 30, "canceled"),
+    ]);
+    expect(statuses[0]).toEqual({
+      status: "processing",
+      count: 2,
+      totalValue: 150,
+    });
+    expect(statuses[1]).toEqual({
+      status: "canceled",
+      count: 1,
+      totalValue: 30,
+    });
+  });
+});
+
+describe("aggregateTopProducts", () => {
+  test("aggregates top-level items by sku, skipping configurable children", () => {
+    const products = aggregateTopProducts(
+      [
+        order("2026-07-03 10:00:00", 100, "processing", [
+          { sku: "SAB-01", name: "Sabonete", qty_ordered: 2, row_total: 40 },
+          {
+            sku: "SAB-01-CHILD",
+            name: "Sabonete P",
+            qty_ordered: 2,
+            row_total: 0,
+            parent_item_id: 99,
+          },
+        ]),
+        order("2026-07-03 11:00:00", 60, "processing", [
+          { sku: "SAB-01", name: "Sabonete", qty_ordered: 1, row_total: 20 },
+          { sku: "COL-02", name: "Colônia", qty_ordered: 1, row_total: 90 },
+        ]),
+      ],
+      10,
+    );
+
+    expect(products[0]).toEqual({
+      sku: "SAB-01",
+      name: "Sabonete",
+      quantity: 3,
+      revenue: 60,
+      orders: 2,
+    });
+    expect(products.find((p) => p.sku === "SAB-01-CHILD")).toBeUndefined();
+  });
+
+  test("respects the limit", () => {
+    const products = aggregateTopProducts(
+      [
+        order("2026-07-03 10:00:00", 100, "processing", [
+          { sku: "A", name: "A", qty_ordered: 3, row_total: 30 },
+          { sku: "B", name: "B", qty_ordered: 2, row_total: 20 },
+          { sku: "C", name: "C", qty_ordered: 1, row_total: 10 },
+        ]),
+      ],
+      2,
+    );
+    expect(products.length).toBe(2);
+    expect(products.map((p) => p.sku)).toEqual(["A", "B"]);
+  });
+});

--- a/magento/server/tools/custom/orders-search.test.ts
+++ b/magento/server/tools/custom/orders-search.test.ts
@@ -209,6 +209,25 @@ describe("aggregateTopProducts", () => {
     expect(products.find((p) => p.sku === "SAB-01-CHILD")).toBeUndefined();
   });
 
+  test("counts distinct orders even when a SKU repeats within one order", () => {
+    const products = aggregateTopProducts(
+      [
+        order("2026-07-03 10:00:00", 100, "processing", [
+          { sku: "SAB-01", name: "Sabonete", qty_ordered: 1, row_total: 20 },
+          { sku: "SAB-01", name: "Sabonete", qty_ordered: 2, row_total: 40 },
+        ]),
+      ],
+      10,
+    );
+    expect(products[0]).toEqual({
+      sku: "SAB-01",
+      name: "Sabonete",
+      quantity: 3,
+      revenue: 60,
+      orders: 1,
+    });
+  });
+
   test("respects the limit", () => {
     const products = aggregateTopProducts(
       [

--- a/magento/server/tools/custom/orders-search.ts
+++ b/magento/server/tools/custom/orders-search.ts
@@ -1,0 +1,252 @@
+/**
+ * Shared paginated /V1/orders fetch + in-memory aggregation helpers used by
+ * the analytics tools (timeline, sales card, cancellation rate, top products,
+ * status breakdown).
+ */
+import { magentoFetch, type MagentoCredentials } from "../../lib/client.ts";
+import {
+  buildSearchCriteriaParams,
+  type SearchFilter,
+} from "../../lib/search-criteria.ts";
+import {
+  getHourIndex,
+  parseMagentoUtc,
+  toMagentoUtc,
+  type TimeWindow,
+} from "../../lib/time.ts";
+
+export interface MagentoOrderLineItem {
+  sku?: string;
+  name?: string;
+  qty_ordered?: number;
+  row_total?: number;
+  parent_item_id?: number | null;
+  product_type?: string;
+}
+
+export interface MagentoOrderSummary {
+  increment_id?: string;
+  status?: string;
+  state?: string;
+  grand_total?: number;
+  created_at?: string;
+  items?: MagentoOrderLineItem[];
+}
+
+export interface OrdersSearchPage {
+  items?: MagentoOrderSummary[];
+  total_count?: number;
+}
+
+/** Response trimming — keeps each order at ~80 bytes. */
+export const ORDER_SUMMARY_FIELDS =
+  "total_count,items[increment_id,status,state,grand_total,created_at]";
+
+/** Summary + line items, for product-level aggregation. */
+export const ORDER_WITH_LINES_FIELDS =
+  "total_count,items[increment_id,status,state,grand_total,created_at,items[sku,name,qty_ordered,row_total,parent_item_id,product_type]]";
+
+const DEFAULT_PAGE_SIZE = 500;
+const DEFAULT_MAX_PAGES = 20;
+
+export interface SearchOrdersResult {
+  items: MagentoOrderSummary[];
+  totalCount: number;
+  /** True when total_count exceeded the pagination cap — numbers may be partial. */
+  truncated: boolean;
+}
+
+export interface SearchOrdersOptions {
+  creds: MagentoCredentials;
+  window: TimeWindow;
+  extraFilters?: SearchFilter[];
+  fields?: string;
+  pageSize?: number;
+  maxPages?: number;
+  toolId?: string;
+}
+
+export async function searchOrders(
+  options: SearchOrdersOptions,
+): Promise<SearchOrdersResult> {
+  const {
+    creds,
+    window,
+    extraFilters = [],
+    fields = ORDER_SUMMARY_FIELDS,
+    pageSize = DEFAULT_PAGE_SIZE,
+    maxPages = DEFAULT_MAX_PAGES,
+    toolId,
+  } = options;
+
+  const filters: SearchFilter[] = [
+    {
+      field: "created_at",
+      value: toMagentoUtc(window.startUtc),
+      conditionType: "gteq",
+    },
+    {
+      field: "created_at",
+      value: toMagentoUtc(window.endUtc),
+      conditionType: "lteq",
+    },
+    ...extraFilters,
+  ];
+
+  const items: MagentoOrderSummary[] = [];
+  let totalCount = 0;
+
+  for (let currentPage = 1; currentPage <= maxPages; currentPage++) {
+    const params = buildSearchCriteriaParams({
+      filters,
+      sortOrders: [{ field: "created_at", direction: "ASC" }],
+      pageSize,
+      currentPage,
+      fields,
+    });
+    const page = await magentoFetch<OrdersSearchPage>(creds, "/orders", {
+      params,
+      toolId,
+    });
+
+    const pageItems = page.items ?? [];
+    items.push(...pageItems);
+    totalCount = page.total_count ?? items.length;
+
+    if (pageItems.length === 0 || items.length >= totalCount) break;
+  }
+
+  return { items, totalCount, truncated: items.length < totalCount };
+}
+
+/** Cheap exact count — single request with pageSize=1 and total_count only. */
+export async function countOrders(
+  creds: MagentoCredentials,
+  filters: SearchFilter[],
+  toolId?: string,
+): Promise<number> {
+  const params = buildSearchCriteriaParams({
+    filters,
+    pageSize: 1,
+    fields: "total_count",
+  });
+  const page = await magentoFetch<OrdersSearchPage>(creds, "/orders", {
+    params,
+    toolId,
+  });
+  return page.total_count ?? 0;
+}
+
+// ── Aggregations ─────────────────────────────────────────────────────────────
+
+export interface HourlyOrderBucket {
+  hour: string;
+  count: number;
+  totalValue: number;
+}
+
+/** Bucket orders into 24 local hours (zero-filled). */
+export function aggregateHourlyBuckets(
+  orders: MagentoOrderSummary[],
+  dayStartMs: number,
+): HourlyOrderBucket[] {
+  const buckets = Array.from({ length: 24 }, (_, index) => ({
+    hour: `${String(index).padStart(2, "0")}:00`,
+    count: 0,
+    totalValue: 0,
+  }));
+
+  for (const order of orders) {
+    if (!order.created_at) continue;
+    const createdMs = parseMagentoUtc(order.created_at);
+    if (Number.isNaN(createdMs)) continue;
+    const bucket = buckets[getHourIndex(createdMs, dayStartMs)];
+    bucket.count += 1;
+    bucket.totalValue += order.grand_total ?? 0;
+  }
+
+  return buckets;
+}
+
+export interface PeriodStats {
+  orders: number;
+  totalValue: number;
+}
+
+/** Count + grand_total sum of orders created at or after `startMs`. */
+export function aggregateWindowStats(
+  orders: MagentoOrderSummary[],
+  startMs: number,
+): PeriodStats {
+  let count = 0;
+  let totalValue = 0;
+  for (const order of orders) {
+    if (!order.created_at) continue;
+    const createdMs = parseMagentoUtc(order.created_at);
+    if (Number.isNaN(createdMs) || createdMs < startMs) continue;
+    count += 1;
+    totalValue += order.grand_total ?? 0;
+  }
+  return { orders: count, totalValue };
+}
+
+export interface StatusBucket {
+  status: string;
+  count: number;
+  totalValue: number;
+}
+
+export function aggregateByStatus(
+  orders: MagentoOrderSummary[],
+): StatusBucket[] {
+  const byStatus = new Map<string, StatusBucket>();
+  for (const order of orders) {
+    const status = order.status ?? "unknown";
+    const bucket = byStatus.get(status) ?? { status, count: 0, totalValue: 0 };
+    bucket.count += 1;
+    bucket.totalValue += order.grand_total ?? 0;
+    byStatus.set(status, bucket);
+  }
+  return [...byStatus.values()].sort((a, b) => b.count - a.count);
+}
+
+export interface ProductAggregate {
+  sku: string;
+  name: string;
+  quantity: number;
+  revenue: number;
+  orders: number;
+}
+
+/**
+ * Aggregate line items by SKU. Only top-level items count (children of
+ * configurable/bundle parents carry parent_item_id and would double-count).
+ */
+export function aggregateTopProducts(
+  orders: MagentoOrderSummary[],
+  limit: number,
+): ProductAggregate[] {
+  const bySku = new Map<string, ProductAggregate>();
+
+  for (const order of orders) {
+    for (const item of order.items ?? []) {
+      if (item.parent_item_id != null) continue;
+      const sku = item.sku ?? "unknown";
+      const aggregate = bySku.get(sku) ?? {
+        sku,
+        name: item.name ?? sku,
+        quantity: 0,
+        revenue: 0,
+        orders: 0,
+      };
+      aggregate.quantity += item.qty_ordered ?? 0;
+      aggregate.revenue += item.row_total ?? 0;
+      aggregate.orders += 1;
+      bySku.set(sku, aggregate);
+    }
+  }
+
+  return [...bySku.values()]
+    .sort((a, b) => b.quantity - a.quantity || b.revenue - a.revenue)
+    .slice(0, limit);
+}

--- a/magento/server/tools/custom/orders-search.ts
+++ b/magento/server/tools/custom/orders-search.ts
@@ -215,6 +215,7 @@ export interface ProductAggregate {
   name: string;
   quantity: number;
   revenue: number;
+  /** Distinct orders containing the SKU (not line-item occurrences). */
   orders: number;
 }
 
@@ -229,6 +230,9 @@ export function aggregateTopProducts(
   const bySku = new Map<string, ProductAggregate>();
 
   for (const order of orders) {
+    // The same SKU can appear in multiple line items of one order (bundle
+    // splits, admin edits) — count the order once per SKU.
+    const countedSkus = new Set<string>();
     for (const item of order.items ?? []) {
       if (item.parent_item_id != null) continue;
       const sku = item.sku ?? "unknown";
@@ -241,7 +245,10 @@ export function aggregateTopProducts(
       };
       aggregate.quantity += item.qty_ordered ?? 0;
       aggregate.revenue += item.row_total ?? 0;
-      aggregate.orders += 1;
+      if (!countedSkus.has(sku)) {
+        aggregate.orders += 1;
+        countedSkus.add(sku);
+      }
       bySku.set(sku, aggregate);
     }
   }

--- a/magento/server/tools/custom/orders-timeline.ts
+++ b/magento/server/tools/custom/orders-timeline.ts
@@ -1,0 +1,53 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { MAGENTO_ORDERS_TIMELINE_RESOURCE_URI } from "../../constants.ts";
+import {
+  assertValidCredentials,
+  DEFAULT_CURRENCY,
+  resolveCredentials,
+} from "../../lib/client.ts";
+import { DEFAULT_STORE_TIMEZONE, getTodayWindow } from "../../lib/time.ts";
+import type { Env } from "../../types/env.ts";
+import { aggregateHourlyBuckets, searchOrders } from "./orders-search.ts";
+
+const TOOL_ID = "MAGENTO_ORDERS_TIMELINE";
+
+const hourBucketSchema = z.object({
+  hour: z.string(),
+  count: z.number(),
+  totalValue: z.number(),
+});
+
+const outputSchema = z.object({
+  hours: z.array(hourBucketSchema),
+  date: z.string(),
+  currency: z.string(),
+  truncated: z.boolean(),
+});
+
+export const ordersTimeline = (_env: Env) =>
+  createTool({
+    id: TOOL_ID,
+    description:
+      "Fetch today's orders aggregated by hour for a bar chart. Queries /V1/orders with a created_at window in the store timezone and buckets results into 24 local hours.",
+    inputSchema: z.object({}),
+    outputSchema,
+    _meta: { ui: { resourceUri: MAGENTO_ORDERS_TIMELINE_RESOURCE_URI } },
+    annotations: { readOnlyHint: true },
+    execute: async ({ runtimeContext }) => {
+      const env = runtimeContext.env as Env;
+      const creds = resolveCredentials(env.MESH_REQUEST_CONTEXT?.state);
+      assertValidCredentials(creds, TOOL_ID);
+
+      const timezone = creds.timezone ?? DEFAULT_STORE_TIMEZONE;
+      const window = getTodayWindow(timezone);
+      const result = await searchOrders({ creds, window, toolId: TOOL_ID });
+
+      return {
+        hours: aggregateHourlyBuckets(result.items, window.startUtc.getTime()),
+        date: window.date ?? "",
+        currency: creds.currencyCode ?? DEFAULT_CURRENCY,
+        truncated: result.truncated,
+      };
+    },
+  });

--- a/magento/server/tools/custom/status-breakdown.ts
+++ b/magento/server/tools/custom/status-breakdown.ts
@@ -1,0 +1,71 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { MAGENTO_STATUS_BREAKDOWN_RESOURCE_URI } from "../../constants.ts";
+import {
+  assertValidCredentials,
+  DEFAULT_CURRENCY,
+  resolveCredentials,
+} from "../../lib/client.ts";
+import {
+  DEFAULT_STORE_TIMEZONE,
+  getRangeForPeriod,
+  reportPeriodSchema,
+  toMagentoUtc,
+} from "../../lib/time.ts";
+import type { Env } from "../../types/env.ts";
+import { aggregateByStatus, searchOrders } from "./orders-search.ts";
+
+const TOOL_ID = "MAGENTO_STATUS_BREAKDOWN";
+
+const statusBucketSchema = z.object({
+  status: z.string(),
+  count: z.number(),
+  totalValue: z.number(),
+});
+
+const outputSchema = z.object({
+  statuses: z.array(statusBucketSchema),
+  total: z.number(),
+  period: reportPeriodSchema,
+  startDate: z.string(),
+  endDate: z.string(),
+  currency: z.string(),
+  truncated: z.boolean(),
+});
+
+export const statusBreakdown = (_env: Env) =>
+  createTool({
+    id: TOOL_ID,
+    description:
+      "Orders grouped by status (processing, complete, canceled, pending…) for a period (today, last 7 days, or last 30 days), with count and grand_total sum per status. Useful for a donut chart of order health.",
+    inputSchema: z.object({
+      period: reportPeriodSchema
+        .optional()
+        .describe('Reporting window: "today", "7d" or "30d" (default "today")'),
+    }),
+    outputSchema,
+    _meta: { ui: { resourceUri: MAGENTO_STATUS_BREAKDOWN_RESOURCE_URI } },
+    annotations: { readOnlyHint: true },
+    execute: async ({ context, runtimeContext }) => {
+      const env = runtimeContext.env as Env;
+      const creds = resolveCredentials(env.MESH_REQUEST_CONTEXT?.state);
+      assertValidCredentials(creds, TOOL_ID);
+
+      const timezone = creds.timezone ?? DEFAULT_STORE_TIMEZONE;
+      const period = context.period ?? "today";
+      const window = getRangeForPeriod(period, timezone);
+
+      const result = await searchOrders({ creds, window, toolId: TOOL_ID });
+      const statuses = aggregateByStatus(result.items);
+
+      return {
+        statuses,
+        total: result.totalCount,
+        period,
+        startDate: toMagentoUtc(window.startUtc),
+        endDate: toMagentoUtc(window.endUtc),
+        currency: creds.currencyCode ?? DEFAULT_CURRENCY,
+        truncated: result.truncated,
+      };
+    },
+  });

--- a/magento/server/tools/custom/top-products.ts
+++ b/magento/server/tools/custom/top-products.ts
@@ -1,0 +1,91 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { MAGENTO_TOP_PRODUCTS_RESOURCE_URI } from "../../constants.ts";
+import {
+  assertValidCredentials,
+  DEFAULT_CURRENCY,
+  resolveCredentials,
+} from "../../lib/client.ts";
+import {
+  DEFAULT_STORE_TIMEZONE,
+  getRangeForPeriod,
+  reportPeriodSchema,
+  toMagentoUtc,
+} from "../../lib/time.ts";
+import type { Env } from "../../types/env.ts";
+import {
+  aggregateTopProducts,
+  ORDER_WITH_LINES_FIELDS,
+  searchOrders,
+} from "./orders-search.ts";
+
+const TOOL_ID = "MAGENTO_TOP_PRODUCTS";
+
+const DEFAULT_LIMIT = 10;
+
+const productSchema = z.object({
+  sku: z.string(),
+  name: z.string(),
+  quantity: z.number(),
+  revenue: z.number(),
+  orders: z.number(),
+});
+
+const outputSchema = z.object({
+  products: z.array(productSchema),
+  period: reportPeriodSchema,
+  startDate: z.string(),
+  endDate: z.string(),
+  currency: z.string(),
+  truncated: z.boolean(),
+});
+
+export const topProducts = (_env: Env) =>
+  createTool({
+    id: TOOL_ID,
+    description:
+      "Top selling products by quantity for a period (today, last 7 days, or last 30 days). Fetches orders with line items from /V1/orders and aggregates by SKU (top-level items only, so configurable children are not double-counted).",
+    inputSchema: z.object({
+      period: reportPeriodSchema
+        .optional()
+        .describe('Reporting window: "today", "7d" or "30d" (default "today")'),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(50)
+        .optional()
+        .describe("How many products to return (default 10)"),
+    }),
+    outputSchema,
+    _meta: { ui: { resourceUri: MAGENTO_TOP_PRODUCTS_RESOURCE_URI } },
+    annotations: { readOnlyHint: true },
+    execute: async ({ context, runtimeContext }) => {
+      const env = runtimeContext.env as Env;
+      const creds = resolveCredentials(env.MESH_REQUEST_CONTEXT?.state);
+      assertValidCredentials(creds, TOOL_ID);
+
+      const timezone = creds.timezone ?? DEFAULT_STORE_TIMEZONE;
+      const period = context.period ?? "today";
+      const window = getRangeForPeriod(period, timezone);
+
+      const result = await searchOrders({
+        creds,
+        window,
+        fields: ORDER_WITH_LINES_FIELDS,
+        toolId: TOOL_ID,
+      });
+
+      return {
+        products: aggregateTopProducts(
+          result.items,
+          context.limit ?? DEFAULT_LIMIT,
+        ),
+        period,
+        startDate: toMagentoUtc(window.startUtc),
+        endDate: toMagentoUtc(window.endUtc),
+        currency: creds.currencyCode ?? DEFAULT_CURRENCY,
+        truncated: result.truncated,
+      };
+    },
+  });

--- a/magento/server/tools/index.ts
+++ b/magento/server/tools/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Central export point for all Magento tools.
+ *
+ * Registry tools are curated hand-written wrappers over the Magento 2 REST
+ * API. Custom tools power the MCP App UI widgets (analytics over /V1/orders).
+ */
+import { registryTools } from "./registry.ts";
+
+// ── Custom tools (MCP App UI widgets) ────────────────────────────────────────
+import { ordersTimeline } from "./custom/orders-timeline.ts";
+import { ordersSalesCard } from "./custom/orders-sales-card.ts";
+import { cancellationRate } from "./custom/cancellation-rate.ts";
+import { topProducts } from "./custom/top-products.ts";
+import { statusBreakdown } from "./custom/status-breakdown.ts";
+
+const customFactories = [
+  // Today's orders timeline chart (MCP App UI)
+  ordersTimeline,
+  // Sales summary card for today / last hour / last 5 min (MCP App UI)
+  ordersSalesCard,
+  // Cancellation rate card for today / 7d / 30d (MCP App UI)
+  cancellationRate,
+  // Top selling products for today / 7d / 30d (MCP App UI)
+  topProducts,
+  // Orders by status donut for today / 7d / 30d (MCP App UI)
+  statusBreakdown,
+];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const tools = [...registryTools, ...customFactories] as any[];

--- a/magento/server/tools/registry.ts
+++ b/magento/server/tools/registry.ts
@@ -1,0 +1,321 @@
+/**
+ * Curated generic Magento REST tools (read-only in v1).
+ *
+ * Hand-written instead of OpenAPI-generated: Magento's swagger declares
+ * searchCriteria as bracket-indexed literal query params, which produce
+ * unusable generated schemas. Tools expose a clean `filters` array translated
+ * by lib/search-criteria.ts.
+ */
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import {
+  assertValidCredentials,
+  magentoFetch,
+  resolveCredentials,
+} from "../lib/client.ts";
+import {
+  buildSearchCriteriaParams,
+  filtersSchema,
+} from "../lib/search-criteria.ts";
+import type { Env } from "../types/env.ts";
+
+/** Normalize API payloads so tool results are always objects. */
+function toStructured(data: unknown): Record<string, unknown> {
+  if (Array.isArray(data)) return { items: data };
+  if (data !== null && typeof data === "object") {
+    return data as Record<string, unknown>;
+  }
+  return { result: data };
+}
+
+// ── Search-endpoint factory ──────────────────────────────────────────────────
+
+const searchInputSchema = z.object({
+  filters: filtersSchema,
+  pageSize: z
+    .number()
+    .int()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe("Results per page (default 20)"),
+  currentPage: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe("Page number, 1-based"),
+  sortField: z
+    .string()
+    .optional()
+    .describe('Attribute to sort by, e.g. "created_at"'),
+  sortDirection: z.enum(["ASC", "DESC"]).optional(),
+  fields: z
+    .string()
+    .optional()
+    .describe(
+      'Magento response trimming, e.g. "total_count,items[increment_id,status,grand_total]"',
+    ),
+});
+
+function createSearchTool(config: {
+  id: string;
+  description: string;
+  path: string;
+}) {
+  return (_env: Env) =>
+    createTool({
+      id: config.id,
+      description: config.description,
+      inputSchema: searchInputSchema,
+      annotations: { readOnlyHint: true },
+      execute: async ({ context, runtimeContext }) => {
+        const env = runtimeContext.env as Env;
+        const creds = resolveCredentials(env.MESH_REQUEST_CONTEXT?.state);
+        assertValidCredentials(creds, config.id);
+
+        const params = buildSearchCriteriaParams({
+          filters: context.filters,
+          sortOrders:
+            context.sortField != null
+              ? [
+                  {
+                    field: context.sortField,
+                    direction: context.sortDirection ?? "DESC",
+                  },
+                ]
+              : undefined,
+          pageSize: context.pageSize,
+          currentPage: context.currentPage,
+          fields: context.fields,
+        });
+        const data = await magentoFetch(creds, config.path, {
+          params,
+          toolId: config.id,
+        });
+        return toStructured(data);
+      },
+    });
+}
+
+// ── Single-resource factory ──────────────────────────────────────────────────
+
+function createGetTool<TSchema extends z.ZodObject<z.ZodRawShape>>(config: {
+  id: string;
+  description: string;
+  inputSchema: TSchema;
+  buildPath: (input: z.infer<TSchema>) => string;
+  buildParams?: (input: z.infer<TSchema>) => URLSearchParams | undefined;
+}) {
+  return (_env: Env) =>
+    createTool({
+      id: config.id,
+      description: config.description,
+      inputSchema: config.inputSchema,
+      annotations: { readOnlyHint: true },
+      execute: async ({ context, runtimeContext }) => {
+        const env = runtimeContext.env as Env;
+        const creds = resolveCredentials(env.MESH_REQUEST_CONTEXT?.state);
+        assertValidCredentials(creds, config.id);
+
+        const input = context as z.infer<TSchema>;
+        const data = await magentoFetch(creds, config.buildPath(input), {
+          params: config.buildParams?.(input),
+          toolId: config.id,
+        });
+        return toStructured(data);
+      },
+    });
+}
+
+// ── Sales ────────────────────────────────────────────────────────────────────
+
+export const listOrders = createSearchTool({
+  id: "MAGENTO_LIST_ORDERS",
+  description:
+    'Search orders (/V1/orders) with filters, sorting and pagination. Useful filters: created_at (gteq/lteq, UTC "YYYY-MM-DD HH:MM:SS"), status (eq/in), customer_email (eq), grand_total (gt/lt). Use fields to trim large payloads.',
+  path: "/orders",
+});
+
+export const getOrder = createGetTool({
+  id: "MAGENTO_GET_ORDER",
+  description:
+    "Get a single order by its numeric entity_id (/V1/orders/{id}), including items, payment, addresses and status history. For the customer-facing order number use MAGENTO_GET_ORDER_BY_INCREMENT_ID.",
+  inputSchema: z.object({
+    entityId: z
+      .number()
+      .int()
+      .describe("Order entity_id (internal numeric id)"),
+  }),
+  buildPath: (input) => `/orders/${input.entityId}`,
+});
+
+export const getOrderByIncrementId = createGetTool({
+  id: "MAGENTO_GET_ORDER_BY_INCREMENT_ID",
+  description:
+    "Find an order by its customer-facing increment_id (order number shown to shoppers), e.g. 000123456.",
+  inputSchema: z.object({
+    incrementId: z.string().describe("Customer-facing order number"),
+  }),
+  buildPath: () => "/orders",
+  buildParams: (input) =>
+    buildSearchCriteriaParams({
+      filters: [
+        {
+          field: "increment_id",
+          value: input.incrementId,
+          conditionType: "eq",
+        },
+      ],
+      pageSize: 1,
+    }),
+});
+
+export const listInvoices = createSearchTool({
+  id: "MAGENTO_LIST_INVOICES",
+  description:
+    "Search invoices (/V1/invoices) with filters, sorting and pagination. Useful filters: created_at, order_id, state.",
+  path: "/invoices",
+});
+
+export const listShipments = createSearchTool({
+  id: "MAGENTO_LIST_SHIPMENTS",
+  description:
+    "Search shipments (/V1/shipments) with filters, sorting and pagination. Useful filters: created_at, order_id.",
+  path: "/shipments",
+});
+
+export const listCreditmemos = createSearchTool({
+  id: "MAGENTO_LIST_CREDITMEMOS",
+  description:
+    "Search credit memos / refunds (/V1/creditmemos) with filters, sorting and pagination. Useful filters: created_at, order_id, state.",
+  path: "/creditmemos",
+});
+
+// ── Catalog ──────────────────────────────────────────────────────────────────
+
+export const listProducts = createSearchTool({
+  id: "MAGENTO_LIST_PRODUCTS",
+  description:
+    "Search products (/V1/products) with filters, sorting and pagination. Useful filters: sku (in/like), name (like), status (eq), type_id (eq), updated_at (gteq).",
+  path: "/products",
+});
+
+export const getProduct = createGetTool({
+  id: "MAGENTO_GET_PRODUCT",
+  description:
+    "Get a single product by SKU (/V1/products/{sku}) with attributes, price and extension data.",
+  inputSchema: z.object({
+    sku: z.string().describe("Product SKU"),
+  }),
+  buildPath: (input) => `/products/${encodeURIComponent(input.sku)}`,
+});
+
+export const getCategoryTree = createGetTool({
+  id: "MAGENTO_GET_CATEGORY_TREE",
+  description:
+    "Get the category tree (/V1/categories), optionally rooted at a category and limited in depth.",
+  inputSchema: z.object({
+    rootCategoryId: z
+      .number()
+      .int()
+      .optional()
+      .describe("Root category id (omit for the store's full tree)"),
+    depth: z.number().int().optional().describe("How many levels to descend"),
+  }),
+  buildPath: () => "/categories",
+  buildParams: (input) => {
+    const params = new URLSearchParams();
+    if (input.rootCategoryId !== undefined) {
+      params.set("rootCategoryId", String(input.rootCategoryId));
+    }
+    if (input.depth !== undefined) params.set("depth", String(input.depth));
+    return params;
+  },
+});
+
+export const getCategoryProducts = createGetTool({
+  id: "MAGENTO_GET_CATEGORY_PRODUCTS",
+  description:
+    "List the products assigned to a category (/V1/categories/{id}/products) with SKU and position.",
+  inputSchema: z.object({
+    categoryId: z.number().int().describe("Category id"),
+  }),
+  buildPath: (input) => `/categories/${input.categoryId}/products`,
+});
+
+// ── Customers ────────────────────────────────────────────────────────────────
+
+export const searchCustomers = createSearchTool({
+  id: "MAGENTO_SEARCH_CUSTOMERS",
+  description:
+    "Search customers (/V1/customers/search) with filters, sorting and pagination. Useful filters: email (eq/like), created_at (gteq), firstname/lastname (like).",
+  path: "/customers/search",
+});
+
+export const getCustomer = createGetTool({
+  id: "MAGENTO_GET_CUSTOMER",
+  description:
+    "Get a single customer by numeric id (/V1/customers/{id}) with addresses and attributes.",
+  inputSchema: z.object({
+    customerId: z.number().int().describe("Customer id"),
+  }),
+  buildPath: (input) => `/customers/${input.customerId}`,
+});
+
+// ── Inventory ────────────────────────────────────────────────────────────────
+
+export const getStockItem = createGetTool({
+  id: "MAGENTO_GET_STOCK_ITEM",
+  description:
+    "Get stock information for a SKU (/V1/stockItems/{sku}): qty, is_in_stock, backorders and thresholds.",
+  inputSchema: z.object({
+    sku: z.string().describe("Product SKU"),
+  }),
+  buildPath: (input) => `/stockItems/${encodeURIComponent(input.sku)}`,
+});
+
+// ── CMS ──────────────────────────────────────────────────────────────────────
+
+export const searchCmsPages = createSearchTool({
+  id: "MAGENTO_SEARCH_CMS_PAGES",
+  description:
+    "Search CMS pages (/V1/cmsPage/search) with filters, sorting and pagination. Useful filters: identifier (like), title (like), is_active (eq).",
+  path: "/cmsPage/search",
+});
+
+export const searchCmsBlocks = createSearchTool({
+  id: "MAGENTO_SEARCH_CMS_BLOCKS",
+  description:
+    "Search CMS blocks (/V1/cmsBlock/search) with filters, sorting and pagination. Useful filters: identifier (like), title (like), is_active (eq).",
+  path: "/cmsBlock/search",
+});
+
+// ── Store ────────────────────────────────────────────────────────────────────
+
+export const getStoreConfigs = createGetTool({
+  id: "MAGENTO_GET_STORE_CONFIGS",
+  description:
+    "Get store configurations (/V1/store/storeConfigs): base URLs, locale, timezone, currency codes. Also works as a connectivity/auth smoke test for the configured credentials.",
+  inputSchema: z.object({}),
+  buildPath: () => "/store/storeConfigs",
+});
+
+export const registryTools = [
+  listOrders,
+  getOrder,
+  getOrderByIncrementId,
+  listInvoices,
+  listShipments,
+  listCreditmemos,
+  listProducts,
+  getProduct,
+  getCategoryTree,
+  getCategoryProducts,
+  searchCustomers,
+  getCustomer,
+  getStockItem,
+  searchCmsPages,
+  searchCmsBlocks,
+  getStoreConfigs,
+];

--- a/magento/server/types/env.ts
+++ b/magento/server/types/env.ts
@@ -1,0 +1,56 @@
+/**
+ * Environment Type Definitions
+ */
+import { type DefaultEnv } from "@decocms/runtime";
+import { z } from "zod";
+
+export const StateSchema = z.object({
+  baseUrl: z
+    .string()
+    .describe(
+      "Magento store base URL, e.g. https://loja.granado.com.br (no trailing slash, no /rest)",
+    ),
+  apiToken: z
+    .string()
+    .describe(
+      "Magento integration access token, sent as Authorization: Bearer",
+    ),
+  storeCode: z
+    .string()
+    .optional()
+    .describe(
+      'REST store code path segment, e.g. "granado" (default "all" — queries every store view)',
+    ),
+  currencyCode: z
+    .string()
+    .optional()
+    .describe("Currency for money values, e.g. BRL or USD (default BRL)"),
+  timezone: z
+    .string()
+    .optional()
+    .describe(
+      "Store timezone — IANA name like America/Sao_Paulo or ±HH:MM offset (default America/Sao_Paulo)",
+    ),
+  originHeader: z
+    .string()
+    .optional()
+    .describe(
+      "Secret value sent as the x-origin-header on every request (required by WAF-protected stores like Granado)",
+    ),
+  extraHeaders: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe("Additional headers sent on every Magento request"),
+});
+
+export type Env = DefaultEnv<typeof StateSchema>;
+
+export interface MagentoCredentials {
+  baseUrl: string;
+  apiToken: string;
+  storeCode?: string;
+  currencyCode?: string;
+  timezone?: string;
+  originHeader?: string;
+  extraHeaders?: Record<string, string>;
+}

--- a/magento/status-breakdown.html
+++ b/magento/status-breakdown.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Magento Status Breakdown</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./web/tools/status-breakdown/main.tsx"></script>
+	</body>
+</html>

--- a/magento/top-products.html
+++ b/magento/top-products.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Magento Top Products</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./web/tools/top-products/main.tsx"></script>
+	</body>
+</html>

--- a/magento/tsconfig.json
+++ b/magento/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "types": ["@cloudflare/workers-types", "bun", "vite/client"],
+    "paths": {
+      "@/*": ["./web/*"]
+    }
+  },
+  "include": ["server", "web"]
+}

--- a/magento/vite.config.ts
+++ b/magento/vite.config.ts
@@ -19,6 +19,11 @@ function resolveEntry(): McpAppEntry {
   if (entry && entry in MCP_APP_ENTRIES) {
     return entry as McpAppEntry;
   }
+  if (entry) {
+    console.warn(
+      `[vite] Unknown MCP_APP_ENTRY "${entry}" — falling back to "orders-timeline". Valid entries: ${Object.keys(MCP_APP_ENTRIES).join(", ")}`,
+    );
+  }
   return "orders-timeline";
 }
 

--- a/magento/vite.config.ts
+++ b/magento/vite.config.ts
@@ -1,0 +1,49 @@
+import path from "node:path";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+import { viteSingleFile } from "vite-plugin-singlefile";
+
+const MCP_APP_ENTRIES = {
+  "orders-timeline": path.resolve(__dirname, "orders-timeline.html"),
+  "orders-sales-card": path.resolve(__dirname, "orders-sales-card.html"),
+  "cancellation-rate": path.resolve(__dirname, "cancellation-rate.html"),
+  "top-products": path.resolve(__dirname, "top-products.html"),
+  "status-breakdown": path.resolve(__dirname, "status-breakdown.html"),
+} as const;
+
+type McpAppEntry = keyof typeof MCP_APP_ENTRIES;
+
+function resolveEntry(): McpAppEntry {
+  const entry = process.env.MCP_APP_ENTRY;
+  if (entry && entry in MCP_APP_ENTRIES) {
+    return entry as McpAppEntry;
+  }
+  return "orders-timeline";
+}
+
+const activeEntry = resolveEntry();
+
+export default defineConfig({
+  plugins: [
+    react({
+      babel: {
+        plugins: ["babel-plugin-react-compiler"],
+      },
+    }),
+    tailwindcss(),
+    viteSingleFile(),
+  ],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./web"),
+    },
+  },
+  build: {
+    outDir: "dist/client",
+    emptyOutDir: process.env.MCP_APP_EMPTY_OUTDIR !== "false",
+    rollupOptions: {
+      input: MCP_APP_ENTRIES[activeEntry],
+    },
+  },
+});

--- a/magento/web/bootstrap.tsx
+++ b/magento/web/bootstrap.tsx
@@ -1,0 +1,24 @@
+import { StrictMode, type ComponentType } from "react";
+import { createRoot } from "react-dom/client";
+import { McpAppShell } from "@/components/mcp-app-shell.tsx";
+import { McpProvider } from "@/context.tsx";
+import "./globals.css";
+
+export function mountMcpApp(Page: ComponentType) {
+  const rootElement = document.getElementById("root");
+
+  if (!rootElement) {
+    throw new Error("Missing root element");
+  }
+
+  const root = createRoot(rootElement);
+  root.render(
+    <StrictMode>
+      <McpProvider>
+        <McpAppShell>
+          <Page />
+        </McpAppShell>
+      </McpProvider>
+    </StrictMode>,
+  );
+}

--- a/magento/web/components/mcp-app-shell.tsx
+++ b/magento/web/components/mcp-app-shell.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+import { useMcpHostContext } from "@/context.tsx";
+
+export function McpAppShell({ children }: { children: ReactNode }) {
+  const hostContext = useMcpHostContext();
+  const insets = hostContext?.safeAreaInsets;
+
+  return (
+    <div
+      className="flex min-h-0 w-full flex-1 flex-col overflow-hidden"
+      style={
+        insets
+          ? {
+              paddingTop: `${insets.top}px`,
+              paddingRight: `${insets.right}px`,
+              paddingBottom: `${insets.bottom}px`,
+              paddingLeft: `${insets.left}px`,
+            }
+          : undefined
+      }
+    >
+      {children}
+    </div>
+  );
+}

--- a/magento/web/components/page-header.tsx
+++ b/magento/web/components/page-header.tsx
@@ -1,0 +1,19 @@
+interface PageHeaderProps {
+  title: string;
+  subtitle?: string;
+  right?: React.ReactNode;
+}
+
+export function PageHeader({ title, subtitle, right }: PageHeaderProps) {
+  return (
+    <header className="flex items-start justify-between gap-4 mb-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+        {subtitle ? (
+          <p className="text-sm text-muted-foreground mt-1">{subtitle}</p>
+        ) : null}
+      </div>
+      {right ? <div>{right}</div> : null}
+    </header>
+  );
+}

--- a/magento/web/components/status-frame.tsx
+++ b/magento/web/components/status-frame.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import {
   Card,
   CardContent,
@@ -14,6 +15,23 @@ interface StatusFrameProps {
   connectedHint?: string;
 }
 
+function Centered({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex items-center justify-center min-h-dvh p-6">
+      {children}
+    </div>
+  );
+}
+
+function Spinner({ message }: { message: string }) {
+  return (
+    <div className="flex items-center gap-3 text-muted-foreground">
+      <span className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
+      <span className="text-sm">{message}</span>
+    </div>
+  );
+}
+
 export function StatusFrame({
   status,
   error,
@@ -23,18 +41,15 @@ export function StatusFrame({
 }: StatusFrameProps) {
   if (status === "initializing") {
     return (
-      <div className="flex items-center justify-center min-h-dvh p-6">
-        <div className="flex items-center gap-3 text-muted-foreground">
-          <span className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
-          <span className="text-sm">Connecting to host…</span>
-        </div>
-      </div>
+      <Centered>
+        <Spinner message="Connecting to host…" />
+      </Centered>
     );
   }
 
   if (status === "connected") {
     return (
-      <div className="flex items-center justify-center min-h-dvh p-6">
+      <Centered>
         <Card className="w-full max-w-md text-center">
           <CardHeader>
             <CardTitle>{connectedTitle}</CardTitle>
@@ -43,14 +58,14 @@ export function StatusFrame({
             <p className="text-muted-foreground text-sm">{connectedHint}</p>
           </CardContent>
         </Card>
-      </div>
+      </Centered>
     );
   }
 
   if (status === "error") {
     return (
-      <div className="flex items-center justify-center min-h-dvh p-6">
-        <Card className="w-full max-w-md border-destructive">
+      <Centered>
+        <Card role="alert" className="w-full max-w-md border-destructive">
           <CardHeader>
             <CardTitle className="text-destructive">Error</CardTitle>
           </CardHeader>
@@ -60,14 +75,14 @@ export function StatusFrame({
             </p>
           </CardContent>
         </Card>
-      </div>
+      </Centered>
     );
   }
 
   if (status === "tool-cancelled") {
     return (
-      <div className="flex items-center justify-center min-h-dvh p-6">
-        <Card className="w-full max-w-md border-destructive">
+      <Centered>
+        <Card role="alert" className="w-full max-w-md border-destructive">
           <CardHeader>
             <CardTitle className="text-destructive">Cancelled</CardTitle>
           </CardHeader>
@@ -75,16 +90,13 @@ export function StatusFrame({
             <p className="text-sm text-destructive">Tool call was cancelled.</p>
           </CardContent>
         </Card>
-      </div>
+      </Centered>
     );
   }
 
   return (
-    <div className="flex items-center justify-center min-h-dvh p-6">
-      <div className="flex items-center gap-3 text-muted-foreground">
-        <span className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
-        <span className="text-sm">{pendingMessage}</span>
-      </div>
-    </div>
+    <Centered>
+      <Spinner message={pendingMessage} />
+    </Centered>
   );
 }

--- a/magento/web/components/status-frame.tsx
+++ b/magento/web/components/status-frame.tsx
@@ -1,0 +1,90 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.tsx";
+import type { McpStatus } from "../types.ts";
+
+interface StatusFrameProps {
+  status: McpStatus;
+  error?: string;
+  pendingMessage?: string;
+  connectedTitle?: string;
+  connectedHint?: string;
+}
+
+export function StatusFrame({
+  status,
+  error,
+  pendingMessage = "Loading…",
+  connectedTitle = "Magento Dashboard",
+  connectedHint = "Invoke a tool to see analytics here.",
+}: StatusFrameProps) {
+  if (status === "initializing") {
+    return (
+      <div className="flex items-center justify-center min-h-dvh p-6">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <span className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
+          <span className="text-sm">Connecting to host…</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "connected") {
+    return (
+      <div className="flex items-center justify-center min-h-dvh p-6">
+        <Card className="w-full max-w-md text-center">
+          <CardHeader>
+            <CardTitle>{connectedTitle}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-muted-foreground text-sm">{connectedHint}</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <div className="flex items-center justify-center min-h-dvh p-6">
+        <Card className="w-full max-w-md border-destructive">
+          <CardHeader>
+            <CardTitle className="text-destructive">Error</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-destructive whitespace-pre-wrap break-words">
+              {error ?? "Unknown error"}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (status === "tool-cancelled") {
+    return (
+      <div className="flex items-center justify-center min-h-dvh p-6">
+        <Card className="w-full max-w-md border-destructive">
+          <CardHeader>
+            <CardTitle className="text-destructive">Cancelled</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-destructive">Tool call was cancelled.</p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-dvh p-6">
+      <div className="flex items-center gap-3 text-muted-foreground">
+        <span className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
+        <span className="text-sm">{pendingMessage}</span>
+      </div>
+    </div>
+  );
+}

--- a/magento/web/components/ui/card.tsx
+++ b/magento/web/components/ui/card.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import { cn } from "@/lib/utils.ts";
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  );
+}
+
+export { Card, CardContent, CardHeader, CardTitle };

--- a/magento/web/constants.ts
+++ b/magento/web/constants.ts
@@ -1,0 +1,16 @@
+/** Magento brand orange — timeline bars and card icon backgrounds. */
+export const MAGENTO_ACCENT = "#f46f25";
+
+/** Dark contrast for card icons (on orange tint). */
+export const MAGENTO_ICON = "#5c2300";
+
+/** Categorical palette for the status donut (accent first). */
+export const MAGENTO_CHART_COLORS = [
+  "#f46f25",
+  "#2f855a",
+  "#3182ce",
+  "#d69e2e",
+  "#e53e3e",
+  "#805ad5",
+  "#718096",
+] as const;

--- a/magento/web/context.tsx
+++ b/magento/web/context.tsx
@@ -1,0 +1,111 @@
+import {
+  type App,
+  type McpUiHostContext,
+  useApp,
+  useHostStyles,
+} from "@modelcontextprotocol/ext-apps/react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useState,
+} from "react";
+import { INITIAL_STATE, type McpState } from "./types.ts";
+
+const McpStateContext = createContext<McpState>(INITIAL_STATE);
+const McpAppContext = createContext<App | null>(null);
+const McpHostContext = createContext<McpUiHostContext | undefined>(undefined);
+
+export function McpProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<McpState>(INITIAL_STATE);
+  const [hostContext, setHostContext] = useState<McpUiHostContext | undefined>(
+    undefined,
+  );
+
+  const onAppCreated = useCallback((app: App) => {
+    app.ontoolinput = (params) => {
+      setState((prev) => {
+        const toolName =
+          prev.toolName ?? app.getHostContext()?.toolInfo?.tool.name;
+        return {
+          ...prev,
+          status: "tool-input",
+          toolInput: params.arguments,
+          ...(toolName ? { toolName } : {}),
+        };
+      });
+    };
+
+    app.ontoolresult = (result) => {
+      if (result.isError) {
+        const textBlock = result.content?.find((c) => c.type === "text");
+        const errorText =
+          (textBlock?.type === "text" ? textBlock.text : undefined) ??
+          "Tool returned an error";
+        setState((prev) => ({ ...prev, status: "error", error: errorText }));
+        return;
+      }
+      setState((prev) => ({
+        ...prev,
+        status: "tool-result",
+        toolResult: result.structuredContent,
+      }));
+    };
+
+    app.ontoolcancelled = () => {
+      setState((prev) => ({ ...prev, status: "tool-cancelled" }));
+    };
+
+    app.onerror = (err) => {
+      console.error("MCP App error:", err);
+    };
+
+    app.onhostcontextchanged = (ctx) => {
+      setHostContext((prev) => ({ ...prev, ...ctx }));
+      const toolName = ctx.toolInfo?.tool.name;
+      if (toolName) {
+        setState((prev) => ({ ...prev, toolName }));
+      }
+    };
+  }, []);
+
+  const { app, isConnected } = useApp({
+    appInfo: { name: "Magento MCP App", version: "1.0.0" },
+    capabilities: {},
+    onAppCreated,
+  });
+
+  useHostStyles(app, app?.getHostContext());
+
+  if (isConnected && state.status === "initializing") {
+    const ctx = app?.getHostContext();
+    if (ctx) setHostContext(ctx);
+    const toolName = ctx?.toolInfo?.tool.name;
+    setState({ status: "connected", toolName });
+  }
+
+  return (
+    <McpAppContext.Provider value={app}>
+      <McpHostContext.Provider value={hostContext}>
+        <McpStateContext.Provider value={state}>
+          {children}
+        </McpStateContext.Provider>
+      </McpHostContext.Provider>
+    </McpAppContext.Provider>
+  );
+}
+
+export function useMcpState<TInput = unknown, TResult = unknown>() {
+  return useContext(McpStateContext) as McpState<TInput, TResult>;
+}
+
+export function useMcpApp() {
+  return useContext(McpAppContext);
+}
+
+export function useMcpHostContext() {
+  return useContext(McpHostContext);
+}
+
+export { useDocumentTheme as useTheme } from "@modelcontextprotocol/ext-apps/react";

--- a/magento/web/globals.css
+++ b/magento/web/globals.css
@@ -1,0 +1,131 @@
+@import "tailwindcss";
+
+@custom-variant dark (&:is([data-theme="dark"] *));
+
+:root {
+	/* Host variable fallbacks (light) */
+	--color-background-primary: hsl(0 0% 100%);
+	--color-background-secondary: hsl(240 4.8% 95.9%);
+	--color-background-tertiary: hsl(240 4.8% 95.9%);
+	--color-background-danger: hsl(0 84.2% 60.2%);
+	--color-text-primary: hsl(240 10% 3.9%);
+	--color-text-secondary: hsl(240 3.8% 46.1%);
+	--color-border-primary: hsl(240 5.9% 90%);
+	--color-border-secondary: hsl(240 5.9% 90%);
+	--color-ring-primary: hsl(240 5.9% 10%);
+
+	/* Magento brand */
+	--primary: #f46f25;
+	--primary-foreground: #ffffff;
+	--color-ring-primary: #f46f25;
+
+	/* Sidebar tokens (existing) */
+	--sidebar: hsl(0 0% 98%);
+	--sidebar-foreground: hsl(240 5.3% 26.1%);
+	--sidebar-primary: #f46f25;
+	--sidebar-primary-foreground: #ffffff;
+	--sidebar-accent: hsl(240 4.8% 95.9%);
+	--sidebar-accent-foreground: hsl(240 5.9% 10%);
+	--sidebar-border: hsl(220 13% 91%);
+	--sidebar-ring: #f46f25;
+}
+
+[data-theme="dark"] {
+	/* Host variable fallbacks (dark) */
+	--color-background-primary: hsl(240 10% 3.9%);
+	--color-background-secondary: hsl(240 3.7% 15.9%);
+	--color-background-tertiary: hsl(240 3.7% 15.9%);
+	--color-background-danger: hsl(0 62.8% 30.6%);
+	--color-text-primary: hsl(0 0% 98%);
+	--color-text-secondary: hsl(240 5% 64.9%);
+	--color-border-primary: hsl(240 3.7% 15.9%);
+	--color-border-secondary: hsl(240 3.7% 15.9%);
+	--color-ring-primary: hsl(240 4.9% 83.9%);
+
+	/* Magento brand */
+	--primary: #f46f25;
+	--primary-foreground: #ffffff;
+	--color-ring-primary: #f46f25;
+
+	/* Sidebar tokens (existing) */
+	--sidebar: hsl(240 5.9% 10%);
+	--sidebar-foreground: hsl(240 4.8% 95.9%);
+	--sidebar-primary: #f46f25;
+	--sidebar-primary-foreground: #ffffff;
+	--sidebar-accent: hsl(240 3.7% 15.9%);
+	--sidebar-accent-foreground: hsl(240 4.8% 95.9%);
+	--sidebar-border: hsl(240 3.7% 15.9%);
+	--sidebar-ring: #f46f25;
+}
+
+@layer base {
+	html {
+		height: 100%;
+	}
+
+	body {
+		height: 100%;
+		margin: 0;
+		overflow: hidden;
+		@apply bg-background text-foreground;
+	}
+
+	#root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100dvh;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	button,
+	a,
+	select,
+	summary,
+	[role="button"],
+	[role="tab"],
+	[role="checkbox"],
+	[role="radio"],
+	[role="switch"],
+	[role="menuitem"],
+	[role="option"],
+	label[for] {
+		cursor: pointer;
+	}
+}
+
+@theme inline {
+	/* Core colors — mapped from host variables */
+	--color-background: var(--color-background-primary);
+	--color-foreground: var(--color-text-primary);
+	--color-card: var(--color-background-primary);
+	--color-card-foreground: var(--color-text-primary);
+	--color-popover: var(--color-background-primary);
+	--color-popover-foreground: var(--color-text-primary);
+	--color-primary: var(--primary);
+	--color-primary-foreground: var(--primary-foreground);
+	--color-secondary: var(--color-background-secondary);
+	--color-secondary-foreground: var(--color-text-primary);
+	--color-muted: var(--color-background-secondary);
+	--color-muted-foreground: var(--color-text-secondary);
+	--color-accent: var(--color-background-tertiary);
+	--color-accent-foreground: var(--color-text-primary);
+	--color-destructive: var(--color-background-danger);
+	--color-border: var(--color-border-primary);
+	--color-input: var(--color-border-secondary);
+	--color-ring: var(--color-ring-primary);
+
+	/* Layout */
+	--radius-DEFAULT: var(--border-radius-md, 0.375rem);
+
+	/* Sidebar (existing) */
+	--color-sidebar: var(--sidebar);
+	--color-sidebar-foreground: var(--sidebar-foreground);
+	--color-sidebar-primary: var(--sidebar-primary);
+	--color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+	--color-sidebar-accent: var(--sidebar-accent);
+	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+	--color-sidebar-border: var(--sidebar-border);
+	--color-sidebar-ring: var(--sidebar-ring);
+}

--- a/magento/web/hooks/use-tool.ts
+++ b/magento/web/hooks/use-tool.ts
@@ -1,0 +1,111 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMcpApp, useMcpState } from "@/context.tsx";
+
+interface ToolCallResult {
+  structuredContent?: unknown;
+  isError?: boolean;
+  content?: Array<{ type: string; text?: string }>;
+}
+
+interface UseToolResult<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+}
+
+function extractToolError(result: ToolCallResult): string | null {
+  if (!result.isError) return null;
+  const text = (result.content ?? [])
+    .filter((c) => c.type === "text" && typeof c.text === "string")
+    .map((c) => c.text ?? "")
+    .join("\n")
+    .trim();
+  return text || "Tool returned an error";
+}
+
+function stableArgsKey(args: Record<string, unknown>): string {
+  return JSON.stringify(args);
+}
+
+/**
+ * Fetch tool data for MCP App UIs.
+ *
+ * - Chat flow: uses `ontoolresult` when the host pushes structured content.
+ * - Home tiles: calls `app.callServerTool` directly (same pattern as system-health-agent).
+ */
+export function useTool<
+  T,
+  A extends Record<string, unknown> = Record<string, unknown>,
+>(name: string, args: A): UseToolResult<T> {
+  const app = useMcpApp();
+  const mcpState = useMcpState<A, T>();
+  const argsKey = useMemo(() => stableArgsKey(args), [args]);
+
+  const hostResult =
+    mcpState.status === "tool-result"
+      ? (mcpState.toolResult as T | undefined)
+      : undefined;
+  const hostError =
+    mcpState.status === "error" ? (mcpState.error ?? "Tool failed") : null;
+
+  const [fetched, setFetched] = useState<UseToolResult<T>>({
+    data: hostResult ?? null,
+    loading: !hostResult && !hostError,
+    error: hostError,
+  });
+
+  useEffect(() => {
+    if (hostResult) {
+      setFetched({ data: hostResult, loading: false, error: null });
+      return;
+    }
+    if (hostError) {
+      setFetched({ data: null, loading: false, error: hostError });
+      return;
+    }
+    if (!app?.callServerTool) {
+      setFetched((prev) => ({ ...prev, loading: true, error: null }));
+      return;
+    }
+
+    let cancelled = false;
+    setFetched({ data: null, loading: true, error: null });
+
+    app
+      .callServerTool({ name, arguments: args })
+      .then((result) => {
+        if (cancelled) return;
+        const toolResult = result as ToolCallResult;
+        const toolErr = extractToolError(toolResult);
+        if (toolErr) {
+          setFetched({ data: null, loading: false, error: toolErr });
+          return;
+        }
+        setFetched({
+          data: (toolResult.structuredContent as T) ?? null,
+          loading: false,
+          error: null,
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setFetched({
+          data: null,
+          loading: false,
+          error: err instanceof Error ? err.message : "Tool call failed",
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [app, args, argsKey, hostError, hostResult, name]);
+
+  if (hostResult) {
+    return { data: hostResult, loading: false, error: null };
+  }
+  if (hostError) {
+    return { data: null, loading: false, error: hostError };
+  }
+  return fetched;
+}

--- a/magento/web/hooks/use-tool.ts
+++ b/magento/web/hooks/use-tool.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useMcpApp, useMcpState } from "@/context.tsx";
 
 interface ToolCallResult {
@@ -39,7 +39,12 @@ export function useTool<
 >(name: string, args: A): UseToolResult<T> {
   const app = useMcpApp();
   const mcpState = useMcpState<A, T>();
-  const argsKey = useMemo(() => stableArgsKey(args), [args]);
+  // Callers often build `args` inline, so its identity changes every render.
+  // The effect keys off the serialized value and reads the latest object from
+  // a ref — otherwise each setFetched rerender would refire the tool call.
+  const argsKey = stableArgsKey(args);
+  const argsRef = useRef(args);
+  argsRef.current = args;
 
   const hostResult =
     mcpState.status === "tool-result"
@@ -72,7 +77,7 @@ export function useTool<
     setFetched({ data: null, loading: true, error: null });
 
     app
-      .callServerTool({ name, arguments: args })
+      .callServerTool({ name, arguments: argsRef.current })
       .then((result) => {
         if (cancelled) return;
         const toolResult = result as ToolCallResult;
@@ -99,7 +104,7 @@ export function useTool<
     return () => {
       cancelled = true;
     };
-  }, [app, args, argsKey, hostError, hostResult, name]);
+  }, [app, argsKey, hostError, hostResult, name]);
 
   if (hostResult) {
     return { data: hostResult, loading: false, error: null };

--- a/magento/web/lib/utils.ts
+++ b/magento/web/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/magento/web/tools/cancellation-rate/index.tsx
+++ b/magento/web/tools/cancellation-rate/index.tsx
@@ -1,0 +1,95 @@
+import { Ban } from "lucide-react";
+import { StatusFrame } from "@/components/status-frame.tsx";
+import { MAGENTO_ACCENT, MAGENTO_ICON } from "@/constants.ts";
+import { useMcpState } from "@/context.tsx";
+import { useTool } from "@/hooks/use-tool.ts";
+
+const TOOL_NAME = "MAGENTO_CANCELLATION_RATE";
+
+type ReportPeriod = "today" | "7d" | "30d";
+
+interface CancellationRateInput {
+  period?: ReportPeriod;
+}
+
+interface CancellationRateOutput {
+  period: ReportPeriod;
+  canceled: number;
+  total: number;
+  rate: number;
+  startDate: string;
+  endDate: string;
+}
+
+const PERIOD_LABELS: Record<ReportPeriod, string> = {
+  today: "Hoje",
+  "7d": "Últimos 7 dias",
+  "30d": "Últimos 30 dias",
+};
+
+function fmt(n: number | undefined) {
+  return new Intl.NumberFormat("pt-BR").format(n ?? 0);
+}
+
+function fmtPercent(rate: number | undefined) {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "percent",
+    maximumFractionDigits: 1,
+  }).format(rate ?? 0);
+}
+
+export default function CancellationRatePage() {
+  const { toolInput } = useMcpState<
+    CancellationRateInput,
+    CancellationRateOutput
+  >();
+  const args: Record<string, unknown> = toolInput?.period
+    ? { period: toolInput.period }
+    : {};
+  const { data, loading, error } = useTool<CancellationRateOutput>(
+    TOOL_NAME,
+    args,
+  );
+
+  if (error) {
+    return <StatusFrame status="error" error={error} />;
+  }
+
+  if (loading || !data) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center bg-card">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <span className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
+          <span className="text-sm">Waiting for Magento response…</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="@container box-border flex min-h-0 w-full flex-1 flex-col items-center justify-center overflow-hidden bg-card p-3">
+      <div className="flex items-center gap-4">
+        <div
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md sm:h-12 sm:w-12"
+          style={{
+            backgroundColor: `${MAGENTO_ACCENT}33`,
+            color: MAGENTO_ICON,
+          }}
+        >
+          <Ban className="h-5 w-5 sm:h-6 sm:w-6" />
+        </div>
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <p className="text-[11px] text-muted-foreground sm:text-xs">
+            Taxa de cancelamento · {PERIOD_LABELS[data.period]}
+          </p>
+          <p className="text-2xl font-semibold tabular-nums @sm:text-3xl">
+            {fmtPercent(data.rate)}
+          </p>
+          <p className="text-[11px] text-muted-foreground sm:text-xs">
+            {fmt(data.canceled)} cancelados de {fmt(data.total)} pedidos
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/magento/web/tools/cancellation-rate/main.tsx
+++ b/magento/web/tools/cancellation-rate/main.tsx
@@ -1,0 +1,4 @@
+import { mountMcpApp } from "@/bootstrap.tsx";
+import CancellationRatePage from "./index.tsx";
+
+mountMcpApp(CancellationRatePage);

--- a/magento/web/tools/orders-sales-card/index.tsx
+++ b/magento/web/tools/orders-sales-card/index.tsx
@@ -1,0 +1,156 @@
+import { Clock, Timer, TrendingUp } from "lucide-react";
+import { StatusFrame } from "@/components/status-frame.tsx";
+import { MAGENTO_ACCENT, MAGENTO_ICON } from "@/constants.ts";
+import { useMcpState } from "@/context.tsx";
+import { useTool } from "@/hooks/use-tool.ts";
+import { cn } from "@/lib/utils.ts";
+
+const TOOL_NAME = "MAGENTO_ORDERS_SALES_CARD";
+
+type SalesPeriod = "today" | "last_1h" | "last_5min";
+
+interface SalesCard {
+  period: SalesPeriod;
+  orders: number;
+  totalValue: number;
+  date?: string;
+}
+
+interface SalesCardInput {
+  period?: SalesPeriod;
+}
+
+interface SalesCardOutput {
+  cards: SalesCard[];
+  currency: string;
+  truncated: boolean;
+}
+
+const PERIOD_LABELS: Record<SalesPeriod, string> = {
+  today: "Vendas hoje",
+  last_1h: "Última 1h",
+  last_5min: "Últimos 5 min",
+};
+
+const PERIOD_ICONS: Record<SalesPeriod, React.ReactNode> = {
+  today: <TrendingUp className="w-5 h-5" />,
+  last_1h: <Clock className="w-5 h-5" />,
+  last_5min: <Timer className="w-5 h-5" />,
+};
+
+const PERIOD_ORDER: SalesPeriod[] = ["today", "last_1h", "last_5min"];
+
+function fmt(n: number | undefined) {
+  return new Intl.NumberFormat("pt-BR").format(n ?? 0);
+}
+
+/** Magento grand_total is a decimal in currency units (not cents). */
+function fmtCurrency(value: number | undefined, currency: string) {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency,
+  }).format(value ?? 0);
+}
+
+function sortCards(cards: SalesCard[]): SalesCard[] {
+  const byPeriod = new Map(cards.map((card) => [card.period, card]));
+  return PERIOD_ORDER.flatMap((period) => {
+    const card = byPeriod.get(period);
+    return card ? [card] : [];
+  });
+}
+
+function SalesCardItem({
+  card,
+  currency,
+}: {
+  card: SalesCard;
+  currency: string;
+}) {
+  const { period, orders, totalValue, date } = card;
+  const ordersLine =
+    period === "today" && date
+      ? `${fmt(orders)} pedidos · ${date}`
+      : `${fmt(orders)} pedidos`;
+
+  return (
+    <div className="@container flex h-full min-h-0 min-w-0 flex-col rounded-xl border-0 bg-card p-3 sm:p-4">
+      <div className="flex h-full min-h-0 flex-1 items-center gap-3">
+        <div className="flex shrink-0 items-center justify-center">
+          <div
+            className="flex h-9 w-9 items-center justify-center rounded-md sm:h-10 sm:w-10"
+            style={{
+              backgroundColor: `${MAGENTO_ACCENT}33`,
+              color: MAGENTO_ICON,
+            }}
+          >
+            {PERIOD_ICONS[period]}
+          </div>
+        </div>
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col justify-center gap-0.5">
+          <p className="text-[11px] text-muted-foreground sm:text-xs">
+            {PERIOD_LABELS[period]}
+          </p>
+          <p className="text-base font-semibold tabular-nums truncate @sm:text-lg @md:text-xl">
+            {fmtCurrency(totalValue, currency)}
+          </p>
+          <p className="text-[11px] text-muted-foreground line-clamp-2 sm:text-xs">
+            {ordersLine}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function OrdersSalesCardPage() {
+  const { toolInput } = useMcpState<SalesCardInput, SalesCardOutput>();
+  const args: Record<string, unknown> = toolInput?.period
+    ? { period: toolInput.period }
+    : {};
+  const { data, loading, error } = useTool<SalesCardOutput>(TOOL_NAME, args);
+
+  if (error) {
+    return <StatusFrame status="error" error={error} />;
+  }
+
+  if (loading || !data) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center bg-card">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <span className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
+          <span className="text-sm">Waiting for Magento response…</span>
+        </div>
+      </div>
+    );
+  }
+
+  const cards = sortCards(data.cards ?? []);
+  const currency = data.currency || "BRL";
+  const equalSize = cards.length === 3;
+
+  return (
+    <div className="@container box-border flex min-h-0 w-full flex-1 flex-col overflow-hidden bg-card">
+      <div
+        className={cn(
+          "min-h-0 w-full gap-3 @md:gap-6",
+          equalSize
+            ? "grid grid-cols-1 @sm:grid-cols-3 @sm:grid-rows-[minmax(0,1fr)] @sm:flex-1"
+            : "flex min-h-0 flex-col @sm:flex-row @sm:flex-1",
+        )}
+      >
+        {cards.map((card) => (
+          <div
+            key={card.period}
+            className={cn(
+              "flex min-h-0 min-w-0 flex-col",
+              equalSize ? "@sm:h-full" : "@sm:flex-1",
+            )}
+          >
+            <SalesCardItem card={card} currency={currency} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/magento/web/tools/orders-sales-card/main.tsx
+++ b/magento/web/tools/orders-sales-card/main.tsx
@@ -1,0 +1,4 @@
+import { mountMcpApp } from "@/bootstrap.tsx";
+import OrdersSalesCardPage from "./index.tsx";
+
+mountMcpApp(OrdersSalesCardPage);

--- a/magento/web/tools/orders-timeline/index.tsx
+++ b/magento/web/tools/orders-timeline/index.tsx
@@ -1,0 +1,90 @@
+import { DollarSign } from "lucide-react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { StatusFrame } from "@/components/status-frame.tsx";
+import { MAGENTO_ACCENT } from "@/constants.ts";
+import { useTool } from "@/hooks/use-tool.ts";
+
+const TOOL_NAME = "MAGENTO_ORDERS_TIMELINE";
+
+interface HourBucket {
+  hour: string;
+  count: number;
+  totalValue: number;
+}
+
+interface OrdersTimelineOutput {
+  hours: HourBucket[];
+  date: string;
+  currency: string;
+  truncated: boolean;
+}
+
+function fmt(n: number | undefined) {
+  return new Intl.NumberFormat("pt-BR").format(n ?? 0);
+}
+
+export default function OrdersTimelinePage() {
+  const { data, loading, error } = useTool<
+    OrdersTimelineOutput,
+    Record<string, never>
+  >(TOOL_NAME, {});
+
+  if (error) {
+    return <StatusFrame status="error" error={error} />;
+  }
+
+  if (loading || !data) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <span className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
+          <span className="text-sm">Waiting for Magento response…</span>
+        </div>
+      </div>
+    );
+  }
+
+  const { hours } = data;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-2 pt-2 pb-1">
+      <p className="mb-3 shrink-0 text-base flex items-center gap-2">
+        <DollarSign className="w-4 h-4" />
+        Pedidos por hora
+      </p>
+      {hours.every((bucket) => bucket.count === 0) ? (
+        <p className="text-sm text-muted-foreground">
+          Nenhum pedido encontrado hoje.
+        </p>
+      ) : (
+        <div className="min-h-0 flex-1">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={hours}
+              margin={{ top: 8, right: 8, bottom: 0, left: 4 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+              <XAxis dataKey="hour" tick={{ fontSize: 11 }} interval={1} />
+              <YAxis tick={{ fontSize: 11 }} allowDecimals={false} />
+              <Tooltip formatter={(value: number) => [fmt(value), "Pedidos"]} />
+              <Bar
+                dataKey="count"
+                fill={MAGENTO_ACCENT}
+                radius={[4, 4, 0, 0]}
+                name="count"
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/magento/web/tools/orders-timeline/index.tsx
+++ b/magento/web/tools/orders-timeline/index.tsx
@@ -60,6 +60,11 @@ export default function OrdersTimelinePage() {
         <DollarSign className="w-4 h-4" />
         Pedidos por hora
       </p>
+      {data.truncated ? (
+        <p className="mb-2 shrink-0 text-[11px] text-muted-foreground">
+          Dados parciais — o volume de pedidos excedeu o limite de paginação.
+        </p>
+      ) : null}
       {hours.every((bucket) => bucket.count === 0) ? (
         <p className="text-sm text-muted-foreground">
           Nenhum pedido encontrado hoje.

--- a/magento/web/tools/orders-timeline/main.tsx
+++ b/magento/web/tools/orders-timeline/main.tsx
@@ -1,0 +1,4 @@
+import { mountMcpApp } from "@/bootstrap.tsx";
+import OrdersTimelinePage from "./index.tsx";
+
+mountMcpApp(OrdersTimelinePage);

--- a/magento/web/tools/status-breakdown/index.tsx
+++ b/magento/web/tools/status-breakdown/index.tsx
@@ -73,13 +73,22 @@ export default function StatusBreakdownPage() {
         <ChartPie className="w-4 h-4" />
         Pedidos por status · {PERIOD_LABELS[data.period]}
       </p>
+      {data.truncated ? (
+        <p className="mb-2 shrink-0 text-[11px] text-muted-foreground">
+          Dados parciais — o volume de pedidos excedeu o limite de paginação.
+        </p>
+      ) : null}
       {statuses.length === 0 ? (
         <p className="text-sm text-muted-foreground">
           Nenhum pedido no período.
         </p>
       ) : (
         <div className="flex min-h-0 flex-1 items-center gap-3">
-          <div className="h-full min-h-0 flex-1">
+          <div
+            className="h-full min-h-0 flex-1"
+            role="img"
+            aria-label={`Gráfico de pizza da distribuição de ${fmt(data.total)} pedidos por status`}
+          >
             <ResponsiveContainer width="100%" height="100%">
               <PieChart>
                 <Tooltip

--- a/magento/web/tools/status-breakdown/index.tsx
+++ b/magento/web/tools/status-breakdown/index.tsx
@@ -1,0 +1,138 @@
+import { ChartPie } from "lucide-react";
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+import { StatusFrame } from "@/components/status-frame.tsx";
+import { MAGENTO_CHART_COLORS } from "@/constants.ts";
+import { useMcpState } from "@/context.tsx";
+import { useTool } from "@/hooks/use-tool.ts";
+
+const TOOL_NAME = "MAGENTO_STATUS_BREAKDOWN";
+
+type ReportPeriod = "today" | "7d" | "30d";
+
+interface StatusBucket {
+  status: string;
+  count: number;
+  totalValue: number;
+}
+
+interface StatusBreakdownInput {
+  period?: ReportPeriod;
+}
+
+interface StatusBreakdownOutput {
+  statuses: StatusBucket[];
+  total: number;
+  period: ReportPeriod;
+  currency: string;
+  truncated: boolean;
+}
+
+const PERIOD_LABELS: Record<ReportPeriod, string> = {
+  today: "hoje",
+  "7d": "últimos 7 dias",
+  "30d": "últimos 30 dias",
+};
+
+function fmt(n: number | undefined) {
+  return new Intl.NumberFormat("pt-BR").format(n ?? 0);
+}
+
+export default function StatusBreakdownPage() {
+  const { toolInput } = useMcpState<
+    StatusBreakdownInput,
+    StatusBreakdownOutput
+  >();
+  const args: Record<string, unknown> = toolInput?.period
+    ? { period: toolInput.period }
+    : {};
+  const { data, loading, error } = useTool<StatusBreakdownOutput>(
+    TOOL_NAME,
+    args,
+  );
+
+  if (error) {
+    return <StatusFrame status="error" error={error} />;
+  }
+
+  if (loading || !data) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center bg-card">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <span className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
+          <span className="text-sm">Waiting for Magento response…</span>
+        </div>
+      </div>
+    );
+  }
+
+  const statuses = data.statuses ?? [];
+
+  return (
+    <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden bg-card px-2 pt-2 pb-1">
+      <p className="mb-2 shrink-0 text-base flex items-center gap-2">
+        <ChartPie className="w-4 h-4" />
+        Pedidos por status · {PERIOD_LABELS[data.period]}
+      </p>
+      {statuses.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Nenhum pedido no período.
+        </p>
+      ) : (
+        <div className="flex min-h-0 flex-1 items-center gap-3">
+          <div className="h-full min-h-0 flex-1">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Tooltip
+                  formatter={(value: number, name: string) => [
+                    `${fmt(value)} pedidos`,
+                    name,
+                  ]}
+                />
+                <Pie
+                  data={statuses}
+                  dataKey="count"
+                  nameKey="status"
+                  innerRadius="55%"
+                  outerRadius="90%"
+                  paddingAngle={2}
+                  stroke="none"
+                >
+                  {statuses.map((bucket, index) => (
+                    <Cell
+                      key={bucket.status}
+                      fill={
+                        MAGENTO_CHART_COLORS[
+                          index % MAGENTO_CHART_COLORS.length
+                        ]
+                      }
+                    />
+                  ))}
+                </Pie>
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+          <ul className="flex max-h-full min-w-0 flex-col gap-1 overflow-y-auto pr-1">
+            {statuses.map((bucket, index) => (
+              <li
+                key={bucket.status}
+                className="flex items-center gap-2 text-xs"
+              >
+                <span
+                  className="h-2.5 w-2.5 shrink-0 rounded-sm"
+                  style={{
+                    backgroundColor:
+                      MAGENTO_CHART_COLORS[index % MAGENTO_CHART_COLORS.length],
+                  }}
+                />
+                <span className="truncate">{bucket.status}</span>
+                <span className="ml-auto tabular-nums text-muted-foreground">
+                  {fmt(bucket.count)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/magento/web/tools/status-breakdown/main.tsx
+++ b/magento/web/tools/status-breakdown/main.tsx
@@ -1,0 +1,4 @@
+import { mountMcpApp } from "@/bootstrap.tsx";
+import StatusBreakdownPage from "./index.tsx";
+
+mountMcpApp(StatusBreakdownPage);

--- a/magento/web/tools/top-products/index.tsx
+++ b/magento/web/tools/top-products/index.tsx
@@ -1,0 +1,119 @@
+import { Trophy } from "lucide-react";
+import { StatusFrame } from "@/components/status-frame.tsx";
+import { MAGENTO_ACCENT } from "@/constants.ts";
+import { useMcpState } from "@/context.tsx";
+import { useTool } from "@/hooks/use-tool.ts";
+
+const TOOL_NAME = "MAGENTO_TOP_PRODUCTS";
+
+type ReportPeriod = "today" | "7d" | "30d";
+
+interface TopProduct {
+  sku: string;
+  name: string;
+  quantity: number;
+  revenue: number;
+  orders: number;
+}
+
+interface TopProductsInput {
+  period?: ReportPeriod;
+  limit?: number;
+}
+
+interface TopProductsOutput {
+  products: TopProduct[];
+  period: ReportPeriod;
+  currency: string;
+  truncated: boolean;
+}
+
+const PERIOD_LABELS: Record<ReportPeriod, string> = {
+  today: "hoje",
+  "7d": "últimos 7 dias",
+  "30d": "últimos 30 dias",
+};
+
+function fmt(n: number | undefined) {
+  return new Intl.NumberFormat("pt-BR").format(n ?? 0);
+}
+
+function fmtCurrency(value: number | undefined, currency: string) {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 0,
+  }).format(value ?? 0);
+}
+
+export default function TopProductsPage() {
+  const { toolInput } = useMcpState<TopProductsInput, TopProductsOutput>();
+  const args: Record<string, unknown> = {
+    ...(toolInput?.period ? { period: toolInput.period } : {}),
+    ...(toolInput?.limit ? { limit: toolInput.limit } : {}),
+  };
+  const { data, loading, error } = useTool<TopProductsOutput>(TOOL_NAME, args);
+
+  if (error) {
+    return <StatusFrame status="error" error={error} />;
+  }
+
+  if (loading || !data) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center bg-card">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <span className="w-4 h-4 border-2 border-muted border-t-primary rounded-full animate-spin" />
+          <span className="text-sm">Waiting for Magento response…</span>
+        </div>
+      </div>
+    );
+  }
+
+  const products = data.products ?? [];
+  const currency = data.currency || "BRL";
+  const maxQuantity = Math.max(1, ...products.map((p) => p.quantity));
+
+  return (
+    <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden bg-card px-2 pt-2 pb-1">
+      <p className="mb-3 shrink-0 text-base flex items-center gap-2">
+        <Trophy className="w-4 h-4" />
+        Top produtos · {PERIOD_LABELS[data.period]}
+      </p>
+      {products.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Nenhum pedido no período.
+        </p>
+      ) : (
+        <ol className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto pr-1">
+          {products.map((product, index) => (
+            <li key={product.sku} className="flex items-center gap-3">
+              <span className="w-5 shrink-0 text-right text-xs tabular-nums text-muted-foreground">
+                {index + 1}.
+              </span>
+              <div className="flex min-w-0 flex-1 flex-col gap-1">
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="truncate text-sm" title={product.name}>
+                    {product.name}
+                  </span>
+                  <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                    {fmt(product.quantity)} un ·{" "}
+                    {fmtCurrency(product.revenue, currency)}
+                  </span>
+                </div>
+                <div className="h-1.5 w-full rounded-full bg-muted">
+                  <div
+                    className="h-1.5 rounded-full"
+                    style={{
+                      width: `${Math.max(4, (product.quantity / maxQuantity) * 100)}%`,
+                      backgroundColor: MAGENTO_ACCENT,
+                    }}
+                  />
+                </div>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/magento/web/tools/top-products/index.tsx
+++ b/magento/web/tools/top-products/index.tsx
@@ -79,6 +79,11 @@ export default function TopProductsPage() {
         <Trophy className="w-4 h-4" />
         Top produtos · {PERIOD_LABELS[data.period]}
       </p>
+      {data.truncated ? (
+        <p className="mb-2 shrink-0 text-[11px] text-muted-foreground">
+          Dados parciais — o volume de pedidos excedeu o limite de paginação.
+        </p>
+      ) : null}
       {products.length === 0 ? (
         <p className="text-sm text-muted-foreground">
           Nenhum pedido no período.

--- a/magento/web/tools/top-products/main.tsx
+++ b/magento/web/tools/top-products/main.tsx
@@ -1,0 +1,4 @@
+import { mountMcpApp } from "@/bootstrap.tsx";
+import TopProductsPage from "./index.tsx";
+
+mountMcpApp(TopProductsPage);

--- a/magento/web/types.ts
+++ b/magento/web/types.ts
@@ -1,0 +1,17 @@
+export type McpStatus =
+  | "initializing"
+  | "connected"
+  | "tool-input"
+  | "tool-result"
+  | "tool-cancelled"
+  | "error";
+
+export interface McpState<TInput = unknown, TResult = unknown> {
+  status: McpStatus;
+  toolName?: string;
+  error?: string;
+  toolInput?: TInput;
+  toolResult?: TResult;
+}
+
+export const INITIAL_STATE: McpState = { status: "initializing" };

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "google-workspace",
     "grain",
     "hyperdx",
+    "magento",
     "mcp-studio",
     "meta-ads",
     "microsoft-teams",

--- a/registry.json
+++ b/registry.json
@@ -2498,6 +2498,55 @@
     }
   },
   {
+    "id": "deco/magento",
+    "title": "Magento Commerce",
+    "description": "MCP for Magento 2 REST APIs — live sales dashboard widgets (orders per hour, sales cards, cancellation rate, top products, status breakdown) plus curated tools for orders, catalog, customers, inventory and CMS.",
+    "is_public": true,
+    "_meta": {
+      "mcp.mesh": {
+        "verified": false,
+        "friendly_name": "Magento Commerce",
+        "short_description": "Manage Magento 2 stores and get live sales insights with dashboard widgets.",
+        "owner": "deco",
+        "has_remote": true,
+        "has_oauth": true,
+        "tags": [
+          "magento",
+          "adobe-commerce",
+          "ecommerce",
+          "orders",
+          "catalog",
+          "analytics",
+          "dashboard",
+          "api"
+        ],
+        "categories": [
+          "E-commerce"
+        ],
+        "readme": "The Magento Commerce MCP provides direct access to Magento 2 (Adobe Commerce) REST APIs for e-commerce operations, plus live analytics widgets for the studio home. It enables AI agents to search and inspect orders, invoices, shipments and credit memos, browse products and categories, look up customers and stock, and read CMS pages/blocks. Analytics tools aggregate the orders API into hourly sales timelines, revenue summary cards, cancellation rates, top selling products and status breakdowns — each with a rich UI widget. Works with any Magento 2 store via an integration token, including WAF-protected stores through a configurable origin header."
+      }
+    },
+    "server": {
+      "name": "magento",
+      "title": "Magento Commerce",
+      "description": "MCP for Magento 2 REST APIs — live sales dashboard widgets (orders per hour, sales cards, cancellation rate, top products, status breakdown) plus curated tools for orders, catalog, customers, inventory and CMS.",
+      "icons": [
+        {
+          "src": "https://github.com/magento.png"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "HTTP",
+          "url": "https://sites-magento.deco.site/mcp",
+          "name": "magento",
+          "title": "Magento Commerce",
+          "description": "MCP for Magento 2 REST APIs — live sales dashboard widgets (orders per hour, sales cards, cancellation rate, top products, status breakdown) plus curated tools for orders, catalog, customers, inventory and CMS."
+        }
+      ]
+    }
+  },
+  {
     "id": "deco/mcp-registry",
     "title": "MCP Registry",
     "description": "A registry translation server that normalizes third-party MCP registries into this system's format. When no external registry URL is supplied, the server automatically falls back to the official MCP store.",


### PR DESCRIPTION
## O que é

Novo MCP **`magento/`** espelhando a arquitetura do `vtex/` (withRuntime tools + MCP App UI resources), para gerenciar lojas Magento 2 e dar insights de vendas direto no home do Studio.

## Widgets (MCP App UI, React + Recharts)

| Tool | Widget |
|---|---|
| `MAGENTO_ORDERS_TIMELINE` | Pedidos por hora (barras, hoje, 24 buckets no fuso da loja) |
| `MAGENTO_ORDERS_SALES_CARD` | Vendas hoje / Última 1h / Últimos 5 min (cards) |
| `MAGENTO_CANCELLATION_RATE` | Taxa de cancelamento (hoje/7d/30d) |
| `MAGENTO_TOP_PRODUCTS` | Top produtos vendidos por quantidade + receita |
| `MAGENTO_STATUS_BREAKDOWN` | Donut de pedidos por status |

Todos agregam o `/V1/orders` no servidor (paginação `pageSize=500`/`maxPages=20` com flag `truncated`; janelas timezone-safe UTC↔fuso via Intl; `grand_total` em unidades de moeda — sem /100 como no VTEX).

## Tools genéricos (16, read-only)

Orders, invoices, shipments, creditmemos, products, categories, customers, stock items, CMS pages/blocks e store configs (smoke test de auth). Escritos à mão com schema de filtros limpo (`filters: [{field, value, conditionType}]`) em vez dos params bracket-indexed do swagger do Magento, que geram schemas inutilizáveis para LLM.

## Config (state)

`baseUrl`, `apiToken` (Bearer integration token), `storeCode`, `currencyCode`, `timezone` e `originHeader`/`extraHeaders` para lojas atrás de WAF (caso Granado: Cloudflare exige `x-origin-header` secreto).

## Validação

- 26 testes unitários (`bun test`): janelas de tempo (edges de meia-noite), searchCriteria, paginação/truncation, agregações
- `tsc --noEmit` e `oxlint` limpos
- E2E local via JSON-RPC: `tools/list` com os 5 bindings `_meta.ui.resourceUri`, `resources/read` servindo os bundles `text/html;profile=mcp-app`, erro claro sem credenciais
- Integração real com a Granado pendente do secret do WAF (`x-origin-header`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `magento` MCP for Magento 2 with sales dashboard widgets and curated read-only tools. It now shows DST-safe order analytics in Studio via an MCP App UI (React + Recharts), mirrors the `vtex` MCP structure, and improves accessibility and developer ergonomics.

- **New Features**
  - MCP server with `@decocms/runtime` and public MCP App resources; deploy target in `deploy.json` (`magento`, entrypoint `./dist/server/main.js`).
  - 5 analytics widgets backed by `/V1/orders`: hourly orders timeline, sales cards (today/1h/5m), cancellation rate, top products, and status breakdown.
  - 16 read-only REST tools (orders, catalog, customers, inventory, CMS, configs) using a clean `filters` array mapped to Magento `searchCriteria`.
  - DST-safe windows (UTC ↔ store tz via Intl), paginated fetch (`pageSize=500`, max 20 pages) with a `truncated` flag; top products count distinct orders per SKU; money uses currency units.
  - Resilient client with retries and WAF header support (`originHeader`, `extraHeaders`); tests cover DST windows, searchCriteria, pagination, and aggregations; type and lint checks pass.

- **Bug Fixes**
  - Correct 7d/30d ranges across DST by resolving true local midnight; widgets surface `truncated`.
  - MCP App: `useTool` effect keyed by serialized args to avoid refires; status donut has aria-label; error/cancelled cards use role=alert; StatusFrame layout deduped.
  - Vite warns on unknown `MCP_APP_ENTRY`.

<sup>Written for commit 0bb94440fdc5c40d868dd088bb17b9cb55f0fa04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

