### PR TITLE
feat(tanstack-migrator): Fresh→TanStack migration orchestrator MCP

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -981,6 +981,37 @@
         "typescript": "^5.7.2",
       },
     },
+    "tanstack-migrator": {
+      "name": "tanstack-migrator",
+      "version": "0.1.0",
+      "dependencies": {
+        "@decocms/runtime": "^1.6.2",
+        "@modelcontextprotocol/ext-apps": "^1.1.2",
+        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@supabase/supabase-js": "^2.47.10",
+        "@tailwindcss/vite": "^4.2.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.576.0",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "tailwind-merge": "^3.5.0",
+        "tailwindcss": "^4.2.1",
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260206.0",
+        "@decocms/mcps-shared": "1.0.0",
+        "@types/bun": "^1.2.14",
+        "@types/react": "^19.2.2",
+        "@types/react-dom": "^19.2.2",
+        "@vitejs/plugin-react": "^5.0.4",
+        "concurrently": "^9.2.1",
+        "deco-cli": "^0.28.0",
+        "typescript": "^5.7.2",
+        "vite": "^7.3.1",
+        "vite-plugin-singlefile": "^2.3.0",
+      },
+    },
     "template-minimal": {
       "name": "mcp-template-minimal",
       "version": "1.0.0",
@@ -3504,6 +3535,8 @@
 
     "tailwindcss": ["tailwindcss@4.3.1", "", {}, "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q=="],
 
+    "tanstack-migrator": ["tanstack-migrator@workspace:tanstack-migrator"],
+
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
     "terser": ["terser@5.34.0", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.8.2", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-y5NUX+U9HhVsK/zihZwoq4r9dICLyV2jXGOriDAVOeKhq3LKVjgJbGO90FisozXLlJfvjHqgckGmJFBb9KYoWQ=="],
@@ -4398,6 +4431,14 @@
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
+    "tanstack-migrator/@decocms/runtime": ["@decocms/runtime@1.6.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.10", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.29.0", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-r6O4z+ISJpBnhDw4x1K8IYNqfQ+xdwSjNcg6vDqU42I6x82H8snfAg/E6u9WfcMClap7sXxMAdKuDcEMxPq55A=="],
+
+    "tanstack-migrator/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "tanstack-migrator/vite": ["vite@7.3.5", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww=="],
+
+    "tanstack-migrator/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "tiktok-ads/@decocms/runtime": ["@decocms/runtime@1.1.3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-pj6OccmpWulMjyOt9FHTNX41xHk800uzhmoYK/xq9h1f+DfDBMqyOZnt70Zmwrab7dMDO2w3VQD+NlgFKtrw1w=="],
@@ -4985,6 +5026,12 @@
     "strapi/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.4.9", "", { "dependencies": { "@decocms/mcp-utils": "^1.0.5", "@modelcontextprotocol/sdk": "1.29.0", "@tanstack/react-router": "1.169.2", "react": "^19.2.6", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-NvhuHsKL0YpSUaAZqEe0PAzF41/JJSi+H0X7HpMBScOVpALcGqAC+DaJvcKeo3aRXXW7z6du0oCdkhLf2A6Vjw=="],
 
     "strapi/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "tanstack-migrator/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.4.9", "", { "dependencies": { "@decocms/mcp-utils": "^1.0.5", "@modelcontextprotocol/sdk": "1.29.0", "@tanstack/react-router": "1.169.2", "react": "^19.2.6", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-NvhuHsKL0YpSUaAZqEe0PAzF41/JJSi+H0X7HpMBScOVpALcGqAC+DaJvcKeo3aRXXW7z6du0oCdkhLf2A6Vjw=="],
+
+    "tanstack-migrator/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
+
+    "tanstack-migrator/vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "tiktok-ads/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.4.9", "", { "dependencies": { "@decocms/mcp-utils": "^1.0.5", "@modelcontextprotocol/sdk": "1.29.0", "@tanstack/react-router": "1.169.2", "react": "^19.2.6", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-NvhuHsKL0YpSUaAZqEe0PAzF41/JJSi+H0X7HpMBScOVpALcGqAC+DaJvcKeo3aRXXW7z6du0oCdkhLf2A6Vjw=="],
 
@@ -5710,6 +5757,60 @@
 
     "strapi/@decocms/runtime/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 
+    "tanstack-migrator/@decocms/runtime/@decocms/bindings/@tanstack/react-router": ["@tanstack/react-router@1.169.2", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.169.2", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-OJM7Kguc7ERnweaNRWsyWgIKcl3z23rD1B4jaxjzd9RGdnzpt2HfrWa9rggbT0Hfzhfo4D2ZmsfoTme035tniQ=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "tanstack-migrator/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
     "tiktok-ads/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "tiktok-ads/@decocms/runtime/@decocms/bindings/@tanstack/react-router": ["@tanstack/react-router@1.169.2", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.169.2", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-OJM7Kguc7ERnweaNRWsyWgIKcl3z23rD1B4jaxjzd9RGdnzpt2HfrWa9rggbT0Hfzhfo4D2ZmsfoTme035tniQ=="],
@@ -6305,6 +6406,10 @@
     "strapi/@decocms/runtime/@decocms/bindings/@tanstack/react-router/@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
 
     "strapi/@decocms/runtime/@decocms/bindings/@tanstack/react-router/@tanstack/router-core": ["@tanstack/router-core@1.169.2", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-5sm0DJF1A7Mz+9gy4Gz/lLovNailK3yot4vYvz9MkBUPw26uLnhQiR8hSCYxucjE0wD6Mdlc5l+Z0/XTlZ7xHw=="],
+
+    "tanstack-migrator/@decocms/runtime/@decocms/bindings/@tanstack/react-router/@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
+
+    "tanstack-migrator/@decocms/runtime/@decocms/bindings/@tanstack/react-router/@tanstack/router-core": ["@tanstack/router-core@1.169.2", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-5sm0DJF1A7Mz+9gy4Gz/lLovNailK3yot4vYvz9MkBUPw26uLnhQiR8hSCYxucjE0wD6Mdlc5l+Z0/XTlZ7xHw=="],
 
     "tiktok-ads/@decocms/runtime/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 

--- a/deploy.json
+++ b/deploy.json
@@ -466,5 +466,14 @@
       "google-analytics/**",
       "shared/**"
     ]
+  },
+  "tanstack-migrator": {
+    "site": "tanstack-migrator",
+    "entrypoint": "./dist/server/main.js",
+    "platformName": "kubernetes-bun",
+    "watch": [
+      "tanstack-migrator/**",
+      "shared/**"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "slack-mcp",
     "sora",
     "strapi",
+    "tanstack-migrator",
     "template-minimal",
     "tiktok-ads",
     "veo",

--- a/tanstack-migrator/.gitignore
+++ b/tanstack-migrator/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+*.local

--- a/tanstack-migrator/README.md
+++ b/tanstack-migrator/README.md
@@ -1,0 +1,58 @@
+# TanStack Migrator MCP
+
+Orquestrador autônomo de migrações **Fresh/Deno → TanStack Start** para storefronts deco, com dashboard (MCP App) para acompanhar fila, paridade e sites 100% TanStack.
+
+## Como funciona
+
+```
+cadastro (UI) → fila FIFO (1-2 slots)
+  → creating_repo         cria deco-sites/<name>-tanstack + grant de push (MINT_REPO_TOKEN)
+  → provisioning_sandbox  VM_START no mesh (mesmo caminho do agentic CMS)
+  → migrating             sessão decopilot (claude-code) roda scripts/migrate.ts do @decocms/start,
+                          corrige build, push inicial, bun dev de pé
+  → installing_sync       instala .github/workflows/sync-decofile.yml (conteúdo .deco da produção, cron 30min)
+  → validating            loop: @decocms/parity run --prod <prod> --cand <preview> → agente corrige topIssues
+                          → para em score ≥ alvo (95) ou N iterações sem melhora → needs_human
+  → deploying_cf          cria projeto Workers Builds git-connected (push = deploy)
+  → done 🎉
+```
+
+- **% de progresso = `verdict.score` da parity CLI** (heatmaps, seções faltando, hydration, purchase flow).
+- Relatórios (report.html + heatmaps) sobem para o object storage via presigned PUT e abrem na UI.
+- Todo estado vive no Supabase (`sitemig_*`) — o worker retoma de onde parou após restart do pod.
+- Watchdog: 30min sem progresso → `failed` e o slot é liberado.
+
+## Estado / instalação
+
+| Campo | Uso |
+|---|---|
+| `GITHUB` (binding `@deco/github-mcp`) | criar repos, push do workflow de sync, MINT_REPO_TOKEN |
+| `OBJECT_STORAGE` (binding, opcional) | artefatos da parity (report/heatmaps) |
+| `ANTHROPIC_API_KEY` | sessões claude-code + diff visual da parity |
+| `CLOUDFLARE_API_TOKEN` / `ACCOUNT_ID` | criar projeto Workers Builds |
+| `GITHUB_INSTALLATION_ID` | installation da GitHub App na org deco-sites |
+| `SANDBOX_PROVIDER` | `manual` (simulação end-to-end, default) ou `decopilot` (live) |
+| `MAX_CONCURRENT`, `PARITY_TARGET`, `MAX_ITERATIONS`, `NO_IMPROVE_LIMIT` | tuning da fila/loop |
+| `MESH_API_KEY` | opcional — sem ele o MCP minta uma API key persistente sozinho no install (onChange) |
+
+## Primeira vez
+
+1. Aplicar `migrations/001_sitemig.sql` no projeto Supabase compartilhado dos MCPs.
+2. Instalar o MCP no studio, conectar o GitHub (binding) e preencher o state.
+3. Abrir a tool `TANSTACK_MIGRATOR_DASHBOARD` → cadastrar sites.
+4. Com `SANDBOX_PROVIDER=manual` dá pra demonstrar o fluxo inteiro sem efeitos externos.
+
+## Dev
+
+```bash
+bun run dev        # server (porta 8001) + vite build --watch da UI
+bun test           # testes das funções puras (prompts, summary, grants...)
+bun run check      # tsc --noEmit
+bun run build      # dist/client/dashboard.html + dist/server/main.js
+```
+
+## Verificações pendentes (modo live)
+
+- **Spike `/mcp/self`**: criação programática do projeto/virtualMcp bindado ao repo (pré-requisito do `VM_START`) e o `modelId` exato do provider claude-code (`MIGRATOR_DECOPILOT_MODEL` sobrescreve). Isolado em `server/sandbox/drivers/decopilot.ts`.
+- **Permissão `workflows`** da GitHub App para push do `sync-decofile.yml` (degrada para `needs_human` com instrução manual).
+- **Endpoint do Workers Builds** (`server/lib/cloudflare.ts`) — degrada para `needs_human` com instruções manuais.

--- a/tanstack-migrator/app.json
+++ b/tanstack-migrator/app.json
@@ -1,0 +1,28 @@
+{
+  "scopeName": "deco",
+  "name": "tanstack-migrator",
+  "friendlyName": "TanStack Migrator",
+  "connection": {
+    "type": "HTTP",
+    "url": "https://sites-tanstack-migrator.decocache.com/mcp"
+  },
+  "description": "Orchestrates migrations of Deco storefronts from Fresh/Deno to TanStack Start with an autonomous queue, parity validation and Cloudflare deploys.",
+  "icon": "https://assets.decocache.com/decochatweb/a1d17e0a-51bb-4a80-a209-de8b06017649/tanstack.png",
+  "unlisted": true,
+  "auth": {
+    "type": "token",
+    "header": "Authorization",
+    "prefix": "Bearer"
+  },
+  "bindings": {
+    "GITHUB": "@deco/github-mcp",
+    "OBJECT_STORAGE": "@deco/object-storage"
+  },
+  "metadata": {
+    "categories": ["Developer Tools"],
+    "official": false,
+    "tags": ["migration", "tanstack", "deco", "storefront", "parity"],
+    "short_description": "Autonomous Fresh → TanStack Start migration orchestrator",
+    "mesh_description": "The TanStack Migrator MCP orchestrates end-to-end migrations of Deco storefronts from Fresh/Deno to TanStack Start. **Key Features** - Register sites and let a FIFO queue drive each migration automatically. - Creates the -tanstack GitHub repository and installs the .deco content sync workflow. - Runs the @decocms/start migration script and an agent fix loop inside mesh sandboxes with Claude. - Validates visual/functional parity with the @decocms/parity CLI (score, heatmaps, missing sections) until the target score is reached. - Creates the Cloudflare Workers project with git integration for automatic deploys. **Use Cases** - Migrate a portfolio of Fresh storefronts to TanStack Start with minimal human effort, tracking progress percentage and parity reports in a dashboard."
+  }
+}

--- a/tanstack-migrator/dashboard.html
+++ b/tanstack-migrator/dashboard.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>TanStack Migrator</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./web/tools/dashboard/main.tsx"></script>
+	</body>
+</html>

--- a/tanstack-migrator/migrations/001_sitemig.sql
+++ b/tanstack-migrator/migrations/001_sitemig.sql
@@ -1,0 +1,142 @@
+-- TanStack Migrator MCP — schema.
+-- Holds per-connection mesh context plus the migration queue state machine.
+-- Tokens (mesh api key, GitHub refresh grants) are plaintext — the
+-- service-role-only RLS policy is the only protection. Never expose these
+-- tables directly via tools.
+
+-- ============================================================================
+-- sitemig_connections — per-connection mesh context snapshot (onChange)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS sitemig_connections (
+  connection_id   TEXT PRIMARY KEY,
+  organization_id TEXT NOT NULL,
+  mesh_url        TEXT NOT NULL,
+  mesh_token      TEXT,             -- last-seen request JWT (may expire)
+  mesh_api_key    TEXT,             -- durable org API key, preferred
+  state           JSONB,            -- persistable StateSchema values (bindings as {__type,value})
+  configured_at   TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  updated_at      TIMESTAMPTZ DEFAULT NOW() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sitemig_connections_org
+  ON sitemig_connections(organization_id);
+
+-- ============================================================================
+-- sitemig_sites — one row per site registered for migration (FIFO by created_at)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS sitemig_sites (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  connection_id       TEXT NOT NULL REFERENCES sitemig_connections(connection_id) ON DELETE CASCADE,
+  name                TEXT NOT NULL,                    -- slug, e.g. "granadobr"
+  source_repo         TEXT NOT NULL,                    -- "deco-sites/granadobr"
+  source_branch       TEXT NOT NULL DEFAULT 'main',
+  prod_url            TEXT NOT NULL,                    -- https://www.granado.com.br
+  target_repo         TEXT,                             -- "deco-sites/granadobr-tanstack"
+
+  -- state machine
+  status              TEXT NOT NULL DEFAULT 'queued',
+  -- queued | creating_repo | provisioning_sandbox | migrating | installing_sync
+  -- | validating | deploying_cf | done | needs_human | paused | failed | archived
+  phase_detail        TEXT,
+  error               TEXT,
+  needs_human_reason  TEXT,
+  resume_status       TEXT,                             -- status to resume into after paused
+
+  -- parity loop
+  parity_score        NUMERIC,
+  parity_target       INT NOT NULL DEFAULT 95,
+  max_iterations      INT NOT NULL DEFAULT 8,
+  no_improve_limit    INT NOT NULL DEFAULT 3,
+  iterations_done     INT NOT NULL DEFAULT 0,
+  no_improve_count    INT NOT NULL DEFAULT 0,
+  best_score          NUMERIC,
+
+  -- sandbox
+  sandbox_handle      TEXT,                             -- vmId from VM_START
+  sandbox_preview_url TEXT,
+  sandbox_session_id  TEXT,                             -- in-flight decopilot session marker
+  virtual_mcp_id      TEXT,                             -- mesh project/agent the sandbox belongs to
+
+  -- github grant (from MINT_REPO_TOKEN): re-mint ghs_ tokens without user login
+  gh_refresh_token    TEXT,
+  gh_token_endpoint   TEXT,
+  gh_client_id        TEXT,
+
+  -- cloudflare
+  cf_project_name     TEXT,
+  cf_deploy_url       TEXT,
+
+  -- worker lease (protects against double-processing during pod overlap)
+  lease_owner         TEXT,
+  lease_expires_at    TIMESTAMPTZ,
+
+  created_at          TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  updated_at          TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  started_at          TIMESTAMPTZ,
+  finished_at         TIMESTAMPTZ,
+  last_progress_at    TIMESTAMPTZ,                      -- watchdog input
+
+  UNIQUE (connection_id, source_repo)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sitemig_sites_status
+  ON sitemig_sites(status, created_at);
+CREATE INDEX IF NOT EXISTS idx_sitemig_sites_conn
+  ON sitemig_sites(connection_id);
+
+-- ============================================================================
+-- sitemig_runs — one row per phase attempt / parity iteration
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS sitemig_runs (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  site_id         UUID NOT NULL REFERENCES sitemig_sites(id) ON DELETE CASCADE,
+  kind            TEXT NOT NULL,     -- migrate | parity | fix_iteration | install_sync | deploy_cf
+  iteration       INT NOT NULL DEFAULT 0,
+  status          TEXT NOT NULL,     -- running | succeeded | failed
+  parity_score    NUMERIC,
+  summary         JSONB,             -- trimmed report.json: verdict, topIssues<=10, perPage pctDiff
+  artifact_prefix TEXT,              -- object-storage key prefix for report.html/json + heatmaps
+  logs_tail       TEXT,
+  started_at      TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  finished_at     TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_sitemig_runs_site
+  ON sitemig_runs(site_id, started_at DESC);
+
+-- ============================================================================
+-- sitemig_events — activity feed shown in the dashboard
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS sitemig_events (
+  id         BIGSERIAL PRIMARY KEY,
+  site_id    UUID REFERENCES sitemig_sites(id) ON DELETE CASCADE,
+  level      TEXT NOT NULL DEFAULT 'info',   -- info | warn | error
+  message    TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sitemig_events_site
+  ON sitemig_events(site_id, id DESC);
+
+-- ============================================================================
+-- RLS: service_role only, on every table
+-- ============================================================================
+ALTER TABLE sitemig_connections ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "service_role_all" ON sitemig_connections;
+CREATE POLICY "service_role_all" ON sitemig_connections
+  AS PERMISSIVE FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+ALTER TABLE sitemig_sites ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "service_role_all" ON sitemig_sites;
+CREATE POLICY "service_role_all" ON sitemig_sites
+  AS PERMISSIVE FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+ALTER TABLE sitemig_runs ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "service_role_all" ON sitemig_runs;
+CREATE POLICY "service_role_all" ON sitemig_runs
+  AS PERMISSIVE FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+ALTER TABLE sitemig_events ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "service_role_all" ON sitemig_events;
+CREATE POLICY "service_role_all" ON sitemig_events
+  AS PERMISSIVE FOR ALL TO service_role USING (true) WITH CHECK (true);

--- a/tanstack-migrator/package.json
+++ b/tanstack-migrator/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "tanstack-migrator",
+  "version": "0.1.0",
+  "description": "Orchestrates Fresh/Deno → TanStack Start storefront migrations: FIFO queue, mesh sandboxes running Claude, parity validation loop and Cloudflare deploy",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "concurrently -k -n api,web -c magenta,cyan \"bun run dev:api\" \"bun run dev:web\"",
+    "dev:api": "bun run --hot server/main.ts",
+    "dev:web": "MCP_APP_ENTRY=dashboard MCP_APP_EMPTY_OUTDIR=true vite build --watch",
+    "configure": "deco configure",
+    "check": "tsc --noEmit",
+    "build:web": "MCP_APP_ENTRY=dashboard MCP_APP_EMPTY_OUTDIR=true vite build",
+    "build:server": "NODE_ENV=production bun build server/main.ts --target=bun --outfile=dist/server/main.js",
+    "build": "bun run build:web && bun run build:server",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@decocms/runtime": "^1.6.2",
+    "@modelcontextprotocol/ext-apps": "^1.1.2",
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@supabase/supabase-js": "^2.47.10",
+    "@tailwindcss/vite": "^4.2.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.576.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "tailwind-merge": "^3.5.0",
+    "tailwindcss": "^4.2.1",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260206.0",
+    "@decocms/mcps-shared": "1.0.0",
+    "@types/bun": "^1.2.14",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.2",
+    "@vitejs/plugin-react": "^5.0.4",
+    "concurrently": "^9.2.1",
+    "deco-cli": "^0.28.0",
+    "typescript": "^5.7.2",
+    "vite": "^7.3.1",
+    "vite-plugin-singlefile": "^2.3.0"
+  }
+}

--- a/tanstack-migrator/server/constants.ts
+++ b/tanstack-migrator/server/constants.ts
@@ -1,0 +1,21 @@
+export const DASHBOARD_RESOURCE_URI = "ui://tanstack-migrator/dashboard";
+
+/** Worker cadence + safety rails. */
+export const TICK_INTERVAL_MS = 30_000;
+export const LEASE_TTL_MS = 2 * 60_000;
+/** No progress for this long while active → mark failed, release the slot. */
+export const WATCHDOG_STALL_MS = 30 * 60_000;
+
+/** Simulated phase duration used by the manual (simulation) sandbox driver. */
+export const SIMULATION_STEP_MS = 5_000;
+
+export const DEFAULT_GITHUB_ORG = "deco-sites";
+export const DEFAULT_CF_ACCOUNT_ID = "c95fc4cec7fc52453228d9db170c372c";
+
+export const DEFAULT_PARITY_TARGET = 95;
+export const DEFAULT_MAX_ITERATIONS = 8;
+export const DEFAULT_NO_IMPROVE_LIMIT = 3;
+export const DEFAULT_MAX_CONCURRENT = 1;
+
+/** Object-storage key prefix for parity artifacts. */
+export const ARTIFACT_ROOT = "tanstack-migrator";

--- a/tanstack-migrator/server/db/client.ts
+++ b/tanstack-migrator/server/db/client.ts
@@ -1,0 +1,42 @@
+/**
+ * Supabase client singleton for the `sitemig_*` tables.
+ *
+ * SECURITY: rows hold mesh API keys and GitHub refresh grants in plaintext;
+ * the service-role-only RLS policy is the only protection. Never expose raw
+ * rows through MCP tools — always map to safe shapes first.
+ */
+
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+let supabaseClient: SupabaseClient | null = null;
+
+export function getSupabaseClient(): SupabaseClient | null {
+  if (supabaseClient) return supabaseClient;
+
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_ANON_KEY;
+  if (!url || !key) return null;
+
+  try {
+    supabaseClient = createClient(url, key, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+    return supabaseClient;
+  } catch {
+    return null;
+  }
+}
+
+export function isSupabaseConfigured(): boolean {
+  return !!process.env.SUPABASE_URL && !!process.env.SUPABASE_ANON_KEY;
+}
+
+export function requireSupabase(): SupabaseClient {
+  const client = getSupabaseClient();
+  if (!client) {
+    throw new Error(
+      "Supabase not configured (SUPABASE_URL / SUPABASE_ANON_KEY missing)",
+    );
+  }
+  return client;
+}

--- a/tanstack-migrator/server/db/connections.ts
+++ b/tanstack-migrator/server/db/connections.ts
@@ -1,0 +1,61 @@
+/** CRUD for sitemig_connections — mesh context snapshots per connection. */
+
+import { requireSupabase } from "./client.ts";
+import type { ConnectionRow } from "./types.ts";
+
+export interface SaveConnectionInput {
+  connectionId: string;
+  organizationId: string;
+  meshUrl: string;
+  meshToken?: string;
+  meshApiKey?: string;
+  state?: Record<string, unknown>;
+}
+
+export async function saveConnection(
+  input: SaveConnectionInput,
+): Promise<void> {
+  const client = requireSupabase();
+  const now = new Date().toISOString();
+
+  const row: Partial<ConnectionRow> = {
+    connection_id: input.connectionId,
+    organization_id: input.organizationId,
+    mesh_url: input.meshUrl,
+    updated_at: now,
+  };
+  if (input.meshToken !== undefined) row.mesh_token = input.meshToken;
+  if (input.meshApiKey !== undefined) row.mesh_api_key = input.meshApiKey;
+  if (input.state !== undefined) row.state = input.state;
+
+  const { error } = await client
+    .from("sitemig_connections")
+    .upsert(row as Record<string, unknown>, { onConflict: "connection_id" });
+
+  if (error) throw new Error(`Failed to save connection: ${error.message}`);
+}
+
+export async function loadConnection(
+  connectionId: string,
+): Promise<ConnectionRow | null> {
+  const client = requireSupabase();
+  const { data, error } = await client
+    .from("sitemig_connections")
+    .select("*")
+    .eq("connection_id", connectionId)
+    .maybeSingle();
+
+  if (error) throw new Error(`Failed to load connection: ${error.message}`);
+  return (data as ConnectionRow | null) ?? null;
+}
+
+export async function loadAllConnections(): Promise<ConnectionRow[]> {
+  const client = requireSupabase();
+  const { data, error } = await client
+    .from("sitemig_connections")
+    .select("*")
+    .order("updated_at", { ascending: false });
+
+  if (error) throw new Error(`Failed to load connections: ${error.message}`);
+  return (data as ConnectionRow[]) ?? [];
+}

--- a/tanstack-migrator/server/db/events.ts
+++ b/tanstack-migrator/server/db/events.ts
@@ -1,0 +1,36 @@
+/** CRUD for sitemig_events — dashboard activity feed. Best-effort writes. */
+
+import { getSupabaseClient, requireSupabase } from "./client.ts";
+import type { EventRow } from "./types.ts";
+
+export async function addEvent(
+  siteId: string | null,
+  message: string,
+  level: "info" | "warn" | "error" = "info",
+): Promise<void> {
+  const client = getSupabaseClient();
+  if (!client) return;
+  try {
+    await client
+      .from("sitemig_events")
+      .insert({ site_id: siteId, level, message });
+  } catch {
+    // feed is best-effort; never fail a phase because of it
+  }
+}
+
+export async function listEventsForSite(
+  siteId: string,
+  limit = 50,
+): Promise<EventRow[]> {
+  const client = requireSupabase();
+  const { data, error } = await client
+    .from("sitemig_events")
+    .select("*")
+    .eq("site_id", siteId)
+    .order("id", { ascending: false })
+    .limit(limit);
+
+  if (error) throw new Error(`Failed to list events: ${error.message}`);
+  return (data as EventRow[]) ?? [];
+}

--- a/tanstack-migrator/server/db/runs.ts
+++ b/tanstack-migrator/server/db/runs.ts
@@ -1,0 +1,79 @@
+/** CRUD for sitemig_runs — one row per phase attempt / parity iteration. */
+
+import { requireSupabase } from "./client.ts";
+import type { ParitySummary, RunKind, RunRow, RunStatus } from "./types.ts";
+
+export async function createRun(input: {
+  siteId: string;
+  kind: RunKind;
+  iteration?: number;
+}): Promise<RunRow> {
+  const client = requireSupabase();
+  const { data, error } = await client
+    .from("sitemig_runs")
+    .insert({
+      site_id: input.siteId,
+      kind: input.kind,
+      iteration: input.iteration ?? 0,
+      status: "running",
+    })
+    .select("*")
+    .single();
+
+  if (error) throw new Error(`Failed to create run: ${error.message}`);
+  return data as RunRow;
+}
+
+export async function finishRun(
+  runId: string,
+  patch: {
+    status: RunStatus;
+    parityScore?: number;
+    summary?: ParitySummary;
+    artifactPrefix?: string;
+    logsTail?: string;
+  },
+): Promise<void> {
+  const client = requireSupabase();
+  const { error } = await client
+    .from("sitemig_runs")
+    .update({
+      status: patch.status,
+      parity_score: patch.parityScore ?? null,
+      summary: patch.summary ?? null,
+      artifact_prefix: patch.artifactPrefix ?? null,
+      logs_tail: patch.logsTail ?? null,
+      finished_at: new Date().toISOString(),
+    })
+    .eq("id", runId);
+
+  if (error) throw new Error(`Failed to finish run: ${error.message}`);
+}
+
+export async function getRun(runId: string): Promise<RunRow | null> {
+  const client = requireSupabase();
+  const { data, error } = await client
+    .from("sitemig_runs")
+    .select("*")
+    .eq("id", runId)
+    .maybeSingle();
+
+  if (error) throw new Error(`Failed to load run: ${error.message}`);
+  return (data as RunRow | null) ?? null;
+}
+
+export async function listRunsForSite(
+  siteId: string,
+  limit = 50,
+): Promise<RunRow[]> {
+  const client = requireSupabase();
+  const { data, error } = await client
+    .from("sitemig_runs")
+    .select("*")
+    .eq("site_id", siteId)
+    .order("started_at", { ascending: false })
+    .limit(limit);
+
+  if (error) throw new Error(`Failed to list runs: ${error.message}`);
+  return (data as RunRow[]) ?? [];
+}

--- a/tanstack-migrator/server/db/sites.ts
+++ b/tanstack-migrator/server/db/sites.ts
@@ -1,0 +1,167 @@
+/** CRUD + queue/lease operations for sitemig_sites. */
+
+import { requireSupabase } from "./client.ts";
+import { ACTIVE_STATUSES, type SiteRow, type SiteStatus } from "./types.ts";
+
+export interface RegisterSiteInput {
+  connectionId: string;
+  name: string;
+  sourceRepo: string;
+  sourceBranch?: string;
+  prodUrl: string;
+  targetRepo?: string;
+  parityTarget?: number;
+  maxIterations?: number;
+  /** Register an already-finished migration (e.g. granadobr-tanstack). */
+  status?: SiteStatus;
+}
+
+export async function insertSite(input: RegisterSiteInput): Promise<SiteRow> {
+  const client = requireSupabase();
+  const { data, error } = await client
+    .from("sitemig_sites")
+    .insert({
+      connection_id: input.connectionId,
+      name: input.name,
+      source_repo: input.sourceRepo,
+      source_branch: input.sourceBranch ?? "main",
+      prod_url: input.prodUrl,
+      target_repo: input.targetRepo ?? null,
+      status: input.status ?? "queued",
+      parity_target: input.parityTarget ?? 95,
+      max_iterations: input.maxIterations ?? 8,
+    })
+    .select("*")
+    .single();
+
+  if (error) {
+    if (error.code === "23505") {
+      throw new Error(`Site ${input.sourceRepo} is already registered`);
+    }
+    throw new Error(`Failed to register site: ${error.message}`);
+  }
+  return data as SiteRow;
+}
+
+export async function getSite(id: string): Promise<SiteRow | null> {
+  const client = requireSupabase();
+  const { data, error } = await client
+    .from("sitemig_sites")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) throw new Error(`Failed to load site: ${error.message}`);
+  return (data as SiteRow | null) ?? null;
+}
+
+export async function listSites(filter?: {
+  connectionId?: string;
+  statuses?: SiteStatus[];
+}): Promise<SiteRow[]> {
+  const client = requireSupabase();
+  let query = client
+    .from("sitemig_sites")
+    .select("*")
+    .order("created_at", { ascending: true });
+
+  if (filter?.connectionId) {
+    query = query.eq("connection_id", filter.connectionId);
+  }
+  if (filter?.statuses && filter.statuses.length > 0) {
+    query = query.in("status", filter.statuses);
+  }
+
+  const { data, error } = await query;
+  if (error) throw new Error(`Failed to list sites: ${error.message}`);
+  return (data as SiteRow[]) ?? [];
+}
+
+export async function updateSite(
+  id: string,
+  patch: Partial<SiteRow>,
+): Promise<SiteRow> {
+  const client = requireSupabase();
+  const { data, error } = await client
+    .from("sitemig_sites")
+    .update({ ...patch, updated_at: new Date().toISOString() })
+    .eq("id", id)
+    .select("*")
+    .single();
+
+  if (error) throw new Error(`Failed to update site: ${error.message}`);
+  return data as SiteRow;
+}
+
+/** Sites currently occupying a queue slot. */
+export async function listActiveSites(): Promise<SiteRow[]> {
+  return listSites({ statuses: ACTIVE_STATUSES });
+}
+
+export async function listQueuedSites(): Promise<SiteRow[]> {
+  return listSites({ statuses: ["queued"] });
+}
+
+/**
+ * Take (or renew) the per-site worker lease. Conditional update guarded by
+ * lease expiry — if another pod holds a live lease, returns null and the
+ * caller skips the site for this tick.
+ */
+export async function acquireLease(
+  siteId: string,
+  owner: string,
+  ttlMs: number,
+): Promise<SiteRow | null> {
+  const client = requireSupabase();
+  const now = new Date();
+  const expires = new Date(now.getTime() + ttlMs).toISOString();
+
+  // Renew own lease first (common case).
+  const renew = await client
+    .from("sitemig_sites")
+    .update({ lease_expires_at: expires, updated_at: now.toISOString() })
+    .eq("id", siteId)
+    .eq("lease_owner", owner)
+    .select("*");
+  if (renew.error) {
+    throw new Error(`Failed to renew lease: ${renew.error.message}`);
+  }
+  if (renew.data && renew.data.length > 0) return renew.data[0] as SiteRow;
+
+  // Steal free/expired leases.
+  const claim = await client
+    .from("sitemig_sites")
+    .update({
+      lease_owner: owner,
+      lease_expires_at: expires,
+      updated_at: now.toISOString(),
+    })
+    .eq("id", siteId)
+    .or(`lease_expires_at.is.null,lease_expires_at.lt.${now.toISOString()}`)
+    .select("*");
+  if (claim.error) {
+    throw new Error(`Failed to acquire lease: ${claim.error.message}`);
+  }
+  if (claim.data && claim.data.length > 0) return claim.data[0] as SiteRow;
+
+  return null;
+}
+
+/** Hard delete — runs/events cascade via FK. Frees the source_repo unique slot. */
+export async function deleteSite(id: string): Promise<void> {
+  const client = requireSupabase();
+  const { error } = await client.from("sitemig_sites").delete().eq("id", id);
+  if (error) throw new Error(`Failed to delete site: ${error.message}`);
+}
+
+export async function releaseLease(
+  siteId: string,
+  owner: string,
+): Promise<void> {
+  const client = requireSupabase();
+  await client
+    .from("sitemig_sites")
+    .update({ lease_owner: null, lease_expires_at: null })
+    .eq("id", siteId)
+    .eq("lease_owner", owner);
+}

--- a/tanstack-migrator/server/db/types.ts
+++ b/tanstack-migrator/server/db/types.ts
@@ -1,0 +1,152 @@
+/** Row types + status machine vocabulary for the sitemig_* tables. */
+
+export type SiteStatus =
+  | "queued"
+  | "creating_repo"
+  | "provisioning_sandbox"
+  | "migrating"
+  | "installing_sync"
+  | "validating"
+  | "deploying_cf"
+  | "done"
+  | "needs_human"
+  | "paused"
+  | "failed"
+  | "archived";
+
+/** Statuses that occupy a queue slot (count toward MAX_CONCURRENT). */
+export const ACTIVE_STATUSES: SiteStatus[] = [
+  "creating_repo",
+  "provisioning_sandbox",
+  "migrating",
+  "installing_sync",
+  "validating",
+  "deploying_cf",
+];
+
+/** Statuses a site can be resumed/retried from. */
+export const RESUMABLE_STATUSES: SiteStatus[] = [
+  "failed",
+  "needs_human",
+  "paused",
+];
+
+export const TERMINAL_STATUSES: SiteStatus[] = ["done", "archived"];
+
+export function isActiveStatus(status: string): boolean {
+  return (ACTIVE_STATUSES as string[]).includes(status);
+}
+
+export type RunKind =
+  | "migrate"
+  | "parity"
+  | "fix_iteration"
+  | "install_sync"
+  | "deploy_cf";
+
+export type RunStatus = "running" | "succeeded" | "failed";
+
+export interface ConnectionRow {
+  connection_id: string;
+  organization_id: string;
+  mesh_url: string;
+  mesh_token: string | null;
+  mesh_api_key: string | null;
+  state: Record<string, unknown> | null;
+  configured_at: string;
+  updated_at: string;
+}
+
+export interface SiteRow {
+  id: string;
+  connection_id: string;
+  name: string;
+  source_repo: string;
+  source_branch: string;
+  prod_url: string;
+  target_repo: string | null;
+
+  status: SiteStatus;
+  phase_detail: string | null;
+  error: string | null;
+  needs_human_reason: string | null;
+  resume_status: SiteStatus | null;
+
+  parity_score: number | null;
+  parity_target: number;
+  max_iterations: number;
+  no_improve_limit: number;
+  iterations_done: number;
+  no_improve_count: number;
+  best_score: number | null;
+
+  sandbox_handle: string | null;
+  sandbox_preview_url: string | null;
+  sandbox_session_id: string | null;
+  virtual_mcp_id: string | null;
+
+  gh_refresh_token: string | null;
+  gh_token_endpoint: string | null;
+  gh_client_id: string | null;
+
+  cf_project_name: string | null;
+  cf_deploy_url: string | null;
+
+  lease_owner: string | null;
+  lease_expires_at: string | null;
+
+  created_at: string;
+  updated_at: string;
+  started_at: string | null;
+  finished_at: string | null;
+  last_progress_at: string | null;
+}
+
+/** Trimmed parity report stored in sitemig_runs.summary (full report goes to object storage). */
+export interface ParitySummary {
+  verdict?: {
+    status: "pass" | "warn" | "fail";
+    score: number;
+    critical?: number;
+    high?: number;
+    medium?: number;
+    low?: number;
+  };
+  parityOk?: boolean;
+  topIssues?: Array<{
+    severity: string;
+    category?: string;
+    page?: string;
+    summary: string;
+    suggestedFix?: string;
+  }>;
+  perPage?: Array<{
+    pagePath: string;
+    viewport?: string;
+    pctDiff?: number;
+    verdict?: string;
+    sectionsOnlyInProd?: string[];
+  }>;
+}
+
+export interface RunRow {
+  id: string;
+  site_id: string;
+  kind: RunKind;
+  iteration: number;
+  status: RunStatus;
+  parity_score: number | null;
+  summary: ParitySummary | null;
+  artifact_prefix: string | null;
+  logs_tail: string | null;
+  started_at: string;
+  finished_at: string | null;
+}
+
+export interface EventRow {
+  id: number;
+  site_id: string | null;
+  level: "info" | "warn" | "error";
+  message: string;
+  created_at: string;
+}

--- a/tanstack-migrator/server/engine/inflight.ts
+++ b/tanstack-migrator/server/engine/inflight.ts
@@ -1,0 +1,50 @@
+/**
+ * In-process tracker for long-running sandbox sessions (migrate passes,
+ * parity iterations). The tick loop must never block on them: phases launch
+ * the work here and return; the promise updates the DB when it settles.
+ *
+ * Restart semantics: this map dies with the pod. Sites left with
+ * sandbox_session_id set and a stale last_progress_at are recovered by the
+ * watchdog (cleared + retried) — sessions themselves are bounded, so the
+ * worst case is redoing one iteration.
+ */
+
+export interface InflightEntry {
+  kind: string;
+  startedAt: number;
+}
+
+export class InflightTracker {
+  private entries = new Map<string, InflightEntry>();
+
+  has(siteId: string): boolean {
+    return this.entries.has(siteId);
+  }
+
+  get(siteId: string): InflightEntry | undefined {
+    return this.entries.get(siteId);
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+
+  /**
+   * Launch fire-and-forget work for a site. `fn` is responsible for all DB
+   * updates; failures must be handled inside it (this catch is a last resort).
+   */
+  start(siteId: string, kind: string, fn: () => Promise<void>): void {
+    if (this.entries.has(siteId)) return;
+    this.entries.set(siteId, { kind, startedAt: Date.now() });
+    fn()
+      .catch((err) => {
+        console.error(
+          `[inflight] unhandled error in ${kind} for site ${siteId}:`,
+          err instanceof Error ? err.message : err,
+        );
+      })
+      .finally(() => {
+        this.entries.delete(siteId);
+      });
+  }
+}

--- a/tanstack-migrator/server/engine/machine.ts
+++ b/tanstack-migrator/server/engine/machine.ts
@@ -1,0 +1,30 @@
+/** status → phase handler map. Every handler is idempotent per-tick. */
+
+import type { SiteRow, SiteStatus } from "../db/types.ts";
+import type { WorkerCtx } from "../lib/mesh.ts";
+import type { InflightTracker } from "./inflight.ts";
+import { creatingRepo } from "./phases/creating-repo.ts";
+import { deployingCf } from "./phases/deploying-cf.ts";
+import { installingSync } from "./phases/installing-sync.ts";
+import { migrating } from "./phases/migrating.ts";
+import { provisioningSandbox } from "./phases/provisioning-sandbox.ts";
+import { validating } from "./phases/validating.ts";
+
+export interface EngineDeps {
+  inflight: InflightTracker;
+}
+
+export type PhaseHandler = (
+  site: SiteRow,
+  ctx: WorkerCtx,
+  deps: EngineDeps,
+) => Promise<void>;
+
+export const PHASE_HANDLERS: Partial<Record<SiteStatus, PhaseHandler>> = {
+  creating_repo: creatingRepo,
+  provisioning_sandbox: provisioningSandbox,
+  migrating,
+  installing_sync: installingSync,
+  validating,
+  deploying_cf: deployingCf,
+};

--- a/tanstack-migrator/server/engine/phases/creating-repo.ts
+++ b/tanstack-migrator/server/engine/phases/creating-repo.ts
@@ -1,0 +1,90 @@
+/**
+ * Phase: creating_repo — create deco-sites/<name>-tanstack and mint the
+ * durable GitHub grant used by the sandbox for pushes.
+ */
+
+import { addEvent } from "../../db/events.ts";
+import type { SiteRow } from "../../db/types.ts";
+import { updateSite } from "../../db/sites.ts";
+import {
+  ensureRepo,
+  mintRepoGrant,
+  RepoCreatePermissionError,
+  targetRepoFor,
+} from "../../lib/github.ts";
+import type { WorkerCtx } from "../../lib/mesh.ts";
+import { isSimulation } from "../../sandbox/client.ts";
+
+export async function creatingRepo(
+  site: SiteRow,
+  ctx: WorkerCtx,
+): Promise<void> {
+  const targetRepo =
+    site.target_repo ?? targetRepoFor(site, ctx.config.githubOrg);
+
+  if (isSimulation(ctx)) {
+    await updateSite(site.id, {
+      target_repo: targetRepo,
+      status: "provisioning_sandbox",
+      phase_detail: `[simulação] repo ${targetRepo} criado`,
+      last_progress_at: new Date().toISOString(),
+    });
+    await addEvent(site.id, `[simulação] repo ${targetRepo} criado`);
+    return;
+  }
+
+  try {
+    await ensureRepo(ctx, targetRepo);
+  } catch (err) {
+    if (err instanceof RepoCreatePermissionError) {
+      await updateSite(site.id, {
+        target_repo: targetRepo,
+        status: "needs_human",
+        resume_status: "creating_repo",
+        needs_human_reason: `${err.message}. Crie o repo manualmente (gh repo create ${targetRepo} --private) OU dê à GitHub App da deco a permissão de Administration (write) na org, e use Retry.`,
+        last_progress_at: new Date().toISOString(),
+      });
+      await addEvent(
+        site.id,
+        "GitHub App sem permissão de criar repo — precisa de humano",
+        "warn",
+      );
+      return;
+    }
+    throw err;
+  }
+  await addEvent(site.id, `Repo ${targetRepo} garantido no GitHub`);
+
+  // The push grant is optional: the mesh sandbox gets git credentials synced
+  // for the virtualMcp's githubRepo connection (sync-git-credentials), so
+  // sessions can push without an embedded token. Mint only when configured.
+  let grantPatch: Partial<SiteRow> = {};
+  if (!site.gh_refresh_token && ctx.config.githubInstallationId) {
+    try {
+      const grant = await mintRepoGrant(ctx, targetRepo);
+      grantPatch = {
+        gh_refresh_token: grant.refreshToken ?? null,
+        gh_token_endpoint: grant.tokenEndpoint ?? null,
+        gh_client_id: grant.clientId ?? null,
+      };
+      await addEvent(
+        site.id,
+        "Grant de push do GitHub mintado (MINT_REPO_TOKEN)",
+      );
+    } catch (err) {
+      await addEvent(
+        site.id,
+        `Sem grant de push (${err instanceof Error ? err.message : err}) — o sandbox usará as credenciais git sincronizadas pelo mesh`,
+        "warn",
+      );
+    }
+  }
+
+  await updateSite(site.id, {
+    ...grantPatch,
+    target_repo: targetRepo,
+    status: "provisioning_sandbox",
+    phase_detail: "repo criado, provisionando sandbox",
+    last_progress_at: new Date().toISOString(),
+  });
+}

--- a/tanstack-migrator/server/engine/phases/deploying-cf.ts
+++ b/tanstack-migrator/server/engine/phases/deploying-cf.ts
@@ -1,0 +1,100 @@
+/**
+ * Phase: deploying_cf — create the Cloudflare Workers Builds project
+ * (git-connected: every push deploys automatically) and finish the migration.
+ * Degrades to needs_human with manual instructions when the API/token
+ * isn't available.
+ */
+
+import { addEvent } from "../../db/events.ts";
+import { createRun, finishRun } from "../../db/runs.ts";
+import { updateSite } from "../../db/sites.ts";
+import type { SiteRow } from "../../db/types.ts";
+import {
+  createWorkersBuildsProject,
+  manualCfInstructions,
+} from "../../lib/cloudflare.ts";
+import { parseRepo } from "../../lib/github.ts";
+import type { WorkerCtx } from "../../lib/mesh.ts";
+import { getDriver, isSimulation } from "../../sandbox/client.ts";
+
+async function finishMigration(
+  site: SiteRow,
+  ctx: WorkerCtx,
+  patch: Partial<SiteRow>,
+): Promise<void> {
+  await updateSite(site.id, {
+    ...patch,
+    status: "done",
+    phase_detail: "migração concluída",
+    finished_at: new Date().toISOString(),
+    last_progress_at: new Date().toISOString(),
+  });
+  await addEvent(site.id, "Migração concluída 🎉");
+  try {
+    await getDriver(ctx).destroy(site, ctx);
+  } catch {
+    // idle TTL will reap it anyway
+  }
+}
+
+export async function deployingCf(
+  site: SiteRow,
+  ctx: WorkerCtx,
+): Promise<void> {
+  if (!site.target_repo) throw new Error("target_repo not set");
+  const workerName = parseRepo(site.target_repo).repo;
+
+  if (isSimulation(ctx)) {
+    await finishMigration(site, ctx, {
+      cf_project_name: workerName,
+      cf_deploy_url: `https://${workerName}.deco-cx.workers.dev`,
+    });
+    return;
+  }
+
+  if (!ctx.config.cloudflareApiToken) {
+    await updateSite(site.id, {
+      status: "needs_human",
+      resume_status: "deploying_cf",
+      needs_human_reason: manualCfInstructions({
+        workerName,
+        repoFull: site.target_repo,
+      }),
+      last_progress_at: new Date().toISOString(),
+    });
+    await addEvent(
+      site.id,
+      "Sem CLOUDFLARE_API_TOKEN — criação do projeto CF é manual",
+      "warn",
+    );
+    return;
+  }
+
+  const run = await createRun({ siteId: site.id, kind: "deploy_cf" });
+  try {
+    const project = await createWorkersBuildsProject(ctx, {
+      workerName,
+      repoFull: site.target_repo,
+    });
+    await finishRun(run.id, { status: "succeeded" });
+    await addEvent(site.id, `Projeto CF criado: ${project.projectName}`);
+    await finishMigration(site, ctx, {
+      cf_project_name: project.projectName,
+      cf_deploy_url: project.deployUrl,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await finishRun(run.id, { status: "failed", logsTail: message });
+    await updateSite(site.id, {
+      status: "needs_human",
+      resume_status: "deploying_cf",
+      needs_human_reason: `${message}\n\n${manualCfInstructions({ workerName, repoFull: site.target_repo })}`,
+      last_progress_at: new Date().toISOString(),
+    });
+    await addEvent(
+      site.id,
+      `API da CF recusou (${message}) — criação manual`,
+      "warn",
+    );
+  }
+}

--- a/tanstack-migrator/server/engine/phases/installing-sync.ts
+++ b/tanstack-migrator/server/engine/phases/installing-sync.ts
@@ -1,0 +1,111 @@
+/**
+ * Phase: installing_sync — push the .deco content-sync workflow into the
+ * -tanstack repo (MCP-side, via the GITHUB binding): workflow yml + script
+ * shim + package.json script entry. Idempotent (putFile skips unchanged).
+ *
+ * Note: pushing .github/workflows/* requires the GitHub App to have
+ * workflows:write. When GitHub rejects, we degrade to needs_human with a
+ * clear reason instead of failing the whole migration.
+ */
+
+import { addEvent } from "../../db/events.ts";
+import { createRun, finishRun } from "../../db/runs.ts";
+import { updateSite } from "../../db/sites.ts";
+import type { SiteRow } from "../../db/types.ts";
+import { getFile, parseRepo, putFile } from "../../lib/github.ts";
+import type { WorkerCtx } from "../../lib/mesh.ts";
+import { isSimulation } from "../../sandbox/client.ts";
+import {
+  SYNC_PACKAGE_SCRIPT_NAME,
+  SYNC_SCRIPT_PATH,
+  SYNC_WORKFLOW_PATH,
+  syncPackageScriptCommand,
+  syncScriptSource,
+  syncWorkflowYaml,
+} from "../../sandbox/templates/sync-files.ts";
+
+export async function installingSync(
+  site: SiteRow,
+  ctx: WorkerCtx,
+): Promise<void> {
+  if (isSimulation(ctx)) {
+    await updateSite(site.id, {
+      status: "validating",
+      phase_detail: "[simulação] sync do .deco instalado",
+      last_progress_at: new Date().toISOString(),
+    });
+    await addEvent(site.id, "[simulação] workflow de sync do .deco instalado");
+    return;
+  }
+
+  if (!site.target_repo) throw new Error("target_repo not set");
+  const ref = parseRepo(site.target_repo);
+  const run = await createRun({ siteId: site.id, kind: "install_sync" });
+
+  try {
+    await putFile(ctx, ref, {
+      path: SYNC_SCRIPT_PATH,
+      content: syncScriptSource(),
+      message: "chore: add .deco sync script (tanstack-migrator)",
+    });
+
+    // package.json: read-modify-write to add the sync:decofile script
+    const pkgFile = await getFile(ctx, ref, "package.json");
+    if (pkgFile) {
+      try {
+        const pkg = JSON.parse(pkgFile.text) as {
+          scripts?: Record<string, string>;
+        };
+        const command = syncPackageScriptCommand(site.prod_url);
+        if (pkg.scripts?.[SYNC_PACKAGE_SCRIPT_NAME] !== command) {
+          pkg.scripts = { ...pkg.scripts, [SYNC_PACKAGE_SCRIPT_NAME]: command };
+          await putFile(ctx, ref, {
+            path: "package.json",
+            content: `${JSON.stringify(pkg, null, 2)}\n`,
+            message: "chore: add sync:decofile script (tanstack-migrator)",
+          });
+        }
+      } catch {
+        await addEvent(
+          site.id,
+          "package.json não parseável — script sync:decofile não adicionado",
+          "warn",
+        );
+      }
+    }
+
+    await putFile(ctx, ref, {
+      path: SYNC_WORKFLOW_PATH,
+      content: syncWorkflowYaml({ prodUrl: site.prod_url }),
+      message: "ci: sync .deco/blocks from production (tanstack-migrator)",
+    });
+
+    await finishRun(run.id, { status: "succeeded" });
+    await updateSite(site.id, {
+      status: "validating",
+      phase_detail: "sync do .deco instalado, iniciando loop de paridade",
+      last_progress_at: new Date().toISOString(),
+    });
+    await addEvent(site.id, "Workflow de sync do .deco instalado no repo");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await finishRun(run.id, { status: "failed", logsTail: message });
+
+    if (/workflow|permission|403|resource not accessible/i.test(message)) {
+      // App lacks workflows:write — a human installs the workflow, then resumes
+      await updateSite(site.id, {
+        status: "needs_human",
+        resume_status: "validating",
+        needs_human_reason: `GitHub recusou o push do workflow (${message}). Instale ${SYNC_WORKFLOW_PATH} manualmente no repo ${site.target_repo} e use SITE_RETRY para seguir para a validação.`,
+        last_progress_at: new Date().toISOString(),
+      });
+      await addEvent(
+        site.id,
+        "Push do workflow negado — precisa de humano",
+        "warn",
+      );
+      return;
+    }
+    throw err;
+  }
+}

--- a/tanstack-migrator/server/engine/phases/migrating.ts
+++ b/tanstack-migrator/server/engine/phases/migrating.ts
@@ -1,0 +1,99 @@
+/**
+ * Phase: migrating — one bounded session runs the @decocms/start migrate
+ * script (7 phases), fixes build/typecheck, pushes the initial commit and
+ * leaves `bun dev` up. Launched fire-and-forget via the inflight tracker;
+ * the tick loop keeps the sandbox TTL alive while it runs.
+ */
+
+import { addEvent } from "../../db/events.ts";
+import { createRun, finishRun } from "../../db/runs.ts";
+import { getSite, updateSite } from "../../db/sites.ts";
+import type { SiteRow } from "../../db/types.ts";
+import { ghsTokenForSite } from "../../lib/github.ts";
+import type { WorkerCtx } from "../../lib/mesh.ts";
+import { getDriver, isSimulation } from "../../sandbox/client.ts";
+import { migratePrompt } from "../../sandbox/templates/prompts.ts";
+import type { EngineDeps } from "../machine.ts";
+import { clearStaleSession, markSessionStart } from "./session-guard.ts";
+
+export async function migrating(
+  site: SiteRow,
+  ctx: WorkerCtx,
+  deps: EngineDeps,
+): Promise<void> {
+  if (deps.inflight.has(site.id)) return; // session running in this pod
+
+  const proceed = await clearStaleSession(site, deps);
+  if (!proceed) return; // another pod's session looks alive — just wait
+
+  const run = await createRun({ siteId: site.id, kind: "migrate" });
+  await markSessionStart(site.id, "migrate");
+  await addEvent(site.id, "Sessão de migração inicial iniciada");
+
+  deps.inflight.start(site.id, "migrate", async () => {
+    try {
+      let prompt = "";
+      if (!isSimulation(ctx)) {
+        const { token, grant } = await ghsTokenForSite(ctx, site);
+        if (grant?.refreshToken) {
+          await updateSite(site.id, {
+            gh_refresh_token: grant.refreshToken,
+            gh_token_endpoint: grant.tokenEndpoint ?? null,
+            gh_client_id: grant.clientId ?? null,
+          });
+        }
+        prompt = migratePrompt({
+          site,
+          ghToken: token,
+          anthropicApiKey: ctx.config.anthropicApiKey,
+        });
+      }
+
+      const result = await getDriver(ctx).runTask(site, ctx, {
+        kind: "migrate",
+        prompt,
+      });
+
+      const current = await getSite(site.id);
+      if (!current || current.status !== "migrating") return; // paused/changed meanwhile
+
+      if (result.ok) {
+        await finishRun(run.id, {
+          status: "succeeded",
+          logsTail: result.output,
+        });
+        await updateSite(site.id, {
+          status: "installing_sync",
+          phase_detail: "migração inicial concluída, instalando sync do .deco",
+          sandbox_session_id: null,
+          last_progress_at: new Date().toISOString(),
+        });
+        await addEvent(
+          site.id,
+          "Migração inicial concluída (build verde, push feito)",
+        );
+      } else {
+        await finishRun(run.id, {
+          status: "failed",
+          logsTail: result.output,
+        });
+        await updateSite(site.id, {
+          status: "failed",
+          error: result.error ?? "migração inicial falhou",
+          sandbox_session_id: null,
+          last_progress_at: new Date().toISOString(),
+        });
+        await addEvent(site.id, `Migração falhou: ${result.error}`, "error");
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await finishRun(run.id, { status: "failed", logsTail: message });
+      await updateSite(site.id, {
+        status: "failed",
+        error: message,
+        sandbox_session_id: null,
+      });
+      await addEvent(site.id, `Migração falhou: ${message}`, "error");
+    }
+  });
+}

--- a/tanstack-migrator/server/engine/phases/provisioning-sandbox.ts
+++ b/tanstack-migrator/server/engine/phases/provisioning-sandbox.ts
@@ -1,0 +1,38 @@
+/** Phase: provisioning_sandbox — VM_START (or simulation) for the target repo. */
+
+import { addEvent } from "../../db/events.ts";
+import { updateSite } from "../../db/sites.ts";
+import type { SiteRow } from "../../db/types.ts";
+import type { WorkerCtx } from "../../lib/mesh.ts";
+import { getDriver } from "../../sandbox/client.ts";
+
+export async function provisioningSandbox(
+  site: SiteRow,
+  ctx: WorkerCtx,
+): Promise<void> {
+  const driver = getDriver(ctx);
+
+  // Persist the project id BEFORE starting the sandbox — a failed start then
+  // retries against the same project instead of creating duplicates.
+  let current = site;
+  if (driver.prepareProject && !site.virtual_mcp_id) {
+    const { virtualMcpId } = await driver.prepareProject(site, ctx);
+    current = await updateSite(site.id, { virtual_mcp_id: virtualMcpId });
+    await addEvent(site.id, `Projeto mesh criado: ${virtualMcpId}`);
+  }
+
+  const info = await driver.ensure(current, ctx);
+
+  await updateSite(site.id, {
+    sandbox_handle: info.handle,
+    sandbox_preview_url: info.previewUrl,
+    virtual_mcp_id: info.virtualMcpId ?? site.virtual_mcp_id,
+    status: "migrating",
+    phase_detail: "sandbox de pé, iniciando migração",
+    last_progress_at: new Date().toISOString(),
+  });
+  await addEvent(
+    site.id,
+    `Sandbox provisionado (${driver.name}): ${info.handle}${info.previewUrl ? ` — preview ${info.previewUrl}` : ""}`,
+  );
+}

--- a/tanstack-migrator/server/engine/phases/session-guard.ts
+++ b/tanstack-migrator/server/engine/phases/session-guard.ts
@@ -1,0 +1,45 @@
+/**
+ * Cross-pod session guard. sandbox_session_id marks "a bounded session is
+ * (probably) running somewhere". This pod only relaunches when the marker is
+ * stale (no progress for WATCHDOG_STALL_MS) — otherwise it waits, since the
+ * session may belong to another pod during a rolling deploy.
+ */
+
+import { WATCHDOG_STALL_MS } from "../../constants.ts";
+import { addEvent } from "../../db/events.ts";
+import { updateSite } from "../../db/sites.ts";
+import type { SiteRow } from "../../db/types.ts";
+import type { EngineDeps } from "../machine.ts";
+
+/** @returns true when this pod may launch a new session for the site. */
+export async function clearStaleSession(
+  site: SiteRow,
+  deps: EngineDeps,
+): Promise<boolean> {
+  if (!site.sandbox_session_id) return true;
+  if (deps.inflight.has(site.id)) return false;
+
+  const lastProgress = Date.parse(
+    site.last_progress_at ?? site.updated_at ?? site.created_at,
+  );
+  const stale = Date.now() - lastProgress > WATCHDOG_STALL_MS;
+  if (!stale) return false;
+
+  await updateSite(site.id, { sandbox_session_id: null });
+  await addEvent(
+    site.id,
+    "Sessão anterior ficou sem progresso — relançando",
+    "warn",
+  );
+  return true;
+}
+
+export async function markSessionStart(
+  siteId: string,
+  kind: string,
+): Promise<void> {
+  await updateSite(siteId, {
+    sandbox_session_id: `${kind}:${Date.now()}`,
+    last_progress_at: new Date().toISOString(),
+  });
+}

--- a/tanstack-migrator/server/engine/phases/validating.ts
+++ b/tanstack-migrator/server/engine/phases/validating.ts
@@ -1,0 +1,216 @@
+/**
+ * Phase: validating — the parity loop. Each pass = one bounded session:
+ * run @decocms/parity (prod vs sandbox preview), upload artifacts to object
+ * storage via pre-minted presigned PUTs, fix the top issues, push, repeat.
+ *
+ * Stops when parity_score >= parity_target (→ deploying_cf) or when
+ * iterations run out / stop improving (→ needs_human).
+ */
+
+import { addEvent } from "../../db/events.ts";
+import { createRun, finishRun } from "../../db/runs.ts";
+import { getSite, updateSite } from "../../db/sites.ts";
+import type { ParitySummary, SiteRow } from "../../db/types.ts";
+import {
+  artifactKeys,
+  fetchReportSummary,
+  presignPutUrls,
+} from "../../lib/artifacts.ts";
+import { ghsTokenForSite } from "../../lib/github.ts";
+import type { WorkerCtx } from "../../lib/mesh.ts";
+import { getDriver, isSimulation } from "../../sandbox/client.ts";
+import { fixIterationPrompt } from "../../sandbox/templates/prompts.ts";
+import type { EngineDeps } from "../machine.ts";
+import { clearStaleSession, markSessionStart } from "./session-guard.ts";
+
+function simulatedSummary(score: number): ParitySummary {
+  return {
+    verdict: { status: score >= 95 ? "pass" : "warn", score },
+    parityOk: score >= 95,
+    topIssues:
+      score >= 95
+        ? []
+        : [
+            {
+              severity: "high",
+              category: "visual",
+              page: "/",
+              summary: "[simulação] Hero banner divergente no mobile",
+            },
+          ],
+    perPage: [
+      {
+        pagePath: "/",
+        viewport: "mobile",
+        pctDiff: Math.max(0, 100 - score) / 10,
+      },
+    ],
+  };
+}
+
+export async function validating(
+  site: SiteRow,
+  ctx: WorkerCtx,
+  deps: EngineDeps,
+): Promise<void> {
+  // Terminal checks first (idempotent re-entry)
+  const target = site.parity_target;
+  if (site.parity_score !== null && site.parity_score >= target) {
+    await updateSite(site.id, {
+      status: "deploying_cf",
+      phase_detail: `paridade ${site.parity_score} >= ${target}, indo pro deploy`,
+      last_progress_at: new Date().toISOString(),
+    });
+    await addEvent(
+      site.id,
+      `Paridade atingiu ${site.parity_score}% — deploy CF`,
+    );
+    return;
+  }
+  if (site.iterations_done >= site.max_iterations) {
+    await updateSite(site.id, {
+      status: "needs_human",
+      resume_status: "validating",
+      needs_human_reason: `Loop de paridade esgotou ${site.max_iterations} iterações (melhor score: ${site.best_score ?? "n/a"}).`,
+      last_progress_at: new Date().toISOString(),
+    });
+    await addEvent(
+      site.id,
+      "Máximo de iterações atingido — precisa de humano",
+      "warn",
+    );
+    return;
+  }
+  if (site.no_improve_count >= site.no_improve_limit) {
+    await updateSite(site.id, {
+      status: "needs_human",
+      resume_status: "validating",
+      needs_human_reason: `${site.no_improve_count} iterações sem melhora de score (melhor: ${site.best_score ?? "n/a"}).`,
+      last_progress_at: new Date().toISOString(),
+    });
+    await addEvent(site.id, "Score estagnou — precisa de humano", "warn");
+    return;
+  }
+
+  if (deps.inflight.has(site.id)) return;
+  const proceed = await clearStaleSession(site, deps);
+  if (!proceed) return;
+
+  const iteration = site.iterations_done + 1;
+  const run = await createRun({
+    siteId: site.id,
+    kind: "fix_iteration",
+    iteration,
+  });
+  await markSessionStart(site.id, `parity-${iteration}`);
+  await addEvent(site.id, `Iteração de paridade ${iteration} iniciada`);
+
+  deps.inflight.start(site.id, `parity-${iteration}`, async () => {
+    const keys = artifactKeys(site.id, run.id);
+    try {
+      let result;
+      let summary: ParitySummary | null = null;
+
+      if (isSimulation(ctx)) {
+        result = await getDriver(ctx).runTask(site, ctx, {
+          kind: "fix_iteration",
+          prompt: "",
+          iteration,
+        });
+        summary =
+          result.parityScore !== undefined
+            ? simulatedSummary(result.parityScore)
+            : null;
+      } else {
+        const artifacts = await presignPutUrls(ctx, keys);
+        const { token, grant } = await ghsTokenForSite(ctx, site);
+        if (grant?.refreshToken) {
+          await updateSite(site.id, {
+            gh_refresh_token: grant.refreshToken,
+            gh_token_endpoint: grant.tokenEndpoint ?? null,
+            gh_client_id: grant.clientId ?? null,
+          });
+        }
+        const previousIssues = (
+          await getSite(site.id)
+        )?.needs_human_reason?.split("\n");
+
+        result = await getDriver(ctx).runTask(site, ctx, {
+          kind: "fix_iteration",
+          iteration,
+          prompt: fixIterationPrompt({
+            site,
+            iteration,
+            ghToken: token,
+            anthropicApiKey: ctx.config.anthropicApiKey,
+            openrouterApiKey: ctx.config.openrouterApiKey,
+            artifacts: artifacts ?? undefined,
+            previousIssues,
+          }),
+        });
+        summary = await fetchReportSummary(ctx, keys.prefix);
+      }
+
+      const current = await getSite(site.id);
+      if (!current || current.status !== "validating") return;
+
+      if (!result.ok) {
+        await finishRun(run.id, { status: "failed", logsTail: result.output });
+        await updateSite(site.id, {
+          status: "needs_human",
+          resume_status: "validating",
+          needs_human_reason: `Iteração ${iteration} não conseguiu rodar a parity CLI: ${result.error}`,
+          sandbox_session_id: null,
+          last_progress_at: new Date().toISOString(),
+        });
+        await addEvent(
+          site.id,
+          `Iteração ${iteration} falhou: ${result.error}`,
+          "error",
+        );
+        return;
+      }
+
+      const score = result.parityScore ?? summary?.verdict?.score ?? null;
+      const best = current.best_score ?? 0;
+      const improved = score !== null && score > best;
+
+      await finishRun(run.id, {
+        status: "succeeded",
+        parityScore: score ?? undefined,
+        summary: summary ?? undefined,
+        artifactPrefix: keys.prefix,
+        logsTail: result.output,
+      });
+
+      await updateSite(site.id, {
+        parity_score: score,
+        best_score: improved ? score : current.best_score,
+        iterations_done: iteration,
+        no_improve_count: improved ? 0 : current.no_improve_count + 1,
+        sandbox_session_id: null,
+        phase_detail: `iteração ${iteration}: score ${score ?? "?"}`,
+        last_progress_at: new Date().toISOString(),
+      });
+      await addEvent(
+        site.id,
+        `Iteração ${iteration} concluída — score ${score ?? "desconhecido"}%`,
+      );
+      // the next tick re-enters this phase and decides: done / next iteration / needs_human
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await finishRun(run.id, { status: "failed", logsTail: message });
+      await updateSite(site.id, {
+        status: "needs_human",
+        resume_status: "validating",
+        needs_human_reason: `Iteração ${iteration} quebrou: ${message}`,
+        sandbox_session_id: null,
+      });
+      await addEvent(
+        site.id,
+        `Iteração ${iteration} quebrou: ${message}`,
+        "error",
+      );
+    }
+  });
+}

--- a/tanstack-migrator/server/engine/worker.ts
+++ b/tanstack-migrator/server/engine/worker.ts
@@ -1,0 +1,222 @@
+/**
+ * Background worker — the heart of the orchestrator.
+ *
+ * setImmediate(bootstrap) + setInterval(tick). Every tick, per connection:
+ *   1. watchdog: active sites without progress for WATCHDOG_STALL_MS → failed
+ *   2. fill slots: FIFO-start queued sites while active < MAX_CONCURRENT
+ *   3. advance: run the phase handler for each active site (lease-guarded)
+ *   4. keepalive: reset sandbox idle TTL for sites with in-flight sessions
+ *
+ * All state lives in Supabase — a pod restart resumes from the DB (discord
+ * MCP pattern). Long sessions run fire-and-forget via InflightTracker.
+ */
+
+import {
+  LEASE_TTL_MS,
+  TICK_INTERVAL_MS,
+  WATCHDOG_STALL_MS,
+} from "../constants.ts";
+import { isSupabaseConfigured } from "../db/client.ts";
+import { loadAllConnections } from "../db/connections.ts";
+import { addEvent } from "../db/events.ts";
+import {
+  acquireLease,
+  listSites,
+  releaseLease,
+  updateSite,
+} from "../db/sites.ts";
+import { ACTIVE_STATUSES, type SiteRow } from "../db/types.ts";
+import { buildWorkerCtx, type WorkerCtx } from "../lib/mesh.ts";
+import { getDriver } from "../sandbox/client.ts";
+import { InflightTracker } from "./inflight.ts";
+import { type EngineDeps, PHASE_HANDLERS } from "./machine.ts";
+
+const WORKER_ID = `pod-${crypto.randomUUID().slice(0, 8)}`;
+const KEEPALIVE_INTERVAL_MS = 5 * 60_000;
+
+const inflight = new InflightTracker();
+const deps: EngineDeps = { inflight };
+const lastKeepalive = new Map<string, number>();
+
+let interval: ReturnType<typeof setInterval> | null = null;
+let ticking = false;
+
+export function getInflightTracker(): InflightTracker {
+  return inflight;
+}
+
+function isStale(site: SiteRow): boolean {
+  const lastProgress = Date.parse(
+    site.last_progress_at ?? site.updated_at ?? site.created_at,
+  );
+  return Date.now() - lastProgress > WATCHDOG_STALL_MS;
+}
+
+async function watchdog(site: SiteRow): Promise<boolean> {
+  if (inflight.has(site.id)) return false; // work is genuinely running here
+  if (!isStale(site)) return false;
+
+  await updateSite(site.id, {
+    status: "failed",
+    error: `Sem progresso há mais de ${Math.round(WATCHDOG_STALL_MS / 60_000)}min (watchdog)`,
+    sandbox_session_id: null,
+    lease_owner: null,
+    lease_expires_at: null,
+  });
+  await addEvent(
+    site.id,
+    "Watchdog: sem progresso, marcado como failed",
+    "error",
+  );
+  return true;
+}
+
+async function keepaliveIfNeeded(site: SiteRow, ctx: WorkerCtx): Promise<void> {
+  if (!site.sandbox_handle) return;
+  const isWorking =
+    inflight.has(site.id) ||
+    site.status === "migrating" ||
+    site.status === "validating";
+  if (!isWorking) return;
+
+  const last = lastKeepalive.get(site.id) ?? 0;
+  if (Date.now() - last < KEEPALIVE_INTERVAL_MS) return;
+  lastKeepalive.set(site.id, Date.now());
+
+  try {
+    await getDriver(ctx).keepalive(site, ctx);
+  } catch (err) {
+    console.warn(
+      `[worker] keepalive failed for ${site.name}:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
+async function advanceSite(site: SiteRow, ctx: WorkerCtx): Promise<void> {
+  const handler = PHASE_HANDLERS[site.status];
+  if (!handler) return;
+
+  const leased = await acquireLease(site.id, WORKER_ID, LEASE_TTL_MS);
+  if (!leased) return; // another pod is on it
+
+  try {
+    await handler(leased, ctx, deps);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[worker] phase ${site.status} failed for ${site.name}:`,
+      message,
+    );
+    await updateSite(site.id, {
+      status: "failed",
+      error: `${site.status}: ${message}`,
+      sandbox_session_id: null,
+    });
+    await addEvent(site.id, `Fase ${site.status} falhou: ${message}`, "error");
+  } finally {
+    await releaseLease(site.id, WORKER_ID).catch(() => {});
+  }
+}
+
+async function tickConnection(ctx: WorkerCtx): Promise<void> {
+  const sites = await listSites({ connectionId: ctx.connectionId });
+
+  const active = sites.filter((s) =>
+    (ACTIVE_STATUSES as string[]).includes(s.status),
+  );
+  const queued = sites
+    .filter((s) => s.status === "queued")
+    .sort((a, b) => a.created_at.localeCompare(b.created_at));
+
+  // 1. watchdog
+  let activeCount = 0;
+  const survivors: SiteRow[] = [];
+  for (const site of active) {
+    const killed = await watchdog(site);
+    if (!killed) {
+      survivors.push(site);
+      activeCount++;
+    }
+  }
+
+  // 2. fill slots (FIFO)
+  for (const site of queued) {
+    if (activeCount >= ctx.config.maxConcurrent) break;
+    const leased = await acquireLease(site.id, WORKER_ID, LEASE_TTL_MS);
+    if (!leased || leased.status !== "queued") continue;
+    await updateSite(site.id, {
+      status: "creating_repo",
+      started_at: leased.started_at ?? new Date().toISOString(),
+      error: null,
+      phase_detail: "iniciando",
+      last_progress_at: new Date().toISOString(),
+    });
+    await addEvent(
+      site.id,
+      `Migração iniciada (slot ${activeCount + 1}/${ctx.config.maxConcurrent})`,
+    );
+    await releaseLease(site.id, WORKER_ID).catch(() => {});
+    survivors.push({ ...leased, status: "creating_repo" });
+    activeCount++;
+  }
+
+  // 3. advance + 4. keepalive
+  for (const site of survivors) {
+    await advanceSite(site, ctx);
+    await keepaliveIfNeeded(site, ctx);
+  }
+}
+
+export async function runTickOnce(): Promise<{
+  connections: number;
+  advanced: number;
+}> {
+  if (!isSupabaseConfigured()) return { connections: 0, advanced: 0 };
+  const rows = await loadAllConnections();
+  let advanced = 0;
+  for (const row of rows) {
+    try {
+      const ctx = buildWorkerCtx(row);
+      await tickConnection(ctx);
+      advanced++;
+    } catch (err) {
+      console.error(
+        `[worker] tick failed for connection ${row.connection_id}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+  return { connections: rows.length, advanced };
+}
+
+async function tick(): Promise<void> {
+  if (ticking) return;
+  ticking = true;
+  try {
+    await runTickOnce();
+  } catch (err) {
+    console.error(
+      "[worker] tick error:",
+      err instanceof Error ? err.message : err,
+    );
+  } finally {
+    ticking = false;
+  }
+}
+
+export function startWorker(): void {
+  if (interval) return;
+  console.log(
+    `[worker] starting (${WORKER_ID}), tick every ${TICK_INTERVAL_MS / 1000}s`,
+  );
+  setImmediate(tick);
+  interval = setInterval(tick, TICK_INTERVAL_MS);
+}
+
+export function stopWorker(): void {
+  if (interval) {
+    clearInterval(interval);
+    interval = null;
+  }
+}

--- a/tanstack-migrator/server/lib/api-key.ts
+++ b/tanstack-migrator/server/lib/api-key.ts
@@ -1,0 +1,118 @@
+/**
+ * Persistent mesh API key for background work. The request JWT expires in
+ * ~5 minutes; the worker needs to call mesh (bindings, VM tools, decopilot)
+ * for hours. On onChange we mint an org API key via API_KEY_CREATE on
+ * /mcp/self, granting access to self + this connection + the binding
+ * connections, and persist it in sitemig_connections.
+ *
+ * Same idea as shared/api-key-manager.ts, with custom permission grants.
+ */
+
+import { resolveMeshUrl } from "./mesh.ts";
+
+export const API_KEY_GRANTS_STATE_KEY = "__API_KEY_GRANTS";
+
+export function desiredGrants(input: {
+  connectionId: string;
+  bindingConnectionIds: string[];
+}): string[] {
+  return ["self", input.connectionId, ...input.bindingConnectionIds].filter(
+    (v, i, arr) => arr.indexOf(v) === i,
+  );
+}
+
+export function grantsChanged(previous: unknown, desired: string[]): boolean {
+  if (!Array.isArray(previous)) return true;
+  const prev = new Set(previous as string[]);
+  return desired.some((g) => !prev.has(g));
+}
+
+export async function mintPersistentApiKey(input: {
+  meshUrl: string;
+  organizationId: string;
+  connectionId: string;
+  temporaryToken: string;
+  grants: string[];
+}): Promise<string | null> {
+  const base = resolveMeshUrl(input.meshUrl);
+  const permissions: Record<string, string[]> = {};
+  for (const grant of input.grants) permissions[grant] = ["*"];
+
+  try {
+    const response = await fetch(`${base}/mcp/self`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: `Bearer ${input.temporaryToken}`,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: Date.now(),
+        method: "tools/call",
+        params: {
+          name: "API_KEY_CREATE",
+          arguments: {
+            name: `tanstack-migrator-${input.connectionId}`,
+            permissions,
+            metadata: {
+              purpose: "tanstack-migrator background worker",
+              connectionId: input.connectionId,
+              organization: { id: input.organizationId },
+              createdAt: new Date().toISOString(),
+            },
+          },
+        },
+      }),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) {
+      console.error(
+        `[api-key] API_KEY_CREATE failed: ${response.status} ${await response.text().then((t) => t.slice(0, 200))}`,
+      );
+      return null;
+    }
+
+    const raw = await response.text();
+    const payload = JSON.parse(
+      raw.trim().startsWith("{")
+        ? raw
+        : (raw
+            .split("\n")
+            .filter((l) => l.startsWith("data:"))
+            .map((l) => l.slice(5).trim())
+            .findLast((l) => l && l !== "[DONE]") ?? "{}"),
+    ) as {
+      result?: {
+        structuredContent?: { key?: string };
+        content?: Array<{ type: string; text?: string }>;
+      };
+      error?: { message: string };
+    };
+
+    if (payload.error) {
+      console.error(`[api-key] API_KEY_CREATE error: ${payload.error.message}`);
+      return null;
+    }
+    const direct = payload.result?.structuredContent?.key;
+    if (direct) return direct;
+
+    const text = payload.result?.content?.find((c) => c.type === "text")?.text;
+    if (text) {
+      try {
+        const parsed = JSON.parse(text) as { key?: string };
+        if (parsed.key) return parsed.key;
+      } catch {
+        // not JSON
+      }
+    }
+    return null;
+  } catch (err) {
+    console.error(
+      "[api-key] mint failed:",
+      err instanceof Error ? err.message : err,
+    );
+    return null;
+  }
+}

--- a/tanstack-migrator/server/lib/artifacts.ts
+++ b/tanstack-migrator/server/lib/artifacts.ts
@@ -1,0 +1,163 @@
+/**
+ * Parity report artifacts on object storage (OBJECT_STORAGE binding).
+ *
+ * The MCP pre-mints presigned PUT URLs and hands them to the sandbox session,
+ * which curls report.html / report.json / heatmaps up after each parity run.
+ * The UI later gets presigned GET URLs via the PARITY_REPORT_URLS tool.
+ * No storage credentials ever enter the sandbox.
+ */
+
+import { ARTIFACT_ROOT } from "../constants.ts";
+import type { ParitySummary } from "../db/types.ts";
+import { callBindingTool, hasBinding, type WorkerCtx } from "./mesh.ts";
+
+export const HEATMAP_SLOTS = 6;
+
+export interface ArtifactKeys {
+  prefix: string;
+  reportHtml: string;
+  reportJson: string;
+  heatmaps: string[];
+}
+
+export function artifactKeys(siteId: string, runId: string): ArtifactKeys {
+  const prefix = `${ARTIFACT_ROOT}/${siteId}/runs/${runId}`;
+  return {
+    prefix,
+    reportHtml: `${prefix}/report.html`,
+    reportJson: `${prefix}/report.json`,
+    heatmaps: Array.from(
+      { length: HEATMAP_SLOTS },
+      (_, i) => `${prefix}/heatmap_${i}.png`,
+    ),
+  };
+}
+
+async function presign(
+  ctx: WorkerCtx,
+  kind: "GET_PRESIGNED_URL" | "PUT_PRESIGNED_URL",
+  key: string,
+  contentType?: string,
+  expiresIn = 3600,
+): Promise<string> {
+  const result = await callBindingTool<{ url: string }>(
+    ctx,
+    "OBJECT_STORAGE",
+    kind,
+    { key, expiresIn, ...(contentType ? { contentType } : {}) },
+  );
+  if (!result?.url) throw new Error(`${kind} returned no url for ${key}`);
+  return result.url;
+}
+
+export async function presignPutUrls(
+  ctx: WorkerCtx,
+  keys: ArtifactKeys,
+): Promise<{
+  reportHtmlPut: string;
+  reportJsonPut: string;
+  heatmapPuts: string[];
+} | null> {
+  if (!hasBinding(ctx, "OBJECT_STORAGE")) return null;
+  const [reportHtmlPut, reportJsonPut, ...heatmapPuts] = await Promise.all([
+    presign(ctx, "PUT_PRESIGNED_URL", keys.reportHtml, "text/html", 7200),
+    presign(
+      ctx,
+      "PUT_PRESIGNED_URL",
+      keys.reportJson,
+      "application/json",
+      7200,
+    ),
+    ...keys.heatmaps.map((key) =>
+      presign(ctx, "PUT_PRESIGNED_URL", key, "image/png", 7200),
+    ),
+  ]);
+  return { reportHtmlPut, reportJsonPut, heatmapPuts };
+}
+
+export async function presignGetUrls(
+  ctx: WorkerCtx,
+  prefix: string,
+): Promise<{
+  reportHtml: string;
+  reportJson: string;
+  heatmaps: Array<{ name: string; url: string }>;
+}> {
+  const keys: ArtifactKeys = {
+    prefix,
+    reportHtml: `${prefix}/report.html`,
+    reportJson: `${prefix}/report.json`,
+    heatmaps: Array.from(
+      { length: HEATMAP_SLOTS },
+      (_, i) => `${prefix}/heatmap_${i}.png`,
+    ),
+  };
+  const [reportHtml, reportJson, ...heatmaps] = await Promise.all([
+    presign(ctx, "GET_PRESIGNED_URL", keys.reportHtml),
+    presign(ctx, "GET_PRESIGNED_URL", keys.reportJson),
+    ...keys.heatmaps.map((key) => presign(ctx, "GET_PRESIGNED_URL", key)),
+  ]);
+  return {
+    reportHtml,
+    reportJson,
+    heatmaps: heatmaps.map((url, i) => ({ name: `heatmap_${i}.png`, url })),
+  };
+}
+
+/**
+ * Fetch the uploaded report.json (via presigned GET) and trim it to the
+ * summary stored in sitemig_runs (full report never goes to Postgres).
+ */
+export async function fetchReportSummary(
+  ctx: WorkerCtx,
+  prefix: string,
+): Promise<ParitySummary | null> {
+  if (!hasBinding(ctx, "OBJECT_STORAGE")) return null;
+  try {
+    const url = await presign(
+      ctx,
+      "GET_PRESIGNED_URL",
+      `${prefix}/report.json`,
+    );
+    const response = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+    if (!response.ok) return null;
+    const report = (await response.json()) as Record<string, unknown>;
+    return trimReportSummary(report);
+  } catch {
+    return null;
+  }
+}
+
+export function trimReportSummary(
+  report: Record<string, unknown>,
+): ParitySummary {
+  const verdict = report.verdict as ParitySummary["verdict"] | undefined;
+  const visualDiff = report.visualDiff as
+    | {
+        parityOk?: boolean;
+        results?: Array<Record<string, unknown>>;
+      }
+    | undefined;
+  const topIssues = (report.topIssues as Array<Record<string, unknown>>) ?? [];
+
+  return {
+    verdict,
+    parityOk: visualDiff?.parityOk,
+    topIssues: topIssues.slice(0, 10).map((issue) => ({
+      severity: String(issue.severity ?? "unknown"),
+      category: issue.category ? String(issue.category) : undefined,
+      page: issue.page ? String(issue.page) : undefined,
+      summary: String(issue.summary ?? issue.details ?? ""),
+      suggestedFix: issue.suggestedFix ? String(issue.suggestedFix) : undefined,
+    })),
+    perPage: (visualDiff?.results ?? []).slice(0, 20).map((r) => ({
+      pagePath: String(r.pagePath ?? r.pageKey ?? "?"),
+      viewport: r.viewport ? String(r.viewport) : undefined,
+      pctDiff: typeof r.pctDiff === "number" ? r.pctDiff : undefined,
+      verdict: r.verdict ? String(r.verdict) : undefined,
+      sectionsOnlyInProd: Array.isArray(r.sectionsOnlyInProd)
+        ? (r.sectionsOnlyInProd as string[]).slice(0, 10)
+        : undefined,
+    })),
+  };
+}

--- a/tanstack-migrator/server/lib/cloudflare.ts
+++ b/tanstack-migrator/server/lib/cloudflare.ts
@@ -1,0 +1,109 @@
+/**
+ * Cloudflare Workers Builds — create the git-connected project so pushes to
+ * the -tanstack repo deploy automatically (same setup granadobr-tanstack
+ * uses, minus the dashboard clicks).
+ *
+ * The Workers Builds API is recent; the exact endpoint shape is a
+ * VERIFY-ON-PHASE-C item. Everything here degrades to a clear error that the
+ * deploy-cf phase turns into a needs_human note with manual instructions.
+ */
+
+import type { WorkerCtx } from "./mesh.ts";
+
+const CF_API = "https://api.cloudflare.com/client/v4";
+
+async function cfFetch<T>(
+  ctx: WorkerCtx,
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
+  const token = ctx.config.cloudflareApiToken;
+  if (!token) {
+    throw new Error("CLOUDFLARE_API_TOKEN is not configured in the MCP state.");
+  }
+  const response = await fetch(`${CF_API}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      ...init?.headers,
+    },
+    signal: AbortSignal.timeout(60_000),
+  });
+  const payload = (await response.json().catch(() => ({}))) as {
+    success?: boolean;
+    result?: T;
+    errors?: Array<{ code: number; message: string }>;
+  };
+  if (!response.ok || payload.success === false) {
+    const detail =
+      payload.errors?.map((e) => `${e.code}: ${e.message}`).join("; ") ??
+      `HTTP ${response.status}`;
+    throw new Error(`Cloudflare API ${path} failed — ${detail}`);
+  }
+  return payload.result as T;
+}
+
+export async function workerExists(
+  ctx: WorkerCtx,
+  name: string,
+): Promise<boolean> {
+  try {
+    await cfFetch(
+      ctx,
+      `/accounts/${ctx.config.cloudflareAccountId}/workers/services/${name}`,
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface CfProjectResult {
+  projectName: string;
+  deployUrl: string | null;
+}
+
+/**
+ * Create the Workers Builds project connected to the GitHub repo.
+ * Throws with a descriptive message when the API rejects — the phase maps
+ * that to needs_human with manual instructions.
+ */
+export async function createWorkersBuildsProject(
+  ctx: WorkerCtx,
+  input: { workerName: string; repoFull: string; branch?: string },
+): Promise<CfProjectResult> {
+  const accountId = ctx.config.cloudflareAccountId;
+  const [owner, repo] = input.repoFull.split("/");
+
+  // VERIFY-ON-PHASE-C: Workers Builds trigger creation endpoint. Shape based
+  // on the beta API (builds/triggers); adjust after probing with the real token.
+  await cfFetch(ctx, `/accounts/${accountId}/builds/triggers`, {
+    method: "POST",
+    body: JSON.stringify({
+      external_script_id: input.workerName,
+      trigger_name: `${input.workerName}-main`,
+      repo_connection: { provider: "github", owner, repo },
+      branch_includes: [input.branch ?? "main"],
+      build_command: "npm run build",
+      deploy_command: "npx wrangler deploy",
+      root_directory: "/",
+    }),
+  });
+
+  return {
+    projectName: input.workerName,
+    deployUrl: `https://${input.workerName}.deco-cx.workers.dev`,
+  };
+}
+
+export function manualCfInstructions(input: {
+  workerName: string;
+  repoFull: string;
+}): string {
+  return (
+    `Criar o projeto Workers Builds manualmente: Cloudflare dashboard → Workers & Pages → ` +
+    `Create → Import a repository → ${input.repoFull} (build: npm run build; deploy: npx wrangler deploy; ` +
+    `worker name: ${input.workerName}). Depois marque a fase como concluída com SITE_RETRY.`
+  );
+}

--- a/tanstack-migrator/server/lib/ensure-api-key.ts
+++ b/tanstack-migrator/server/lib/ensure-api-key.ts
@@ -1,0 +1,80 @@
+/**
+ * Lazy, throttled minting of the durable mesh API key from ANY request
+ * context. onChange is the happy path, but it doesn't always fire (runtime
+ * version differences) — so tools also call this fire-and-forget. First
+ * request with a valid JWT wins; result is persisted in sitemig_connections.
+ */
+
+import { isSupabaseConfigured } from "../db/client.ts";
+import { loadConnection, saveConnection } from "../db/connections.ts";
+import type { Env } from "../types/env.ts";
+import {
+  API_KEY_GRANTS_STATE_KEY,
+  desiredGrants,
+  grantsChanged,
+  mintPersistentApiKey,
+} from "./api-key.ts";
+import { bindingConnectionId } from "./persist-state.ts";
+
+const THROTTLE_MS = 60_000;
+const lastAttempt = new Map<string, number>();
+
+export async function ensureApiKeyFromRequest(env: Env): Promise<void> {
+  if (!isSupabaseConfigured()) return;
+  const mrc = env.MESH_REQUEST_CONTEXT;
+  const connectionId = mrc?.connectionId;
+  if (!connectionId || !mrc?.token) return;
+
+  const last = lastAttempt.get(connectionId) ?? 0;
+  if (Date.now() - last < THROTTLE_MS) return;
+  lastAttempt.set(connectionId, Date.now());
+
+  try {
+    const existing = await loadConnection(connectionId).catch(() => null);
+    const organizationId = mrc.organizationId || existing?.organization_id;
+    const meshUrl = mrc.meshUrl || existing?.mesh_url;
+    if (!organizationId || !meshUrl) return;
+
+    const state = existing?.state ?? {};
+    const explicitKey =
+      typeof state.MESH_API_KEY === "string" && state.MESH_API_KEY;
+    if (explicitKey) return;
+
+    const grants = desiredGrants({
+      connectionId,
+      bindingConnectionIds: [
+        bindingConnectionId(state, "GITHUB"),
+        bindingConnectionId(state, "OBJECT_STORAGE"),
+      ].filter((v): v is string => !!v),
+    });
+    const previousGrants = state[API_KEY_GRANTS_STATE_KEY];
+
+    if (existing?.mesh_api_key && !grantsChanged(previousGrants, grants)) {
+      return; // already have a key covering the current bindings
+    }
+
+    const minted = await mintPersistentApiKey({
+      meshUrl,
+      organizationId,
+      connectionId,
+      temporaryToken: mrc.token,
+      grants,
+    });
+    if (!minted) return;
+
+    await saveConnection({
+      connectionId,
+      organizationId,
+      meshUrl,
+      meshToken: mrc.token,
+      meshApiKey: minted,
+      state: { ...state, [API_KEY_GRANTS_STATE_KEY]: grants },
+    });
+    console.log(`[api-key] minted persistent API key for ${connectionId}`);
+  } catch (err) {
+    console.error(
+      "[api-key] lazy mint failed:",
+      err instanceof Error ? err.message : err,
+    );
+  }
+}

--- a/tanstack-migrator/server/lib/github.ts
+++ b/tanstack-migrator/server/lib/github.ts
@@ -1,0 +1,258 @@
+/**
+ * GitHub operations via the GITHUB binding (deco github MCP, which proxies
+ * the official GitHub MCP tools + first-party MINT_REPO_TOKEN).
+ *
+ * Tool names (create_repository, get_file_contents, create_or_update_file)
+ * are the official GitHub MCP ones, discovered dynamically by the proxy.
+ */
+
+import type { SiteRow } from "../db/types.ts";
+import { callBindingTool, type WorkerCtx } from "./mesh.ts";
+
+export interface RepoRef {
+  owner: string;
+  repo: string;
+}
+
+export function parseRepo(full: string): RepoRef {
+  const [owner, repo] = full.split("/");
+  if (!owner || !repo) throw new Error(`Invalid repo ref: ${full}`);
+  return { owner, repo };
+}
+
+export function targetRepoFor(site: SiteRow, org: string): string {
+  const { repo } = parseRepo(site.source_repo);
+  return `${org}/${repo}-tanstack`;
+}
+
+/** Thrown when the GitHub App lacks org repo-creation permission (403). */
+export class RepoCreatePermissionError extends Error {}
+
+/** Does the repo exist/is it reachable with the current GitHub credentials? */
+export async function repoExists(
+  ctx: WorkerCtx,
+  full: string,
+): Promise<boolean> {
+  const ref = parseRepo(full);
+  try {
+    const raw = await callBindingTool(ctx, "GITHUB", "get_file_contents", {
+      owner: ref.owner,
+      repo: ref.repo,
+      path: "/",
+    });
+    return raw !== null && raw !== undefined;
+  } catch (err) {
+    // GitHub answers 404 "This repository is empty" for existing empty repos
+    const message = err instanceof Error ? err.message : String(err);
+    return /repository is empty/i.test(message);
+  }
+}
+
+/**
+ * Idempotent: create the -tanstack repo, treating "already exists" as
+ * success. Created EMPTY (no autoInit) so the migration's initial push
+ * doesn't diverge from a README commit.
+ */
+export async function ensureRepo(ctx: WorkerCtx, full: string): Promise<void> {
+  const { owner, repo } = parseRepo(full);
+  // Cheap existence check first — also covers manually-created repos.
+  if (await repoExists(ctx, full)) return;
+
+  try {
+    await callBindingTool(ctx, "GITHUB", "create_repository", {
+      name: repo,
+      organization: owner,
+      description: `TanStack Start migration of ${repo} — managed by tanstack-migrator`,
+      private: true,
+      autoInit: false,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/already exists|name already exists/i.test(message)) return;
+    if (/403|not accessible by integration|forbidden/i.test(message)) {
+      throw new RepoCreatePermissionError(
+        `GitHub App sem permissão para criar repositórios na org ${owner} (${message})`,
+      );
+    }
+    throw err;
+  }
+}
+
+export interface RepoGrant {
+  token: string;
+  expiresAt?: string;
+  refreshToken?: string;
+  tokenEndpoint?: string;
+  clientId?: string;
+}
+
+/**
+ * Mint a repo-scoped ghs_ token (+ durable ghr_ refresh grant) for the target
+ * repo. The grant lets the worker re-mint fresh 1h tokens for hours-long
+ * sandbox work without a user login.
+ */
+export async function mintRepoGrant(
+  ctx: WorkerCtx,
+  full: string,
+): Promise<RepoGrant> {
+  const installationId = ctx.config.githubInstallationId;
+  if (!installationId) {
+    throw new Error(
+      "GITHUB_INSTALLATION_ID is not configured — set it in the MCP state (GitHub App installation for the deco-sites org).",
+    );
+  }
+  const { owner, repo } = parseRepo(full);
+  const result = await callBindingTool<{
+    token: string;
+    expiresAt?: string;
+    refreshToken?: string;
+    tokenEndpoint?: string;
+    clientId?: string;
+  }>(ctx, "GITHUB", "MINT_REPO_TOKEN", {
+    installationId,
+    owner,
+    repo,
+    permissions: { contents: "write", metadata: "read" },
+  });
+  if (!result?.token) {
+    throw new Error("MINT_REPO_TOKEN returned no token");
+  }
+  return result;
+}
+
+/** Redeem the stored ghr_ grant for a fresh ghs_ token (OAuth refresh flow). */
+export async function refreshGhsToken(site: SiteRow): Promise<string> {
+  if (!site.gh_refresh_token || !site.gh_token_endpoint) {
+    throw new Error(`Site ${site.name} has no stored GitHub grant`);
+  }
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: site.gh_refresh_token,
+  });
+  if (site.gh_client_id) body.set("client_id", site.gh_client_id);
+
+  const response = await fetch(site.gh_token_endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+    signal: AbortSignal.timeout(30_000),
+  });
+  const payload = (await response.json().catch(() => ({}))) as {
+    access_token?: string;
+    token?: string;
+    error?: string;
+    error_description?: string;
+  };
+  if (!response.ok) {
+    throw new Error(
+      `GitHub grant refresh failed (${response.status}): ${payload.error_description ?? payload.error ?? "unknown"}`,
+    );
+  }
+  const token = payload.access_token ?? payload.token;
+  if (!token) throw new Error("GitHub grant refresh returned no token");
+  return token;
+}
+
+/**
+ * ghs_ token for sandbox git operations: refresh the grant, or mint anew.
+ * OPTIONAL — returns {token: undefined} when no grant is stored and no
+ * installation id is configured; in that case the sandbox relies on the git
+ * credentials the mesh syncs for the virtualMcp's githubRepo connection.
+ */
+export async function ghsTokenForSite(
+  ctx: WorkerCtx,
+  site: SiteRow,
+): Promise<{ token?: string; grant?: RepoGrant }> {
+  if (site.gh_refresh_token && site.gh_token_endpoint) {
+    try {
+      return { token: await refreshGhsToken(site) };
+    } catch {
+      // fall through to a fresh mint (grant may have expired/revoked)
+    }
+  }
+  if (!ctx.config.githubInstallationId) {
+    return { token: undefined };
+  }
+  try {
+    const grant = await mintRepoGrant(ctx, site.target_repo ?? "");
+    return { token: grant.token, grant };
+  } catch {
+    return { token: undefined };
+  }
+}
+
+interface FileContents {
+  sha?: string;
+  content?: string;
+  encoding?: string;
+}
+
+function extractFileContents(raw: unknown): FileContents | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  // official MCP returns the GitHub contents API shape (possibly nested)
+  const candidate = (
+    Array.isArray(obj) ? obj[0] : (obj.file ?? obj.data ?? obj)
+  ) as Record<string, unknown>;
+  if (!candidate || typeof candidate !== "object") return null;
+  const sha = typeof candidate.sha === "string" ? candidate.sha : undefined;
+  const content =
+    typeof candidate.content === "string" ? candidate.content : undefined;
+  const encoding =
+    typeof candidate.encoding === "string" ? candidate.encoding : undefined;
+  if (!sha && !content) return null;
+  return { sha, content, encoding };
+}
+
+export async function getFile(
+  ctx: WorkerCtx,
+  ref: RepoRef,
+  path: string,
+  branch = "main",
+): Promise<{ sha?: string; text: string } | null> {
+  try {
+    const raw = await callBindingTool(ctx, "GITHUB", "get_file_contents", {
+      owner: ref.owner,
+      repo: ref.repo,
+      path,
+      ref: branch,
+    });
+    const file = extractFileContents(raw);
+    if (!file) return null;
+    let text = file.content ?? "";
+    if (file.encoding === "base64" || /^[A-Za-z0-9+/=\n]+$/.test(text)) {
+      try {
+        text = Buffer.from(text.replace(/\n/g, ""), "base64").toString("utf-8");
+      } catch {
+        // keep raw text
+      }
+    }
+    return { sha: file.sha, text };
+  } catch {
+    return null; // 404 → doesn't exist
+  }
+}
+
+/** Idempotent create-or-update: skips the write when content already matches. */
+export async function putFile(
+  ctx: WorkerCtx,
+  ref: RepoRef,
+  input: { path: string; content: string; message: string; branch?: string },
+): Promise<"created" | "updated" | "unchanged"> {
+  const branch = input.branch ?? "main";
+  const existing = await getFile(ctx, ref, input.path, branch);
+  if (existing && existing.text.trim() === input.content.trim()) {
+    return "unchanged";
+  }
+
+  await callBindingTool(ctx, "GITHUB", "create_or_update_file", {
+    owner: ref.owner,
+    repo: ref.repo,
+    path: input.path,
+    content: input.content,
+    message: input.message,
+    branch,
+    ...(existing?.sha ? { sha: existing.sha } : {}),
+  });
+  return existing ? "updated" : "created";
+}

--- a/tanstack-migrator/server/lib/mesh.ts
+++ b/tanstack-migrator/server/lib/mesh.ts
@@ -1,0 +1,211 @@
+/**
+ * Mesh access for background work (no live request context).
+ *
+ * The worker rebuilds everything from the sitemig_connections row persisted
+ * by onChange: meshUrl + durable API key (preferred, JWTs expire in ~5min)
+ * + raw binding values ({__type, value: connectionId}).
+ *
+ * Tool calls go straight to the mesh MCP endpoints as JSON-RPC:
+ *   - bindings/other connections: POST {meshUrl}/mcp/{connectionId}  (x-mesh-token)
+ *   - management tools (VM_START, API_KEY_CREATE...): POST {meshUrl}/mcp/self (Bearer)
+ */
+
+import type { ConnectionRow } from "../db/types.ts";
+import { type MigratorConfig, parseMigratorConfig } from "../types/env.ts";
+import { bindingConnectionId } from "./persist-state.ts";
+
+export interface WorkerCtx {
+  connectionId: string;
+  organizationId: string;
+  meshUrl: string;
+  /** Durable API key when available, else the last-seen request JWT. */
+  meshToken: string | null;
+  config: MigratorConfig;
+  /** Raw persisted state (bindings as {__type, value}). */
+  state: Record<string, unknown>;
+}
+
+export function buildWorkerCtx(row: ConnectionRow): WorkerCtx {
+  return {
+    connectionId: row.connection_id,
+    organizationId: row.organization_id,
+    meshUrl: row.mesh_url,
+    meshToken: row.mesh_api_key || row.mesh_token || null,
+    config: parseMigratorConfig(row.state),
+    state: row.state ?? {},
+  };
+}
+
+/**
+ * Tunnel URLs (.deco.host) are only reachable from the developer's browser;
+ * server-to-server traffic goes through localhost. Same rule as
+ * shared/mesh-chat/client.ts.
+ */
+export function resolveMeshUrl(meshUrl: string): string {
+  return meshUrl.includes(".deco.host") ? "http://localhost:3000" : meshUrl;
+}
+
+interface JsonRpcToolResponse {
+  result?: {
+    isError?: boolean;
+    structuredContent?: unknown;
+    content?: Array<{ type: string; text?: string }>;
+  };
+  error?: { code: number; message: string };
+}
+
+function extractToolResult<T>(payload: JsonRpcToolResponse, tool: string): T {
+  if (payload.error) {
+    throw new Error(`${tool} failed: ${payload.error.message}`);
+  }
+  const result = payload.result;
+  if (!result) throw new Error(`${tool} returned an empty response`);
+
+  const text = (result.content ?? [])
+    .filter((c) => c.type === "text" && typeof c.text === "string")
+    .map((c) => c.text)
+    .join("\n");
+
+  if (result.isError) {
+    throw new Error(`${tool} failed: ${text || "tool returned an error"}`);
+  }
+  if (result.structuredContent !== undefined) {
+    return result.structuredContent as T;
+  }
+  if (text) {
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      return text as unknown as T;
+    }
+  }
+  return undefined as unknown as T;
+}
+
+/**
+ * Some mesh responses come back as text/event-stream even with
+ * Accept: application/json first — unwrap the last `data:` payload.
+ */
+function parseRpcBody(raw: string): JsonRpcToolResponse {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("{")) {
+    return JSON.parse(trimmed) as JsonRpcToolResponse;
+  }
+  const dataLines = trimmed
+    .split("\n")
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice(5).trim())
+    .filter(Boolean);
+  for (let i = dataLines.length - 1; i >= 0; i--) {
+    try {
+      const parsed = JSON.parse(dataLines[i]) as JsonRpcToolResponse;
+      if (parsed.result !== undefined || parsed.error !== undefined) {
+        return parsed;
+      }
+    } catch {
+      // keep scanning
+    }
+  }
+  throw new Error(`Unparseable MCP response: ${trimmed.slice(0, 200)}`);
+}
+
+async function callMcpEndpoint<T>(
+  url: string,
+  headers: Record<string, string>,
+  tool: string,
+  args: Record<string, unknown>,
+  timeoutMs = 120_000,
+): Promise<T> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      ...headers,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: Date.now(),
+      method: "tools/call",
+      params: { name: tool, arguments: args },
+    }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+
+  const raw = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `${tool} HTTP ${response.status} at ${url}: ${raw.slice(0, 300)}`,
+    );
+  }
+  return extractToolResult<T>(parseRpcBody(raw), tool);
+}
+
+/** Call a tool on an arbitrary mesh connection (e.g. a binding's connectionId). */
+export async function callConnectionTool<T = unknown>(
+  ctx: WorkerCtx,
+  connectionId: string,
+  tool: string,
+  args: Record<string, unknown>,
+  timeoutMs?: number,
+): Promise<T> {
+  if (!ctx.meshToken) {
+    throw new Error("No mesh token available for background tool calls");
+  }
+  const base = resolveMeshUrl(ctx.meshUrl);
+  return callMcpEndpoint<T>(
+    new URL(`/mcp/${connectionId}`, base).href,
+    {
+      "x-mesh-token": ctx.meshToken,
+      Authorization: `Bearer ${ctx.meshToken}`,
+    },
+    tool,
+    args,
+    timeoutMs,
+  );
+}
+
+/** Call a management tool (VM_START, VM_DELETE, API_KEY_CREATE...) on /mcp/self. */
+export async function callSelfTool<T = unknown>(
+  ctx: WorkerCtx,
+  tool: string,
+  args: Record<string, unknown>,
+  timeoutMs?: number,
+): Promise<T> {
+  if (!ctx.meshToken) {
+    throw new Error("No mesh token available for management tool calls");
+  }
+  const base = resolveMeshUrl(ctx.meshUrl);
+  return callMcpEndpoint<T>(
+    new URL("/mcp/self", base).href,
+    {
+      Authorization: `Bearer ${ctx.meshToken}`,
+      "x-org-id": ctx.organizationId,
+    },
+    tool,
+    args,
+    timeoutMs,
+  );
+}
+
+/** Call a tool on one of this MCP's bindings (GITHUB, OBJECT_STORAGE). */
+export async function callBindingTool<T = unknown>(
+  ctx: WorkerCtx,
+  binding: "GITHUB" | "OBJECT_STORAGE",
+  tool: string,
+  args: Record<string, unknown>,
+  timeoutMs?: number,
+): Promise<T> {
+  const connectionId = bindingConnectionId(ctx.state, binding);
+  if (!connectionId) {
+    throw new Error(`${binding} binding is not configured`);
+  }
+  return callConnectionTool<T>(ctx, connectionId, tool, args, timeoutMs);
+}
+
+export function hasBinding(
+  ctx: WorkerCtx,
+  binding: "GITHUB" | "OBJECT_STORAGE",
+): boolean {
+  return bindingConnectionId(ctx.state, binding) !== null;
+}

--- a/tanstack-migrator/server/lib/persist-state.ts
+++ b/tanstack-migrator/server/lib/persist-state.ts
@@ -1,0 +1,37 @@
+/**
+ * Pull a JSON-serializable snapshot of MESH_REQUEST_CONTEXT.state. After
+ * onChange returns, env.state's binding values turn into Proxies that
+ * serialize to `{}` — we want only the raw values ({__type, value} for
+ * bindings, plain scalars for the rest). Same pattern as discord/server.
+ */
+export function extractPersistableState(
+  state: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!state) return {};
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(state)) {
+    try {
+      JSON.stringify(value);
+      out[key] = value;
+    } catch {
+      // skip non-serializable values
+    }
+  }
+  return out;
+}
+
+/** Binding values persist as {__type, value: connectionId}. */
+export function bindingConnectionId(
+  state: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  const value = (state ?? {})[key];
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { value?: unknown }).value === "string"
+  ) {
+    return (value as { value: string }).value;
+  }
+  return null;
+}

--- a/tanstack-migrator/server/main.ts
+++ b/tanstack-migrator/server/main.ts
@@ -1,0 +1,143 @@
+/**
+ * TanStack Migrator MCP — entrypoint.
+ *
+ * Orchestrates Fresh/Deno → TanStack Start storefront migrations:
+ * FIFO queue → GitHub -tanstack repo → mesh sandbox running Claude
+ * (migrate script + parity fix loop) → Cloudflare Workers Builds deploy.
+ *
+ * Pod-boot lifecycle (discord MCP pattern):
+ *   1. withRuntime() provides the MCP fetch handler, served by Bun.
+ *   2. The background worker starts immediately and rebuilds all context
+ *      from Supabase (sitemig_connections/sitemig_sites) — restart-safe.
+ *   3. Mesh onChange is the source of truth for fresh config: it persists
+ *      the connection snapshot and auto-mints a durable API key so the
+ *      worker can call mesh (bindings, VM tools, decopilot) for hours.
+ */
+
+import { serve } from "@decocms/mcps-shared/serve";
+import { withRuntime } from "@decocms/runtime";
+import packageJson from "../package.json" with { type: "json" };
+import { isSupabaseConfigured } from "./db/client.ts";
+import { loadConnection, saveConnection } from "./db/connections.ts";
+import { startWorker, stopWorker } from "./engine/worker.ts";
+import {
+  API_KEY_GRANTS_STATE_KEY,
+  desiredGrants,
+  grantsChanged,
+  mintPersistentApiKey,
+} from "./lib/api-key.ts";
+import {
+  bindingConnectionId,
+  extractPersistableState,
+} from "./lib/persist-state.ts";
+import { dashboardResource } from "./resources/index.ts";
+import { tools } from "./tools/index.ts";
+import { type Env, StateSchema } from "./types/env.ts";
+
+console.log(`TanStack Migrator MCP v${packageJson.version}`);
+
+export { StateSchema };
+export type { Env };
+
+const runtime = withRuntime<Env, typeof StateSchema>({
+  configuration: {
+    state: StateSchema,
+    scopes: [
+      "GITHUB::*",
+      "OBJECT_STORAGE::GET_PRESIGNED_URL",
+      "OBJECT_STORAGE::PUT_PRESIGNED_URL",
+    ],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onChange: async (env, config?: any) => {
+      if (!isSupabaseConfigured()) return;
+      const mrc = env.MESH_REQUEST_CONTEXT;
+      const connectionId = mrc?.connectionId;
+      console.log(
+        `[onChange] fired (connection=${connectionId ?? "none"}, hasToken=${!!mrc?.token})`,
+      );
+      if (!connectionId) return;
+
+      const existing = await loadConnection(connectionId).catch(() => null);
+      const organizationId = mrc?.organizationId || existing?.organization_id;
+      const meshUrl = mrc?.meshUrl || existing?.mesh_url;
+      if (!organizationId || !meshUrl) return;
+
+      // Prefer raw config.state (has serializable binding metadata);
+      // fall back to env state when config isn't provided.
+      const rawState = (config?.state ?? mrc?.state) as
+        | Record<string, unknown>
+        | undefined;
+      const state = extractPersistableState(rawState);
+
+      // carry grant bookkeeping across saves
+      const previousGrants = existing?.state?.[API_KEY_GRANTS_STATE_KEY];
+      if (previousGrants !== undefined) {
+        state[API_KEY_GRANTS_STATE_KEY] = previousGrants;
+      }
+
+      // Durable API key: explicit state field wins; otherwise auto-mint
+      // (and re-mint when the binding set changes).
+      let meshApiKey =
+        (typeof state.MESH_API_KEY === "string" && state.MESH_API_KEY) ||
+        existing?.mesh_api_key ||
+        null;
+
+      const bindings = [
+        bindingConnectionId(state, "GITHUB"),
+        bindingConnectionId(state, "OBJECT_STORAGE"),
+      ].filter((v): v is string => !!v);
+      const grants = desiredGrants({
+        connectionId,
+        bindingConnectionIds: bindings,
+      });
+
+      const needsMint =
+        !state.MESH_API_KEY &&
+        mrc?.token &&
+        (!meshApiKey || grantsChanged(previousGrants, grants));
+      if (needsMint) {
+        const minted = await mintPersistentApiKey({
+          meshUrl,
+          organizationId,
+          connectionId,
+          temporaryToken: mrc.token,
+          grants,
+        });
+        if (minted) {
+          meshApiKey = minted;
+          state[API_KEY_GRANTS_STATE_KEY] = grants;
+          console.log(
+            `[onChange] minted persistent API key for ${connectionId}`,
+          );
+        }
+      }
+
+      await saveConnection({
+        connectionId,
+        organizationId,
+        meshUrl,
+        meshToken: mrc?.token ?? undefined,
+        meshApiKey: meshApiKey ?? undefined,
+        state,
+      });
+    },
+  },
+  tools: (env: Env) => tools.map((createTool) => createTool(env)),
+  resources: [dashboardResource],
+});
+
+function gracefulShutdown() {
+  try {
+    stopWorker();
+  } catch {
+    // best-effort
+  }
+  process.exit(0);
+}
+
+process.on("SIGINT", gracefulShutdown);
+process.on("SIGTERM", gracefulShutdown);
+
+serve(runtime.fetch);
+
+startWorker();

--- a/tanstack-migrator/server/migrator.test.ts
+++ b/tanstack-migrator/server/migrator.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from "bun:test";
+import { trimReportSummary } from "./lib/artifacts.ts";
+import { desiredGrants, grantsChanged } from "./lib/api-key.ts";
+import { parseRepo, targetRepoFor } from "./lib/github.ts";
+import { simulatedParityScore } from "./sandbox/drivers/manual.ts";
+import {
+  fixIterationPrompt,
+  migratePrompt,
+  parseResultJson,
+} from "./sandbox/templates/prompts.ts";
+import {
+  syncPackageScriptCommand,
+  syncWorkflowYaml,
+} from "./sandbox/templates/sync-files.ts";
+import type { SiteRow } from "./db/types.ts";
+
+const site = {
+  id: "site-1",
+  connection_id: "conn-1",
+  name: "granadobr",
+  source_repo: "deco-sites/granadobr",
+  source_branch: "main",
+  prod_url: "https://www.granado.com.br",
+  target_repo: "deco-sites/granadobr-tanstack",
+  status: "validating",
+  parity_target: 95,
+  max_iterations: 8,
+  no_improve_limit: 3,
+  iterations_done: 2,
+  no_improve_count: 0,
+} as unknown as SiteRow;
+
+describe("parseResultJson", () => {
+  test("parses the RESULT_JSON line from session output", () => {
+    const output = `fiz um monte de coisa...\nRESULT_JSON: {"ok": true, "parityScore": 87.5, "detail": "corrigi o hero"}`;
+    expect(parseResultJson(output)).toEqual({
+      ok: true,
+      parityScore: 87.5,
+      detail: "corrigi o hero",
+    });
+  });
+
+  test("uses the LAST marker when the prompt echoes one", () => {
+    const output = `o formato é RESULT_JSON: {"ok": false}\n...trabalho...\nRESULT_JSON: {"ok": true, "parityScore": 96}`;
+    expect(parseResultJson(output)?.ok).toBe(true);
+    expect(parseResultJson(output)?.parityScore).toBe(96);
+  });
+
+  test("returns null without a marker or with broken JSON", () => {
+    expect(parseResultJson("no marker here")).toBeNull();
+    expect(parseResultJson("RESULT_JSON: {broken")).toBeNull();
+  });
+
+  test("ok=false carries the detail as failure reason", () => {
+    const parsed = parseResultJson(
+      'RESULT_JSON: {"ok": false, "detail": "build quebrado"}',
+    );
+    expect(parsed).toEqual({
+      ok: false,
+      parityScore: undefined,
+      detail: "build quebrado",
+    });
+  });
+});
+
+describe("prompts", () => {
+  test("migratePrompt embeds repos, token and result contract", () => {
+    const prompt = migratePrompt({ site, ghToken: "ghs_abc" });
+    expect(prompt).toContain("deco-sites/granadobr");
+    expect(prompt).toContain("deco-sites/granadobr-tanstack");
+    expect(prompt).toContain("x-access-token:ghs_abc");
+    expect(prompt).toContain("migrate.ts --source /work/source");
+    expect(prompt).toContain("RESULT_JSON");
+    expect(prompt).toContain("MIGRATION_REPORT_PROGRESS");
+  });
+
+  test("without ghToken uses plain URLs and notes mesh-synced git auth", () => {
+    const prompt = migratePrompt({ site });
+    expect(prompt).toContain("https://github.com/deco-sites/granadobr.git");
+    expect(prompt).not.toContain("x-access-token");
+    expect(prompt).toContain("credenciais sincronizadas pelo mesh");
+  });
+
+  test("fixIterationPrompt embeds parity command, target and uploads", () => {
+    const prompt = fixIterationPrompt({
+      site,
+      iteration: 3,
+      ghToken: "ghs_abc",
+      anthropicApiKey: "sk-ant-xxx",
+      artifacts: {
+        reportHtmlPut: "https://storage/put-html",
+        reportJsonPut: "https://storage/put-json",
+        heatmapPuts: ["https://storage/put-h0"],
+      },
+    });
+    expect(prompt).toContain(
+      "@decocms/parity run --prod https://www.granado.com.br",
+    );
+    expect(prompt).toContain("--cand http://localhost:3000");
+    expect(prompt).toContain("ANTHROPIC_API_KEY=sk-ant-xxx");
+    expect(prompt).toContain("score >= 95");
+    expect(prompt).toContain("https://storage/put-html");
+    expect(prompt).toContain("https://storage/put-h0");
+  });
+});
+
+describe("trimReportSummary", () => {
+  test("keeps verdict, caps topIssues at 10 and perPage at 20", () => {
+    const summary = trimReportSummary({
+      verdict: { status: "warn", score: 82, critical: 0, high: 2 },
+      topIssues: Array.from({ length: 15 }, (_, i) => ({
+        severity: "high",
+        summary: `issue ${i}`,
+        page: "/",
+      })),
+      visualDiff: {
+        parityOk: false,
+        results: Array.from({ length: 30 }, (_, i) => ({
+          pagePath: `/p${i}`,
+          viewport: "mobile",
+          pctDiff: i,
+          verdict: "diffs",
+          sectionsOnlyInProd: ["hero"],
+        })),
+      },
+    });
+    expect(summary.verdict?.score).toBe(82);
+    expect(summary.parityOk).toBe(false);
+    expect(summary.topIssues).toHaveLength(10);
+    expect(summary.perPage).toHaveLength(20);
+    expect(summary.perPage?.[0]).toMatchObject({
+      pagePath: "/p0",
+      sectionsOnlyInProd: ["hero"],
+    });
+  });
+});
+
+describe("github helpers", () => {
+  test("parseRepo splits owner/repo and rejects garbage", () => {
+    expect(parseRepo("deco-sites/granadobr")).toEqual({
+      owner: "deco-sites",
+      repo: "granadobr",
+    });
+    expect(() => parseRepo("granadobr")).toThrow();
+  });
+
+  test("targetRepoFor appends -tanstack under the configured org", () => {
+    expect(targetRepoFor(site, "deco-sites")).toBe(
+      "deco-sites/granadobr-tanstack",
+    );
+  });
+});
+
+describe("api key grants", () => {
+  test("desiredGrants dedupes and includes self + connection + bindings", () => {
+    expect(
+      desiredGrants({
+        connectionId: "conn-1",
+        bindingConnectionIds: ["gh-1", "st-1", "gh-1"],
+      }),
+    ).toEqual(["self", "conn-1", "gh-1", "st-1"]);
+  });
+
+  test("grantsChanged detects new bindings and tolerates supersets", () => {
+    expect(grantsChanged(["self", "conn-1"], ["self", "conn-1", "gh-1"])).toBe(
+      true,
+    );
+    expect(grantsChanged(["self", "conn-1", "gh-1"], ["self", "conn-1"])).toBe(
+      false,
+    );
+    expect(grantsChanged(undefined, ["self"])).toBe(true);
+  });
+});
+
+describe("simulation", () => {
+  test("parity score ramps deterministically and caps at 100", () => {
+    expect(simulatedParityScore(1)).toBe(73);
+    expect(simulatedParityScore(3)).toBe(95);
+    expect(simulatedParityScore(10)).toBe(100);
+  });
+});
+
+describe("sync templates", () => {
+  test("workflow yaml references the prod host and the package script", () => {
+    const yaml = syncWorkflowYaml({ prodUrl: "https://www.granado.com.br" });
+    expect(yaml).toContain('cron: "*/30 * * * *"');
+    expect(yaml).toContain("bun run sync:decofile");
+    expect(yaml).toContain("sync: .deco/blocks from www.granado.com.br");
+  });
+
+  test("package script points the shim at the prod url", () => {
+    expect(syncPackageScriptCommand("https://www.granado.com.br")).toBe(
+      "bun scripts/sync-decofile.ts --url https://www.granado.com.br",
+    );
+  });
+});

--- a/tanstack-migrator/server/resources/index.ts
+++ b/tanstack-migrator/server/resources/index.ts
@@ -1,0 +1,10 @@
+import { DASHBOARD_RESOURCE_URI } from "../constants.ts";
+import { createMcpAppResource } from "./mcp-app-resource.ts";
+
+export const dashboardResource = createMcpAppResource({
+  uri: DASHBOARD_RESOURCE_URI,
+  name: "TanStack Migrator Dashboard",
+  description:
+    "Migration queue with parity scores, needs-human list, finished sites and parity reports.",
+  htmlFile: "dashboard.html",
+});

--- a/tanstack-migrator/server/resources/mcp-app-resource.ts
+++ b/tanstack-migrator/server/resources/mcp-app-resource.ts
@@ -1,0 +1,44 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createPublicResource } from "@decocms/runtime/tools";
+
+const RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
+
+function getHtmlPath(filename: string): string {
+  const projectRoot = join(import.meta.dir, "../..");
+  return join(projectRoot, "dist", "client", filename);
+}
+
+export function createMcpAppResource(options: {
+  uri: string;
+  name: string;
+  description: string;
+  htmlFile: string;
+}) {
+  return (_env: unknown) =>
+    createPublicResource({
+      uri: options.uri,
+      name: options.name,
+      description: options.description,
+      mimeType: RESOURCE_MIME_TYPE,
+      read: async () => {
+        const htmlPath = getHtmlPath(options.htmlFile);
+        try {
+          const html = await readFile(htmlPath, "utf-8");
+          return {
+            uri: options.uri,
+            mimeType: RESOURCE_MIME_TYPE,
+            text: html,
+          };
+        } catch (err) {
+          const message =
+            err instanceof Error && "code" in err && err.code === "ENOENT"
+              ? `MCP App bundle not found at ${htmlPath}. Run "bun run build:web" in the tanstack-migrator folder (or "bun run dev" to build and watch).`
+              : err instanceof Error
+                ? err.message
+                : "Failed to read MCP App bundle";
+          throw new Error(message);
+        }
+      },
+    });
+}

--- a/tanstack-migrator/server/sandbox/client.ts
+++ b/tanstack-migrator/server/sandbox/client.ts
@@ -1,0 +1,78 @@
+/**
+ * SandboxClient — abstraction over "where the migration actually runs".
+ *
+ * Drivers:
+ *   - manual:    end-to-end simulation (no external effects). Used for demos
+ *                and to exercise the queue/UI without touching mesh.
+ *   - decopilot: live mode. Lifecycle via mesh management tools
+ *                (VM_START/VM_DELETE on /mcp/self) and execution via bounded
+ *                decopilot sessions (claude-code provider) — the same path
+ *                the agentic CMS uses.
+ *
+ * A future `daemon` driver (mesh PR exposing bash/read externally) can slot
+ * in here without touching the engine.
+ */
+
+import type { SiteRow } from "../db/types.ts";
+import type { WorkerCtx } from "../lib/mesh.ts";
+import { decopilotDriver } from "./drivers/decopilot.ts";
+import { manualDriver } from "./drivers/manual.ts";
+
+export interface SandboxInfo {
+  handle: string;
+  previewUrl: string | null;
+  virtualMcpId?: string;
+}
+
+export type SandboxTaskKind = "migrate" | "fix_iteration" | "parity";
+
+export interface SandboxTaskInput {
+  kind: SandboxTaskKind;
+  prompt: string;
+  /** Parity iteration number, for logging/artifacts. */
+  iteration?: number;
+  timeoutMs?: number;
+}
+
+export interface SandboxTaskResult {
+  ok: boolean;
+  /** Tail of the session output (stored in sitemig_runs.logs_tail). */
+  output: string;
+  /** Parity score parsed from the task output, when the task produces one. */
+  parityScore?: number;
+  error?: string;
+}
+
+export interface SandboxDriver {
+  readonly name: "manual" | "decopilot";
+  /**
+   * Optional pre-step: create the driver's project entity (e.g. mesh
+   * virtualMcp) so the phase can PERSIST its id before ensure() — a failed
+   * ensure() then retries against the same project instead of duplicating.
+   */
+  prepareProject?(
+    site: SiteRow,
+    ctx: WorkerCtx,
+  ): Promise<{ virtualMcpId: string }>;
+  /** Idempotent: create the sandbox if needed, return handle + preview URL. */
+  ensure(site: SiteRow, ctx: WorkerCtx): Promise<SandboxInfo>;
+  /** Run one bounded task (migrate pass / parity+fix iteration). */
+  runTask(
+    site: SiteRow,
+    ctx: WorkerCtx,
+    task: SandboxTaskInput,
+  ): Promise<SandboxTaskResult>;
+  /** Reset the sandbox idle TTL (mesh reaps after ~15min idle). */
+  keepalive(site: SiteRow, ctx: WorkerCtx): Promise<void>;
+  destroy(site: SiteRow, ctx: WorkerCtx): Promise<void>;
+}
+
+export function getDriver(ctx: WorkerCtx): SandboxDriver {
+  return ctx.config.sandboxProvider === "decopilot"
+    ? decopilotDriver
+    : manualDriver;
+}
+
+export function isSimulation(ctx: WorkerCtx): boolean {
+  return ctx.config.sandboxProvider === "manual";
+}

--- a/tanstack-migrator/server/sandbox/drivers/decopilot.ts
+++ b/tanstack-migrator/server/sandbox/drivers/decopilot.ts
@@ -1,0 +1,239 @@
+/**
+ * Decopilot driver — live mode via the same path the agentic CMS uses
+ * (verified against mesh main @ 2026-07-03, apps/mesh/src/tools/{sandbox,virtual}):
+ *
+ *   project:   COLLECTION_VIRTUAL_MCP_CREATE on {meshUrl}/mcp/self creates the
+ *              virtual MCP bound to the repo (metadata.githubRepo {url, owner,
+ *              name, connectionId?, installationId?}).
+ *   lifecycle: SANDBOX_START / SANDBOX_DELETE management tools on /mcp/self
+ *              ({virtualMcpId, branch, sandboxProviderKind: "agent-sandbox"}).
+ *              Re-calling SANDBOX_START resets the idle TTL (keepalive).
+ *   execution: bounded decopilot sessions (claude-code provider) at
+ *              {meshUrl}/api/{org}/decopilot/stream — mesh runs the agent
+ *              loop and executes bash/edits inside the sandbox via its
+ *              internal vm tools.
+ */
+
+import { collectFullStreamText } from "@decocms/mcps-shared/mesh-chat";
+import type { SiteRow } from "../../db/types.ts";
+import {
+  callSelfTool,
+  resolveMeshUrl,
+  type WorkerCtx,
+} from "../../lib/mesh.ts";
+import { bindingConnectionId } from "../../lib/persist-state.ts";
+import { parseRepo } from "../../lib/github.ts";
+import type {
+  SandboxDriver,
+  SandboxInfo,
+  SandboxTaskInput,
+  SandboxTaskResult,
+} from "../client.ts";
+import { parseResultJson } from "../templates/prompts.ts";
+
+/** Model routed to the mesh-side Claude Code coding agent. Override per pod if needed. */
+const DECOPILOT_MODEL_ID =
+  process.env.MIGRATOR_DECOPILOT_MODEL ?? "claude-code:sonnet";
+
+const DEFAULT_TASK_TIMEOUT_MS = 45 * 60_000;
+/** Hosted sandbox; never "user-desktop" (headless worker has no link daemon). */
+const SANDBOX_PROVIDER_KIND = "agent-sandbox";
+const SANDBOX_BRANCH = "main";
+
+interface SandboxStartResult {
+  previewUrl?: string | null;
+  sandboxHandle?: string;
+  branch?: string;
+  isNewVm?: boolean;
+  sandboxProviderKind?: string;
+}
+
+/** Create the mesh project (virtual MCP) bound to the -tanstack repo. */
+async function createVirtualMcp(
+  site: SiteRow,
+  ctx: WorkerCtx,
+): Promise<string> {
+  if (!site.target_repo) {
+    throw new Error(`Site ${site.name} has no target_repo yet`);
+  }
+  const { owner, repo } = parseRepo(site.target_repo);
+  const githubConnectionId =
+    bindingConnectionId(ctx.state, "GITHUB") ?? undefined;
+
+  const result = await callSelfTool<{ item?: { id?: string } }>(
+    ctx,
+    "COLLECTION_VIRTUAL_MCP_CREATE",
+    {
+      data: {
+        title: `${site.name} · tanstack migration`,
+        description: `Managed by tanstack-migrator — ${site.source_repo} → ${site.target_repo}`,
+        metadata: {
+          githubRepo: {
+            url: `https://github.com/${site.target_repo}`,
+            owner,
+            name: repo,
+            ...(githubConnectionId ? { connectionId: githubConnectionId } : {}),
+            ...(ctx.config.githubInstallationId
+              ? { installationId: ctx.config.githubInstallationId }
+              : {}),
+          },
+        },
+        connections: [],
+      },
+    },
+    60_000,
+  );
+
+  const id = result?.item?.id;
+  if (!id) {
+    throw new Error(
+      `COLLECTION_VIRTUAL_MCP_CREATE returned no id: ${JSON.stringify(result).slice(0, 200)}`,
+    );
+  }
+  return id;
+}
+
+async function sandboxStart(
+  virtualMcpId: string,
+  ctx: WorkerCtx,
+): Promise<SandboxStartResult> {
+  return await callSelfTool<SandboxStartResult>(
+    ctx,
+    "SANDBOX_START",
+    {
+      virtualMcpId,
+      branch: SANDBOX_BRANCH,
+      sandboxProviderKind: SANDBOX_PROVIDER_KIND,
+    },
+    180_000,
+  );
+}
+
+/** One bounded decopilot session; resolves with the final assistant text. */
+async function runDecopilotSession(
+  ctx: WorkerCtx,
+  prompt: string,
+  timeoutMs: number,
+): Promise<string> {
+  const base = resolveMeshUrl(ctx.meshUrl);
+  const url = `${base}/api/${ctx.organizationId}/decopilot/stream`;
+  if (!ctx.meshToken) {
+    throw new Error("No mesh token available for decopilot sessions");
+  }
+
+  const body = {
+    messages: [
+      {
+        id: `migrator-${Date.now()}`,
+        role: "user",
+        parts: [{ type: "text", text: prompt }],
+      },
+    ],
+    models: {
+      thinking: {
+        id: DECOPILOT_MODEL_ID,
+        provider: "claude-code",
+      },
+    },
+    stream: true,
+    toolApprovalLevel: "auto" as const,
+  };
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${ctx.meshToken}`,
+      Accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `decopilot stream failed (${response.status}): ${errorText.slice(0, 300)}`,
+    );
+  }
+  if (!response.body) {
+    throw new Error("decopilot stream returned no body");
+  }
+
+  return await collectFullStreamText(response.body);
+}
+
+export const decopilotDriver: SandboxDriver = {
+  name: "decopilot",
+
+  async prepareProject(
+    site: SiteRow,
+    ctx: WorkerCtx,
+  ): Promise<{ virtualMcpId: string }> {
+    if (site.virtual_mcp_id) return { virtualMcpId: site.virtual_mcp_id };
+    return { virtualMcpId: await createVirtualMcp(site, ctx) };
+  },
+
+  async ensure(site: SiteRow, ctx: WorkerCtx): Promise<SandboxInfo> {
+    const virtualMcpId =
+      site.virtual_mcp_id ?? (await createVirtualMcp(site, ctx));
+
+    const result = await sandboxStart(virtualMcpId, ctx);
+    if (!result.sandboxHandle) {
+      throw new Error(
+        `SANDBOX_START returned no sandboxHandle: ${JSON.stringify(result).slice(0, 200)}`,
+      );
+    }
+    return {
+      handle: result.sandboxHandle,
+      previewUrl: result.previewUrl ?? null,
+      virtualMcpId,
+    };
+  },
+
+  async runTask(
+    site: SiteRow,
+    ctx: WorkerCtx,
+    task: SandboxTaskInput,
+  ): Promise<SandboxTaskResult> {
+    const timeoutMs = task.timeoutMs ?? DEFAULT_TASK_TIMEOUT_MS;
+    const output = await runDecopilotSession(ctx, task.prompt, timeoutMs);
+    const tail = output.slice(-4000);
+    const result = parseResultJson(output);
+
+    if (!result) {
+      return {
+        ok: false,
+        output: tail,
+        error: "session ended without a RESULT_JSON line",
+      };
+    }
+    return {
+      ok: result.ok,
+      output: tail,
+      parityScore: result.parityScore,
+      error: result.ok
+        ? undefined
+        : (result.detail ?? "task reported ok=false"),
+    };
+  },
+
+  async keepalive(site: SiteRow, ctx: WorkerCtx): Promise<void> {
+    if (!site.virtual_mcp_id) return;
+    // SANDBOX_START on an existing VM is the documented way to reset the idle TTL
+    await sandboxStart(site.virtual_mcp_id, ctx);
+  },
+
+  async destroy(site: SiteRow, ctx: WorkerCtx): Promise<void> {
+    if (!site.virtual_mcp_id) return;
+    try {
+      await callSelfTool(ctx, "SANDBOX_DELETE", {
+        virtualMcpId: site.virtual_mcp_id,
+        branch: SANDBOX_BRANCH,
+        sandboxProviderKind: SANDBOX_PROVIDER_KIND,
+      });
+    } catch {
+      // sandbox may already be reaped by the idle TTL — fine
+    }
+  },
+};

--- a/tanstack-migrator/server/sandbox/drivers/manual.ts
+++ b/tanstack-migrator/server/sandbox/drivers/manual.ts
@@ -1,0 +1,63 @@
+/**
+ * Manual driver — full simulation. No external calls at all; every task
+ * "succeeds" after a short delay so the queue, state machine and dashboard
+ * can be demoed end-to-end. Parity scores follow a deterministic ramp
+ * (62 → +11 per iteration) so the UI shows a believable progression.
+ */
+
+import { SIMULATION_STEP_MS } from "../../constants.ts";
+import type { SiteRow } from "../../db/types.ts";
+import type { WorkerCtx } from "../../lib/mesh.ts";
+import type {
+  SandboxDriver,
+  SandboxInfo,
+  SandboxTaskInput,
+  SandboxTaskResult,
+} from "../client.ts";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export function simulatedParityScore(iteration: number): number {
+  return Math.min(100, 62 + iteration * 11);
+}
+
+export const manualDriver: SandboxDriver = {
+  name: "manual",
+
+  async ensure(site: SiteRow): Promise<SandboxInfo> {
+    await sleep(SIMULATION_STEP_MS);
+    return {
+      handle: `manual:${site.id}`,
+      previewUrl: `https://sandbox-simulado.local/${site.name}`,
+    };
+  },
+
+  async runTask(
+    site: SiteRow,
+    _ctx: WorkerCtx,
+    task: SandboxTaskInput,
+  ): Promise<SandboxTaskResult> {
+    await sleep(SIMULATION_STEP_MS);
+    if (task.kind === "migrate") {
+      return {
+        ok: true,
+        output: `[simulation] migrate script ran for ${site.source_repo}; build green; initial push done`,
+      };
+    }
+    const iteration = task.iteration ?? site.iterations_done;
+    const score = simulatedParityScore(iteration + 1);
+    return {
+      ok: true,
+      output: `[simulation] parity iteration ${iteration + 1} → score ${score}`,
+      parityScore: score,
+    };
+  },
+
+  async keepalive(): Promise<void> {
+    // nothing to keep alive
+  },
+
+  async destroy(): Promise<void> {
+    // nothing to destroy
+  },
+};

--- a/tanstack-migrator/server/sandbox/templates/prompts.ts
+++ b/tanstack-migrator/server/sandbox/templates/prompts.ts
@@ -1,0 +1,153 @@
+/**
+ * Prompts for the bounded decopilot sessions that drive a migration inside
+ * a mesh sandbox. The session agent has the vm tools (bash/read/write) bound
+ * to the site's sandbox, plus the org's MCP tools — including this MCP's
+ * MIGRATION_REPORT_PROGRESS for granular progress callbacks.
+ *
+ * Contract: the FINAL assistant message must contain a single line
+ *   RESULT_JSON: {"ok": true|false, "parityScore": <number|null>, "detail": "..."}
+ * which the driver parses to decide the phase outcome.
+ */
+
+import type { SiteRow } from "../../db/types.ts";
+
+export const RESULT_MARKER = "RESULT_JSON:";
+
+export interface ParityArtifactUrls {
+  reportHtmlPut?: string;
+  reportJsonPut?: string;
+  heatmapPuts?: string[];
+}
+
+export function parseResultJson(output: string): {
+  ok: boolean;
+  parityScore?: number;
+  detail?: string;
+} | null {
+  const idx = output.lastIndexOf(RESULT_MARKER);
+  if (idx === -1) return null;
+  const rest = output.slice(idx + RESULT_MARKER.length);
+  const match = rest.match(/\{[\s\S]*?\}/);
+  if (!match) return null;
+  try {
+    const parsed = JSON.parse(match[0]) as {
+      ok?: boolean;
+      parityScore?: number | null;
+      detail?: string;
+    };
+    return {
+      ok: parsed.ok === true,
+      parityScore:
+        typeof parsed.parityScore === "number" ? parsed.parityScore : undefined,
+      detail: parsed.detail,
+    };
+  } catch {
+    return null;
+  }
+}
+
+const progressInstruction = (site: SiteRow) =>
+  `Sempre que concluir um passo relevante, chame a tool MIGRATION_REPORT_PROGRESS do MCP tanstack-migrator com {"siteId": "${site.id}", "detail": "<o que acabou de fazer>"} (e "parityScore" quando tiver um score novo).`;
+
+function repoUrl(full: string | null, ghToken?: string): string {
+  if (!full) throw new Error("repo not set");
+  return ghToken
+    ? `https://x-access-token:${ghToken}@github.com/${full}.git`
+    : `https://github.com/${full}.git`;
+}
+
+const gitAuthNote = (ghToken?: string) =>
+  ghToken
+    ? ""
+    : "\nObs: o git do sandbox já está autenticado (credenciais sincronizadas pelo mesh) — clone e push funcionam com as URLs https normais.";
+
+export function migratePrompt(input: {
+  site: SiteRow;
+  ghToken?: string;
+  anthropicApiKey?: string;
+}): string {
+  const { site, ghToken } = input;
+  const sourceUrl = repoUrl(site.source_repo, ghToken);
+  const targetUrl = repoUrl(site.target_repo, ghToken);
+
+  return `Você é o agente de migração Fresh→TanStack da deco. Trabalhe dentro do sandbox usando as tools de vm (bash, read, write). Seja objetivo e não peça confirmação — execute até o fim.
+
+# Objetivo
+Migrar o storefront ${site.source_repo} (Fresh/Deno) para TanStack Start e publicar o resultado em ${site.target_repo}.
+
+# Passos
+1. Se /work/source ainda não existe: \`git clone --depth 1 -b ${site.source_branch} ${sourceUrl} /work/source\` (cópia pristina do site original — NUNCA modifique).
+2. Se /work/site ainda não existe: \`git clone ${sourceUrl} /work/site && cd /work/site && git remote set-url origin ${targetUrl}\`.
+3. Em /work/site: \`npm install @decocms/start tsx\` e rode o script de migração: \`npx tsx node_modules/@decocms/start/scripts/migrate.ts --source /work/source\`. Ele roda 7 fases (analyze, scaffold, transform, cleanup, report, verify, bootstrap). Se o repo já tiver MIGRATION_REPORT.md de uma execução anterior, pule esta etapa.
+4. Corrija erros até \`npx tsc --noEmit\` e \`npm run build\` passarem. Regra de ouro: NUNCA reescreva componentes — porte o original de /work/source com mudanças mecânicas (imports preact→react, class→className, signals→estado react). Consulte /work/source sempre que precisar do comportamento original.
+5. Commit e push: \`git add -A && git commit -m "feat: initial tanstack migration" && git push -u -f origin main\` (o repo alvo é gerenciado pela migração e acabou de ser criado — o force do push inicial é seguro e sobrescreve qualquer README/commit inicial).
+6. Suba o dev server em background na porta 3000: \`nohup bun run dev > /work/dev.log 2>&1 &\` e confirme que responde 200 em http://localhost:3000.
+${gitAuthNote(ghToken)}
+${progressInstruction(site)}
+
+# Resultado
+Termine sua ÚLTIMA mensagem com uma linha exatamente neste formato:
+RESULT_JSON: {"ok": true, "detail": "migração inicial concluída, build verde, dev server de pé"}
+(ok=false com detail explicando o bloqueio se não conseguir terminar)`;
+}
+
+export function fixIterationPrompt(input: {
+  site: SiteRow;
+  iteration: number;
+  ghToken?: string;
+  anthropicApiKey?: string;
+  openrouterApiKey?: string;
+  artifacts?: ParityArtifactUrls;
+  previousIssues?: string[];
+}): string {
+  const { site, iteration, ghToken, artifacts } = input;
+  const targetUrl = repoUrl(site.target_repo, ghToken);
+  const parityEnv = [
+    input.anthropicApiKey ? `ANTHROPIC_API_KEY=${input.anthropicApiKey}` : "",
+    input.openrouterApiKey
+      ? `OPENROUTER_API_KEY=${input.openrouterApiKey}`
+      : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const uploadSteps: string[] = [];
+  if (artifacts?.reportHtmlPut) {
+    uploadSteps.push(
+      `curl -sf -X PUT -H "Content-Type: text/html" --upload-file "$RUN_DIR/report.html" '${artifacts.reportHtmlPut}'`,
+    );
+  }
+  if (artifacts?.reportJsonPut) {
+    uploadSteps.push(
+      `curl -sf -X PUT -H "Content-Type: application/json" --upload-file "$RUN_DIR/report.json" '${artifacts.reportJsonPut}'`,
+    );
+  }
+  (artifacts?.heatmapPuts ?? []).forEach((url, i) => {
+    uploadSteps.push(
+      `H=$(ls "$RUN_DIR"/screenshots/heatmap_*.png 2>/dev/null | sed -n '${i + 1}p'); [ -n "$H" ] && curl -sf -X PUT -H "Content-Type: image/png" --upload-file "$H" '${url}' || true`,
+    );
+  });
+
+  return `Você é o agente de validação de paridade da migração ${site.source_repo} → ${site.target_repo} (iteração ${iteration}). Trabalhe dentro do sandbox usando as tools de vm (bash, read, write). Não peça confirmação.
+
+# Contexto
+- Código migrado em /work/site (original pristino em /work/source — use como referência, nunca modifique).
+- Dev server deve estar de pé na porta 3000; se não estiver: \`cd /work/site && nohup bun run dev > /work/dev.log 2>&1 &\` e aguarde responder.
+- Produção (referência visual/funcional): ${site.prod_url}
+
+# Passos
+1. Rode a parity CLI comparando produção vs candidato:
+   \`cd /work/site && ${parityEnv} npx -y @decocms/parity run --prod ${site.prod_url} --cand http://localhost:3000 --preset ci\`
+2. Localize o diretório do run: \`RUN_DIR=$(ls -td parity-output/runs/*/ | head -1)\` e leia $RUN_DIR/report.json.
+${uploadSteps.length > 0 ? `3. Faça upload dos artefatos:\n${uploadSteps.map((s) => `   ${s}`).join("\n")}` : "3. (sem upload de artefatos configurado)"}
+4. Extraia verdict.score do report.json. Se score >= ${site.parity_target}, NÃO mexa em mais nada — vá direto para o RESULT_JSON.
+5. Caso contrário, corrija os topIssues mais graves (componentes/seções faltando em sectionsOnlyInProd, hydration mismatch, erros de console, fluxo de compra). Porte sempre do original em /work/source. Depois: \`git add -A && git commit -m "fix(parity): iteration ${iteration}" && git push origin main\` (remote: ${targetUrl}) e reinicie o dev server.${gitAuthNote(ghToken)}
+${input.previousIssues?.length ? `\n# Issues em aberto da iteração anterior\n${input.previousIssues.map((i) => `- ${i}`).join("\n")}` : ""}
+
+${progressInstruction(site)}
+
+# Resultado
+Termine sua ÚLTIMA mensagem com uma linha exatamente neste formato:
+RESULT_JSON: {"ok": true, "parityScore": <verdict.score do report.json>, "detail": "<resumo do que corrigiu>"}
+(ok=false apenas se a parity CLI nem conseguiu rodar)`;
+}

--- a/tanstack-migrator/server/sandbox/templates/sync-files.ts
+++ b/tanstack-migrator/server/sandbox/templates/sync-files.ts
@@ -1,0 +1,223 @@
+/**
+ * Files installed into the -tanstack repo so CMS content edited on the
+ * production (Fresh) site keeps flowing in: a scheduled GitHub workflow that
+ * fetches /.decofile from production and rewrites .deco/blocks/.
+ *
+ * Mirrors deco-sites/granadobr-tanstack (.github/workflows/sync-decofile.yml
+ * + scripts/sync-decofile.ts). The script is a local shim of
+ * @decocms/start/scripts/sync-decofile.ts — replace with the node_modules
+ * path once every migrated site is on a release that bundles it.
+ */
+
+export const SYNC_WORKFLOW_PATH = ".github/workflows/sync-decofile.yml";
+export const SYNC_SCRIPT_PATH = "scripts/sync-decofile.ts";
+export const SYNC_PACKAGE_SCRIPT_NAME = "sync:decofile";
+
+export function syncPackageScriptCommand(prodUrl: string): string {
+  return `bun ${SYNC_SCRIPT_PATH} --url ${prodUrl}`;
+}
+
+export function syncWorkflowYaml(input: { prodUrl: string }): string {
+  const host = input.prodUrl.replace(/^https?:\/\//, "").replace(/\/$/, "");
+  return `name: Sync .deco/blocks from production
+
+# Mirrors blocks edited via the deco admin UI on ${input.prodUrl}
+# into this repo's .deco/blocks/ so the TanStack migration sees fresh CMS
+# state. Runs every 30 min on schedule and on-demand via workflow_dispatch.
+# Installed automatically by the tanstack-migrator MCP.
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Fetch /.decofile and write blocks
+        run: bun run ${SYNC_PACKAGE_SCRIPT_NAME}
+
+      - name: Commit & push if changed
+        run: |
+          git config user.name "deco-sync-bot"
+          git config user.email "sync@deco.cx"
+          git add .deco/blocks/
+          if git diff --staged --quiet; then
+            echo "No changes to sync"
+            exit 0
+          fi
+          git commit -m "sync: .deco/blocks from ${host}"
+          git push
+`;
+}
+
+export function syncScriptSource(): string {
+  return `#!/usr/bin/env bun
+/**
+ * Local shim for \`@decocms/start/scripts/sync-decofile.ts\`.
+ * Installed by the tanstack-migrator MCP. Behaviour mirrors the upstream
+ * script: fetch /.decofile from production and rewrite .deco/blocks/.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+interface ParsedArgs {
+  site?: string;
+  url?: string;
+  out: string;
+  dryRun: boolean;
+  clean: boolean;
+}
+
+function parseArgs(): ParsedArgs {
+  const argv = process.argv.slice(2);
+  const get = (name: string): string | undefined => {
+    const i = argv.indexOf(\`--\${name}\`);
+    if (i === -1 || !argv[i + 1] || argv[i + 1].startsWith("--")) return undefined;
+    return argv[i + 1];
+  };
+  const has = (name: string): boolean => argv.includes(\`--\${name}\`);
+  return {
+    site: get("site"),
+    url: get("url"),
+    out: get("out") ?? ".deco/blocks",
+    dryRun: has("dry-run"),
+    clean: !has("no-clean"),
+  };
+}
+
+function normalizeKey(rawKey: string): string {
+  let k = rawKey;
+  while (k.includes("%")) {
+    try {
+      const next = decodeURIComponent(k);
+      if (next === k) break;
+      k = next;
+    } catch {
+      break;
+    }
+  }
+  return k;
+}
+
+function encodeBlockKeyToFilename(key: string): string {
+  return encodeURIComponent(key) + ".json";
+}
+
+function normalizeBlocks(raw: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    out[normalizeKey(k)] = v;
+  }
+  return out;
+}
+
+async function fetchDecofile(baseUrl: string): Promise<Record<string, unknown>> {
+  const url = baseUrl.replace(/\\/$/, "") + "/.decofile";
+  console.log(\`Fetching \${url} ...\`);
+  const res = await fetch(url, { headers: { "user-agent": "decocms-sync-decofile/1.0" } });
+  if (!res.ok) throw new Error(\`GET \${url} returned \${res.status} \${res.statusText}\`);
+  const json = (await res.json()) as Record<string, unknown>;
+  if (!json || typeof json !== "object") throw new Error(\`Unexpected response shape from \${url}\`);
+  return json;
+}
+
+function readExistingSnapshot(dir: string): Record<string, unknown> {
+  if (!fs.existsSync(dir)) return {};
+  const out: Record<string, unknown> = {};
+  for (const f of fs.readdirSync(dir).filter((x) => x.endsWith(".json"))) {
+    const key = normalizeKey(f.replace(/\\.json$/, ""));
+    try {
+      out[key] = JSON.parse(fs.readFileSync(path.join(dir, f), "utf-8"));
+    } catch {
+      // ignore unparseable
+    }
+  }
+  return out;
+}
+
+function diffSnapshots(
+  next: Record<string, unknown>,
+  prev: Record<string, unknown>,
+): { added: string[]; removed: string[]; changed: string[] } {
+  const nextKeys = new Set(Object.keys(next));
+  const prevKeys = new Set(Object.keys(prev));
+  const added: string[] = [];
+  const removed: string[] = [];
+  const changed: string[] = [];
+  for (const k of nextKeys) {
+    if (!prevKeys.has(k)) added.push(k);
+    else if (JSON.stringify(next[k]) !== JSON.stringify(prev[k])) changed.push(k);
+  }
+  for (const k of prevKeys) if (!nextKeys.has(k)) removed.push(k);
+  return { added, removed, changed };
+}
+
+function writeAtomically(dir: string, blocks: Record<string, unknown>, clean: boolean): void {
+  const stagingDir = \`\${dir}.tmp-\${process.pid}\`;
+  if (fs.existsSync(stagingDir)) fs.rmSync(stagingDir, { recursive: true, force: true });
+  fs.mkdirSync(stagingDir, { recursive: true });
+  for (const [key, value] of Object.entries(blocks)) {
+    fs.writeFileSync(
+      path.join(stagingDir, encodeBlockKeyToFilename(key)),
+      JSON.stringify(value, null, 2),
+    );
+  }
+  if (clean) {
+    if (fs.existsSync(dir)) fs.rmSync(dir, { recursive: true, force: true });
+    fs.renameSync(stagingDir, dir);
+  } else {
+    fs.mkdirSync(dir, { recursive: true });
+    for (const f of fs.readdirSync(stagingDir)) {
+      fs.copyFileSync(path.join(stagingDir, f), path.join(dir, f));
+    }
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  if (!args.site && !args.url) {
+    console.error("Usage: bun scripts/sync-decofile.ts --site <name>  OR  --url <base-url>");
+    process.exit(2);
+  }
+  const baseUrl = args.url ?? \`https://www.\${args.site}.com.br\`;
+  const outDir = path.resolve(process.cwd(), args.out);
+
+  const next = normalizeBlocks(await fetchDecofile(baseUrl));
+  const prev = readExistingSnapshot(outDir);
+  const diff = diffSnapshots(next, prev);
+
+  console.log("");
+  console.log(\`  fetched  \${Object.keys(next).length} blocks\`);
+  console.log(\`  on disk  \${Object.keys(prev).length} blocks\`);
+  console.log(\`  added    \${diff.added.length}\`);
+  console.log(\`  removed  \${diff.removed.length}\`);
+  console.log(\`  changed  \${diff.changed.length}\`);
+  console.log("");
+
+  if (args.dryRun) {
+    console.log("--dry-run set, not writing.");
+    return;
+  }
+
+  writeAtomically(outDir, next, args.clean);
+  console.log(\`Wrote \${Object.keys(next).length} blocks to \${path.relative(process.cwd(), outDir)}\`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+`;
+}

--- a/tanstack-migrator/server/tools/admin.ts
+++ b/tanstack-migrator/server/tools/admin.ts
@@ -1,0 +1,21 @@
+/** Debug/ops tools. */
+
+import { createPrivateTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { runTickOnce } from "../engine/worker.ts";
+import type { Env } from "../types/env.ts";
+
+export const createAdvanceQueueTool = (_env: Env) =>
+  createPrivateTool({
+    id: "ADVANCE_QUEUE",
+    description:
+      "Force one worker tick right now (the queue also advances automatically every 30s). Useful for debugging.",
+    inputSchema: z.object({}),
+    outputSchema: z.object({
+      connections: z.number(),
+      advanced: z.number(),
+    }),
+    execute: async () => {
+      return await runTickOnce();
+    },
+  });

--- a/tanstack-migrator/server/tools/dashboard.ts
+++ b/tanstack-migrator/server/tools/dashboard.ts
@@ -1,0 +1,58 @@
+/** Dashboard entry tool — opens the MCP App UI with an aggregate snapshot. */
+
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { DASHBOARD_RESOURCE_URI } from "../constants.ts";
+import { listSites } from "../db/sites.ts";
+import { ACTIVE_STATUSES } from "../db/types.ts";
+import { ensureApiKeyFromRequest } from "../lib/ensure-api-key.ts";
+import { parseMigratorConfig, type Env } from "../types/env.ts";
+import { SiteViewSchema, toSiteView } from "./views.ts";
+
+export const createDashboardTool = (env: Env) =>
+  createTool({
+    id: "TANSTACK_MIGRATOR_DASHBOARD",
+    description:
+      "Open the TanStack Migrator dashboard: migration queue with parity %, sites that are 100% TanStack, repos and reports.",
+    inputSchema: z.object({}),
+    outputSchema: z.object({
+      sites: z.array(SiteViewSchema),
+      queue: z.object({
+        active: z.number(),
+        queued: z.number(),
+        needsHuman: z.number(),
+        done: z.number(),
+        maxConcurrent: z.number(),
+        provider: z.string(),
+      }),
+      updatedAt: z.string(),
+    }),
+    _meta: { ui: { resourceUri: DASHBOARD_RESOURCE_URI } },
+    annotations: { readOnlyHint: true },
+    execute: async () => {
+      const connectionId = env.MESH_REQUEST_CONTEXT?.connectionId;
+      if (!connectionId) throw new Error("No connectionId in request context");
+      void ensureApiKeyFromRequest(env); // fire-and-forget, throttled
+
+      const config = parseMigratorConfig(
+        env.MESH_REQUEST_CONTEXT?.state as Record<string, unknown> | undefined,
+      );
+      const all = await listSites({ connectionId });
+      const visible = all.filter((s) => s.status !== "archived");
+
+      return {
+        sites: visible.map(toSiteView),
+        queue: {
+          active: visible.filter((s) =>
+            (ACTIVE_STATUSES as string[]).includes(s.status),
+          ).length,
+          queued: visible.filter((s) => s.status === "queued").length,
+          needsHuman: visible.filter((s) => s.status === "needs_human").length,
+          done: visible.filter((s) => s.status === "done").length,
+          maxConcurrent: config.maxConcurrent,
+          provider: config.sandboxProvider,
+        },
+        updatedAt: new Date().toISOString(),
+      };
+    },
+  });

--- a/tanstack-migrator/server/tools/index.ts
+++ b/tanstack-migrator/server/tools/index.ts
@@ -1,0 +1,31 @@
+import { createAdvanceQueueTool } from "./admin.ts";
+import { createDashboardTool } from "./dashboard.ts";
+import { createReportProgressTool } from "./progress.ts";
+import { createParityReportUrlsTool } from "./reports.ts";
+import {
+  createSiteArchiveTool,
+  createSiteDeleteTool,
+  createSiteGetTool,
+  createSiteListTool,
+  createSiteMarkDoneTool,
+  createSitePauseTool,
+  createSiteRegisterTool,
+  createSiteResumeTool,
+  createSiteRetryTool,
+} from "./sites.ts";
+
+export const tools = [
+  createDashboardTool,
+  createSiteRegisterTool,
+  createSiteListTool,
+  createSiteGetTool,
+  createSitePauseTool,
+  createSiteResumeTool,
+  createSiteRetryTool,
+  createSiteMarkDoneTool,
+  createSiteArchiveTool,
+  createSiteDeleteTool,
+  createParityReportUrlsTool,
+  createReportProgressTool,
+  createAdvanceQueueTool,
+];

--- a/tanstack-migrator/server/tools/progress.ts
+++ b/tanstack-migrator/server/tools/progress.ts
@@ -1,0 +1,45 @@
+/**
+ * Progress callback for the decopilot sessions driving a migration: the
+ * prompt instructs the agent to call this after each relevant step, which
+ * feeds the dashboard (phase detail, live parity score) and resets the
+ * watchdog clock.
+ */
+
+import { createPrivateTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { addEvent } from "../db/events.ts";
+import { getSite, updateSite } from "../db/sites.ts";
+import type { SiteRow } from "../db/types.ts";
+import type { Env } from "../types/env.ts";
+
+export const createReportProgressTool = (_env: Env) =>
+  createPrivateTool({
+    id: "MIGRATION_REPORT_PROGRESS",
+    description:
+      "Report migration progress for a site (called by the migration agent after each step). Updates the dashboard and resets the stall watchdog.",
+    inputSchema: z.object({
+      siteId: z.string(),
+      detail: z.string().optional().describe("What was just done"),
+      parityScore: z.number().min(0).max(100).optional(),
+      iteration: z.number().int().optional(),
+    }),
+    outputSchema: z.object({ ok: z.boolean() }),
+    execute: async ({ context }) => {
+      const site = await getSite(context.siteId);
+      if (!site) throw new Error("Site not found");
+
+      const patch: Partial<SiteRow> = {
+        last_progress_at: new Date().toISOString(),
+      };
+      if (context.detail) patch.phase_detail = context.detail.slice(0, 500);
+      if (context.parityScore !== undefined) {
+        patch.parity_score = context.parityScore;
+      }
+      await updateSite(site.id, patch);
+
+      if (context.detail) {
+        await addEvent(site.id, `[agente] ${context.detail.slice(0, 500)}`);
+      }
+      return { ok: true };
+    },
+  });

--- a/tanstack-migrator/server/tools/reports.ts
+++ b/tanstack-migrator/server/tools/reports.ts
@@ -1,0 +1,75 @@
+/** Presigned GET URLs for a run's parity artifacts (report + heatmaps). */
+
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { HEATMAP_SLOTS } from "../lib/artifacts.ts";
+import { getRun } from "../db/runs.ts";
+import type { Env } from "../types/env.ts";
+
+interface ObjectStorageBinding {
+  GET_PRESIGNED_URL: (input: {
+    key: string;
+    expiresIn?: number;
+  }) => Promise<{ url: string }>;
+}
+
+function getObjectStorage(env: Env): ObjectStorageBinding {
+  const storage = env.MESH_REQUEST_CONTEXT?.state?.OBJECT_STORAGE;
+  if (!storage) {
+    throw new Error(
+      "OBJECT_STORAGE binding is not configured — connect an object-storage MCP to view reports.",
+    );
+  }
+  return storage as unknown as ObjectStorageBinding;
+}
+
+export const createParityReportUrlsTool = (env: Env) =>
+  createTool({
+    id: "PARITY_REPORT_URLS",
+    description:
+      "Presigned URLs for a parity run's artifacts: full HTML report, report.json and heatmap PNGs.",
+    inputSchema: z.object({ runId: z.string() }),
+    outputSchema: z.object({
+      reportHtml: z.string().nullable(),
+      reportJson: z.string().nullable(),
+      heatmaps: z.array(z.object({ name: z.string(), url: z.string() })),
+    }),
+    annotations: { readOnlyHint: true },
+    execute: async ({ context }) => {
+      const run = await getRun(context.runId);
+      if (!run) throw new Error("Run not found");
+      if (!run.artifact_prefix) {
+        return { reportHtml: null, reportJson: null, heatmaps: [] };
+      }
+
+      const storage = getObjectStorage(env);
+      const presign = async (key: string) => {
+        try {
+          const { url } = await storage.GET_PRESIGNED_URL({
+            key,
+            expiresIn: 3600,
+          });
+          return url;
+        } catch {
+          return null;
+        }
+      };
+
+      const prefix = run.artifact_prefix;
+      const [reportHtml, reportJson, ...heatmaps] = await Promise.all([
+        presign(`${prefix}/report.html`),
+        presign(`${prefix}/report.json`),
+        ...Array.from({ length: HEATMAP_SLOTS }, (_, i) =>
+          presign(`${prefix}/heatmap_${i}.png`),
+        ),
+      ]);
+
+      return {
+        reportHtml,
+        reportJson,
+        heatmaps: heatmaps
+          .map((url, i) => ({ name: `heatmap_${i}.png`, url: url ?? "" }))
+          .filter((h) => h.url),
+      };
+    },
+  });

--- a/tanstack-migrator/server/tools/sites.ts
+++ b/tanstack-migrator/server/tools/sites.ts
@@ -1,0 +1,340 @@
+/** Site registration + queue control tools (called by the dashboard UI and by agents). */
+
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { loadConnection, saveConnection } from "../db/connections.ts";
+import { ensureApiKeyFromRequest } from "../lib/ensure-api-key.ts";
+import { addEvent } from "../db/events.ts";
+import { listEventsForSite } from "../db/events.ts";
+import { listRunsForSite } from "../db/runs.ts";
+import {
+  deleteSite,
+  getSite,
+  insertSite,
+  listSites,
+  updateSite,
+} from "../db/sites.ts";
+import {
+  isActiveStatus,
+  RESUMABLE_STATUSES,
+  type SiteStatus,
+} from "../db/types.ts";
+import type { Env } from "../types/env.ts";
+import {
+  EventViewSchema,
+  RunViewSchema,
+  SiteViewSchema,
+  toEventView,
+  toRunView,
+  toSiteView,
+} from "./views.ts";
+
+function requireConnectionId(env: Env): string {
+  const connectionId = env.MESH_REQUEST_CONTEXT?.connectionId;
+  if (!connectionId) {
+    throw new Error("No connectionId in request context");
+  }
+  return connectionId;
+}
+
+/** Make sure the connection row exists before writing sites that reference it. */
+async function ensureConnectionRow(env: Env): Promise<string> {
+  const connectionId = requireConnectionId(env);
+  const existing = await loadConnection(connectionId).catch(() => null);
+  if (!existing) {
+    await saveConnection({
+      connectionId,
+      organizationId: env.MESH_REQUEST_CONTEXT?.organizationId ?? "unknown",
+      meshUrl: env.MESH_REQUEST_CONTEXT?.meshUrl ?? "https://api.decocms.com",
+      meshToken: env.MESH_REQUEST_CONTEXT?.token,
+    });
+  }
+  void ensureApiKeyFromRequest(env); // fire-and-forget, throttled
+  return connectionId;
+}
+
+function normalizeRepo(input: string, org: string): string {
+  const trimmed = input
+    .trim()
+    .replace(/^https?:\/\/github\.com\//, "")
+    .replace(/\.git$/, "");
+  return trimmed.includes("/") ? trimmed : `${org}/${trimmed}`;
+}
+
+export const createSiteRegisterTool = (env: Env) =>
+  createTool({
+    id: "SITE_REGISTER",
+    description:
+      "Register a site in the migration queue (Fresh/Deno → TanStack Start). The queue starts migrations automatically, FIFO.",
+    inputSchema: z.object({
+      sourceRepo: z
+        .string()
+        .describe(
+          'Source repo, e.g. "deco-sites/granadobr" or just "granadobr"',
+        ),
+      prodUrl: z
+        .string()
+        .describe(
+          "Production URL of the live (Fresh) site, e.g. https://www.granado.com.br",
+        ),
+      name: z
+        .string()
+        .optional()
+        .describe("Display name (defaults to the repo name)"),
+      sourceBranch: z.string().optional(),
+      parityTarget: z.number().min(50).max(100).optional(),
+      maxIterations: z.number().int().min(1).max(30).optional(),
+      alreadyDone: z
+        .boolean()
+        .optional()
+        .describe(
+          "Register a migration that is already finished (shows up in the done list)",
+        ),
+      targetRepo: z
+        .string()
+        .optional()
+        .describe("Override the -tanstack repo (for alreadyDone sites)"),
+    }),
+    outputSchema: z.object({
+      siteId: z.string(),
+      position: z.number().describe("Position in the queue (0 = done/active)"),
+    }),
+    execute: async ({ context }) => {
+      const connectionId = await ensureConnectionRow(env);
+      const org =
+        (env.MESH_REQUEST_CONTEXT?.state as { GITHUB_ORG?: string } | undefined)
+          ?.GITHUB_ORG ?? "deco-sites";
+      const sourceRepo = normalizeRepo(context.sourceRepo, org);
+      const prodUrl = context.prodUrl.replace(/\/$/, "");
+      if (!/^https?:\/\//.test(prodUrl)) {
+        throw new Error("prodUrl must be an absolute http(s) URL");
+      }
+
+      const site = await insertSite({
+        connectionId,
+        name: context.name ?? sourceRepo.split("/")[1],
+        sourceRepo,
+        sourceBranch: context.sourceBranch,
+        prodUrl,
+        parityTarget: context.parityTarget,
+        maxIterations: context.maxIterations,
+        status: context.alreadyDone ? "done" : "queued",
+        targetRepo:
+          context.targetRepo ??
+          (context.alreadyDone ? `${sourceRepo}-tanstack` : undefined),
+      });
+      await addEvent(
+        site.id,
+        context.alreadyDone
+          ? "Cadastrado como migração já concluída"
+          : "Site cadastrado na fila de migração",
+      );
+
+      const queued = await listSites({ connectionId, statuses: ["queued"] });
+      const position = context.alreadyDone
+        ? 0
+        : queued.findIndex((s) => s.id === site.id) + 1;
+      return { siteId: site.id, position };
+    },
+  });
+
+export const createSiteListTool = (env: Env) =>
+  createTool({
+    id: "SITE_LIST",
+    description: "List registered sites with status and parity score.",
+    inputSchema: z.object({
+      status: z.string().optional().describe("Filter by status"),
+    }),
+    outputSchema: z.object({ sites: z.array(SiteViewSchema) }),
+    annotations: { readOnlyHint: true },
+    execute: async ({ context }) => {
+      const connectionId = requireConnectionId(env);
+      const sites = await listSites({
+        connectionId,
+        statuses: context.status ? [context.status as SiteStatus] : undefined,
+      });
+      return { sites: sites.map(toSiteView) };
+    },
+  });
+
+export const createSiteGetTool = (env: Env) =>
+  createTool({
+    id: "SITE_GET",
+    description:
+      "Full detail of a migration: site, runs (with parity summaries) and activity feed.",
+    inputSchema: z.object({ siteId: z.string() }),
+    outputSchema: z.object({
+      site: SiteViewSchema,
+      runs: z.array(RunViewSchema),
+      events: z.array(EventViewSchema),
+    }),
+    annotations: { readOnlyHint: true },
+    execute: async ({ context }) => {
+      requireConnectionId(env);
+      const site = await getSite(context.siteId);
+      if (!site) throw new Error("Site not found");
+      const [runs, events] = await Promise.all([
+        listRunsForSite(site.id),
+        listEventsForSite(site.id),
+      ]);
+      return {
+        site: toSiteView(site),
+        runs: runs.map(toRunView),
+        events: events.map(toEventView),
+      };
+    },
+  });
+
+const siteIdInput = z.object({ siteId: z.string() });
+const siteOutput = z.object({ site: SiteViewSchema });
+
+export const createSitePauseTool = (env: Env) =>
+  createTool({
+    id: "SITE_PAUSE",
+    description:
+      "Pause a queued/active migration (keeps its place; resume later).",
+    inputSchema: siteIdInput,
+    outputSchema: siteOutput,
+    execute: async ({ context }) => {
+      requireConnectionId(env);
+      const site = await getSite(context.siteId);
+      if (!site) throw new Error("Site not found");
+      if (site.status !== "queued" && !isActiveStatus(site.status)) {
+        throw new Error(`Cannot pause a site in status ${site.status}`);
+      }
+      const updated = await updateSite(site.id, {
+        status: "paused",
+        resume_status: site.status === "queued" ? "queued" : site.status,
+        sandbox_session_id: null,
+      });
+      await addEvent(site.id, "Migração pausada");
+      return { site: toSiteView(updated) };
+    },
+  });
+
+export const createSiteResumeTool = (env: Env) =>
+  createTool({
+    id: "SITE_RESUME",
+    description: "Resume a paused migration from where it stopped.",
+    inputSchema: siteIdInput,
+    outputSchema: siteOutput,
+    execute: async ({ context }) => {
+      requireConnectionId(env);
+      const site = await getSite(context.siteId);
+      if (!site) throw new Error("Site not found");
+      if (site.status !== "paused") {
+        throw new Error(`Site is not paused (status: ${site.status})`);
+      }
+      const updated = await updateSite(site.id, {
+        status: (site.resume_status ?? "queued") as SiteStatus,
+        resume_status: null,
+        last_progress_at: new Date().toISOString(),
+      });
+      await addEvent(site.id, "Migração retomada");
+      return { site: toSiteView(updated) };
+    },
+  });
+
+export const createSiteRetryTool = (env: Env) =>
+  createTool({
+    id: "SITE_RETRY",
+    description:
+      "Retry a failed/needs_human migration from the phase where it stopped (clears the error and stall counters).",
+    inputSchema: z.object({
+      siteId: z.string(),
+      fromStatus: z
+        .string()
+        .optional()
+        .describe(
+          "Override the phase to resume into (e.g. validating, deploying_cf)",
+        ),
+    }),
+    outputSchema: siteOutput,
+    execute: async ({ context }) => {
+      requireConnectionId(env);
+      const site = await getSite(context.siteId);
+      if (!site) throw new Error("Site not found");
+      if (!RESUMABLE_STATUSES.includes(site.status)) {
+        throw new Error(`Site is not retryable (status: ${site.status})`);
+      }
+      const nextStatus = (context.fromStatus ??
+        site.resume_status ??
+        "queued") as SiteStatus;
+      const updated = await updateSite(site.id, {
+        status: nextStatus,
+        resume_status: null,
+        error: null,
+        needs_human_reason: null,
+        no_improve_count: 0,
+        sandbox_session_id: null,
+        last_progress_at: new Date().toISOString(),
+      });
+      await addEvent(site.id, `Retry: retomando em ${nextStatus}`);
+      return { site: toSiteView(updated) };
+    },
+  });
+
+export const createSiteMarkDoneTool = (env: Env) =>
+  createTool({
+    id: "SITE_MARK_DONE",
+    description: "Manually mark a migration as done (100% TanStack).",
+    inputSchema: z.object({
+      siteId: z.string(),
+      reason: z.string().optional(),
+    }),
+    outputSchema: siteOutput,
+    execute: async ({ context }) => {
+      requireConnectionId(env);
+      const site = await getSite(context.siteId);
+      if (!site) throw new Error("Site not found");
+      const updated = await updateSite(site.id, {
+        status: "done",
+        finished_at: new Date().toISOString(),
+        needs_human_reason: null,
+        error: null,
+      });
+      await addEvent(
+        site.id,
+        `Marcado como concluído manualmente${context.reason ? `: ${context.reason}` : ""}`,
+      );
+      return { site: toSiteView(updated) };
+    },
+  });
+
+export const createSiteArchiveTool = (env: Env) =>
+  createTool({
+    id: "SITE_ARCHIVE",
+    description: "Archive a site (hides it from the dashboard).",
+    inputSchema: z.object({ siteId: z.string() }),
+    outputSchema: siteOutput,
+    execute: async ({ context }) => {
+      requireConnectionId(env);
+      const site = await getSite(context.siteId);
+      if (!site) throw new Error("Site not found");
+      if (isActiveStatus(site.status)) {
+        throw new Error("Pause the migration before archiving");
+      }
+      const updated = await updateSite(site.id, { status: "archived" });
+      await addEvent(site.id, "Site arquivado");
+      return { site: toSiteView(updated) };
+    },
+  });
+
+export const createSiteDeleteTool = (env: Env) =>
+  createTool({
+    id: "SITE_DELETE",
+    description:
+      "Permanently delete a site and its runs/events. Frees the repo to be registered again. Does NOT touch GitHub/CF/sandbox resources.",
+    inputSchema: z.object({ siteId: z.string() }),
+    outputSchema: z.object({ deleted: z.boolean() }),
+    execute: async ({ context }) => {
+      requireConnectionId(env);
+      const site = await getSite(context.siteId);
+      if (!site) return { deleted: false };
+      if (isActiveStatus(site.status)) {
+        throw new Error("Pause the migration before deleting");
+      }
+      await deleteSite(site.id);
+      return { deleted: true };
+    },
+  });

--- a/tanstack-migrator/server/tools/views.ts
+++ b/tanstack-migrator/server/tools/views.ts
@@ -1,0 +1,101 @@
+/** Row → safe UI shapes (tokens/grants never leave the server). */
+
+import { z } from "zod";
+import type { EventRow, RunRow, SiteRow } from "../db/types.ts";
+
+export const SiteViewSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  sourceRepo: z.string(),
+  sourceBranch: z.string(),
+  targetRepo: z.string().nullable(),
+  prodUrl: z.string(),
+  status: z.string(),
+  phaseDetail: z.string().nullable(),
+  parityScore: z.number().nullable(),
+  parityTarget: z.number(),
+  bestScore: z.number().nullable(),
+  iterationsDone: z.number(),
+  maxIterations: z.number(),
+  previewUrl: z.string().nullable(),
+  cfDeployUrl: z.string().nullable(),
+  error: z.string().nullable(),
+  needsHumanReason: z.string().nullable(),
+  createdAt: z.string(),
+  startedAt: z.string().nullable(),
+  finishedAt: z.string().nullable(),
+  updatedAt: z.string(),
+});
+export type SiteView = z.infer<typeof SiteViewSchema>;
+
+export function toSiteView(row: SiteRow): SiteView {
+  return {
+    id: row.id,
+    name: row.name,
+    sourceRepo: row.source_repo,
+    sourceBranch: row.source_branch,
+    targetRepo: row.target_repo,
+    prodUrl: row.prod_url,
+    status: row.status,
+    phaseDetail: row.phase_detail,
+    parityScore: row.parity_score,
+    parityTarget: row.parity_target,
+    bestScore: row.best_score,
+    iterationsDone: row.iterations_done,
+    maxIterations: row.max_iterations,
+    previewUrl: row.sandbox_preview_url,
+    cfDeployUrl: row.cf_deploy_url,
+    error: row.error,
+    needsHumanReason: row.needs_human_reason,
+    createdAt: row.created_at,
+    startedAt: row.started_at,
+    finishedAt: row.finished_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export const RunViewSchema = z.object({
+  id: z.string(),
+  kind: z.string(),
+  iteration: z.number(),
+  status: z.string(),
+  parityScore: z.number().nullable(),
+  summary: z.unknown().nullable(),
+  hasArtifacts: z.boolean(),
+  logsTail: z.string().nullable(),
+  startedAt: z.string(),
+  finishedAt: z.string().nullable(),
+});
+export type RunView = z.infer<typeof RunViewSchema>;
+
+export function toRunView(row: RunRow): RunView {
+  return {
+    id: row.id,
+    kind: row.kind,
+    iteration: row.iteration,
+    status: row.status,
+    parityScore: row.parity_score,
+    summary: row.summary,
+    hasArtifacts: !!row.artifact_prefix,
+    logsTail: row.logs_tail,
+    startedAt: row.started_at,
+    finishedAt: row.finished_at,
+  };
+}
+
+export const EventViewSchema = z.object({
+  id: z.number(),
+  level: z.string(),
+  message: z.string(),
+  createdAt: z.string(),
+});
+export type EventView = z.infer<typeof EventViewSchema>;
+
+export function toEventView(row: EventRow): EventView {
+  return {
+    id: row.id,
+    level: row.level,
+    message: row.message,
+    createdAt: row.created_at,
+  };
+}

--- a/tanstack-migrator/server/types/env.ts
+++ b/tanstack-migrator/server/types/env.ts
@@ -1,0 +1,164 @@
+import { BindingOf, type DefaultEnv } from "@decocms/runtime";
+import type { ToolBinder } from "@decocms/runtime";
+import { z } from "zod";
+import {
+  DEFAULT_CF_ACCOUNT_ID,
+  DEFAULT_GITHUB_ORG,
+  DEFAULT_MAX_CONCURRENT,
+  DEFAULT_MAX_ITERATIONS,
+  DEFAULT_NO_IMPROVE_LIMIT,
+  DEFAULT_PARITY_TARGET,
+} from "../constants.ts";
+
+/**
+ * Contract-based matching for the GitHub binding: the studio filters
+ * connections by tool names (see mesh createBindingChecker), so ANY GitHub
+ * MCP connection matches regardless of which registry/app_name it was
+ * installed under (deco proxy = @deco/github-mcp, community = mcp-github...).
+ */
+const GITHUB_BINDING_CONTRACT = [
+  { name: "get_file_contents", inputSchema: z.object({}).passthrough() },
+  {
+    name: "create_or_update_file",
+    inputSchema: z.object({}).passthrough(),
+  },
+  {
+    name: "create_repository",
+    inputSchema: z.object({}).passthrough(),
+    opt: true,
+  },
+  {
+    name: "MINT_REPO_TOKEN",
+    inputSchema: z.object({}).passthrough(),
+    opt: true,
+  },
+] as const satisfies readonly ToolBinder[];
+
+/**
+ * Installation-time configuration. Kept flat so the studio install form
+ * renders every field cleanly.
+ */
+export const StateSchema = z.object({
+  GITHUB: BindingOf("@deco/github-mcp", GITHUB_BINDING_CONTRACT)
+    .optional()
+    .describe(
+      "GitHub connection (deco GitHub App or official GitHub MCP) with access to the deco-sites org — used to create the -tanstack repos and push the sync workflow. Required only in live mode (SANDBOX_PROVIDER=decopilot).",
+    ),
+  OBJECT_STORAGE: BindingOf("@deco/object-storage")
+    .optional()
+    .describe(
+      "Object storage for parity report artifacts (report.html, heatmaps). Optional but required to view reports in the UI.",
+    ),
+  ANTHROPIC_API_KEY: z
+    .string()
+    .optional()
+    .describe(
+      "Anthropic API key injected into migration sandboxes (Claude Code sessions + parity CLI visual diff).",
+    ),
+  OPENROUTER_API_KEY: z
+    .string()
+    .optional()
+    .describe("Fallback LLM key for the parity CLI reports."),
+  CLOUDFLARE_ACCOUNT_ID: z
+    .string()
+    .default(DEFAULT_CF_ACCOUNT_ID)
+    .describe("Cloudflare account that hosts the migrated workers."),
+  CLOUDFLARE_API_TOKEN: z
+    .string()
+    .optional()
+    .describe(
+      "Cloudflare API token with Workers Builds permissions — used to create the git-connected project for automatic deploys.",
+    ),
+  MESH_API_KEY: z
+    .string()
+    .optional()
+    .describe(
+      "Durable mesh API key for background work. Leave empty to auto-mint one on install.",
+    ),
+  GITHUB_ORG: z
+    .string()
+    .default(DEFAULT_GITHUB_ORG)
+    .describe("GitHub org that owns the source and -tanstack repos."),
+  GITHUB_INSTALLATION_ID: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      "GitHub App installation id used by MINT_REPO_TOKEN for sandbox push tokens.",
+    ),
+  MAX_CONCURRENT: z
+    .number()
+    .int()
+    .min(1)
+    .max(2)
+    .default(DEFAULT_MAX_CONCURRENT)
+    .describe("How many migrations run at the same time (1-2)."),
+  PARITY_TARGET: z
+    .number()
+    .min(50)
+    .max(100)
+    .default(DEFAULT_PARITY_TARGET)
+    .describe("Default parity score that marks a migration as done."),
+  MAX_ITERATIONS: z
+    .number()
+    .int()
+    .min(1)
+    .default(DEFAULT_MAX_ITERATIONS)
+    .describe("Max fix iterations in the validation loop before needs_human."),
+  NO_IMPROVE_LIMIT: z
+    .number()
+    .int()
+    .min(1)
+    .default(DEFAULT_NO_IMPROVE_LIMIT)
+    .describe(
+      "Consecutive iterations without score improvement before needs_human.",
+    ),
+  SANDBOX_PROVIDER: z
+    .enum(["manual", "decopilot"])
+    .default("manual")
+    .describe(
+      "manual = end-to-end simulation (no external effects, for demos); decopilot = live migrations via mesh sandboxes.",
+    ),
+});
+
+export type Env = DefaultEnv<typeof StateSchema>;
+
+/** Plain (non-binding) config the background worker needs, parsed from the persisted state. */
+export interface MigratorConfig {
+  anthropicApiKey?: string;
+  openrouterApiKey?: string;
+  cloudflareAccountId: string;
+  cloudflareApiToken?: string;
+  githubOrg: string;
+  githubInstallationId?: number;
+  maxConcurrent: number;
+  parityTarget: number;
+  maxIterations: number;
+  noImproveLimit: number;
+  sandboxProvider: "manual" | "decopilot";
+}
+
+export function parseMigratorConfig(
+  state: Record<string, unknown> | null | undefined,
+): MigratorConfig {
+  const s = (state ?? {}) as Record<string, unknown>;
+  const num = (v: unknown): number | undefined =>
+    typeof v === "number" && Number.isFinite(v) ? v : undefined;
+  const str = (v: unknown): string | undefined =>
+    typeof v === "string" && v.length > 0 ? v : undefined;
+
+  return {
+    anthropicApiKey: str(s.ANTHROPIC_API_KEY),
+    openrouterApiKey: str(s.OPENROUTER_API_KEY),
+    cloudflareAccountId: str(s.CLOUDFLARE_ACCOUNT_ID) ?? DEFAULT_CF_ACCOUNT_ID,
+    cloudflareApiToken: str(s.CLOUDFLARE_API_TOKEN),
+    githubOrg: str(s.GITHUB_ORG) ?? DEFAULT_GITHUB_ORG,
+    githubInstallationId: num(s.GITHUB_INSTALLATION_ID),
+    maxConcurrent: num(s.MAX_CONCURRENT) ?? DEFAULT_MAX_CONCURRENT,
+    parityTarget: num(s.PARITY_TARGET) ?? DEFAULT_PARITY_TARGET,
+    maxIterations: num(s.MAX_ITERATIONS) ?? DEFAULT_MAX_ITERATIONS,
+    noImproveLimit: num(s.NO_IMPROVE_LIMIT) ?? DEFAULT_NO_IMPROVE_LIMIT,
+    sandboxProvider:
+      s.SANDBOX_PROVIDER === "decopilot" ? "decopilot" : "manual",
+  };
+}

--- a/tanstack-migrator/tsconfig.json
+++ b/tanstack-migrator/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "types": ["@cloudflare/workers-types", "bun", "vite/client"],
+    "paths": {
+      "@/*": ["./web/*"]
+    }
+  },
+  "include": ["server", "web"]
+}

--- a/tanstack-migrator/vite.config.ts
+++ b/tanstack-migrator/vite.config.ts
@@ -1,0 +1,37 @@
+import path from "node:path";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+import { viteSingleFile } from "vite-plugin-singlefile";
+
+const MCP_APP_ENTRIES = {
+  dashboard: path.resolve(__dirname, "dashboard.html"),
+} as const;
+
+type McpAppEntry = keyof typeof MCP_APP_ENTRIES;
+
+function resolveEntry(): McpAppEntry {
+  const entry = process.env.MCP_APP_ENTRY;
+  if (entry && entry in MCP_APP_ENTRIES) {
+    return entry as McpAppEntry;
+  }
+  return "dashboard";
+}
+
+const activeEntry = resolveEntry();
+
+export default defineConfig({
+  plugins: [react(), tailwindcss(), viteSingleFile()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./web"),
+    },
+  },
+  build: {
+    outDir: "dist/client",
+    emptyOutDir: process.env.MCP_APP_EMPTY_OUTDIR !== "false",
+    rollupOptions: {
+      input: MCP_APP_ENTRIES[activeEntry],
+    },
+  },
+});

--- a/tanstack-migrator/web/bootstrap.tsx
+++ b/tanstack-migrator/web/bootstrap.tsx
@@ -1,0 +1,24 @@
+import { StrictMode, type ComponentType } from "react";
+import { createRoot } from "react-dom/client";
+import { McpAppShell } from "@/components/mcp-app-shell.tsx";
+import { McpProvider } from "@/context.tsx";
+import "./globals.css";
+
+export function mountMcpApp(Page: ComponentType) {
+  const rootElement = document.getElementById("root");
+
+  if (!rootElement) {
+    throw new Error("Missing root element");
+  }
+
+  const root = createRoot(rootElement);
+  root.render(
+    <StrictMode>
+      <McpProvider>
+        <McpAppShell>
+          <Page />
+        </McpAppShell>
+      </McpProvider>
+    </StrictMode>,
+  );
+}

--- a/tanstack-migrator/web/components/mcp-app-shell.tsx
+++ b/tanstack-migrator/web/components/mcp-app-shell.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+import { useMcpHostContext } from "@/context.tsx";
+
+export function McpAppShell({ children }: { children: ReactNode }) {
+  const hostContext = useMcpHostContext();
+  const insets = hostContext?.safeAreaInsets;
+
+  return (
+    <div
+      className="flex min-h-0 w-full flex-1 flex-col overflow-hidden"
+      style={
+        insets
+          ? {
+              paddingTop: `${insets.top}px`,
+              paddingRight: `${insets.right}px`,
+              paddingBottom: `${insets.bottom}px`,
+              paddingLeft: `${insets.left}px`,
+            }
+          : undefined
+      }
+    >
+      {children}
+    </div>
+  );
+}

--- a/tanstack-migrator/web/components/parity-bar.tsx
+++ b/tanstack-migrator/web/components/parity-bar.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/lib/utils.ts";
+
+export function ParityBar({
+  score,
+  target,
+  compact,
+}: {
+  score: number | null;
+  target: number;
+  compact?: boolean;
+}) {
+  const value = score ?? 0;
+  const reached = score !== null && score >= target;
+
+  return (
+    <div className="flex w-full items-center gap-2">
+      <div className="relative h-2 flex-1 overflow-hidden rounded-full bg-muted">
+        <div
+          className={cn(
+            "h-full rounded-full transition-all duration-700",
+            reached ? "bg-primary" : "bg-indigo-500",
+          )}
+          style={{ width: `${Math.min(100, Math.max(0, value))}%` }}
+        />
+        {/* target marker */}
+        <div
+          className="absolute top-0 h-full w-0.5 bg-foreground/40"
+          style={{ left: `${target}%` }}
+          title={`alvo ${target}%`}
+        />
+      </div>
+      {!compact && (
+        <span
+          className={cn(
+            "min-w-[3.5rem] text-right text-sm font-semibold tabular-nums",
+            reached ? "text-emerald-600 dark:text-emerald-400" : "",
+          )}
+        >
+          {score !== null ? `${Math.round(score)}%` : "—"}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/tanstack-migrator/web/components/register-modal.tsx
+++ b/tanstack-migrator/web/components/register-modal.tsx
@@ -1,0 +1,104 @@
+import { Loader2, X } from "lucide-react";
+import { useState } from "react";
+import { useToolCaller } from "@/hooks/use-tool.ts";
+
+export function RegisterModal({
+  onClose,
+  onRegistered,
+}: {
+  onClose: () => void;
+  onRegistered: () => void;
+}) {
+  const callTool = useToolCaller();
+  const [sourceRepo, setSourceRepo] = useState("");
+  const [prodUrl, setProdUrl] = useState("");
+  const [alreadyDone, setAlreadyDone] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    if (!sourceRepo.trim() || !prodUrl.trim()) {
+      setError("Preencha o repo e a URL de produção");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await callTool("SITE_REGISTER", {
+        sourceRepo: sourceRepo.trim(),
+        prodUrl: prodUrl.trim(),
+        alreadyDone,
+      });
+      onRegistered();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Falha ao cadastrar");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-md rounded-lg border border-border bg-card p-5 shadow-xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-base font-semibold">Cadastrar site pra migrar</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 text-muted-foreground hover:bg-muted"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium">Repo de origem (Fresh/Deno)</span>
+            <input
+              value={sourceRepo}
+              onChange={(e) => setSourceRepo(e.target.value)}
+              placeholder="deco-sites/granadobr"
+              className="rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+              autoFocus
+            />
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium">URL de produção</span>
+            <input
+              value={prodUrl}
+              onChange={(e) => setProdUrl(e.target.value)}
+              placeholder="https://www.granado.com.br"
+              className="rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+            />
+          </label>
+
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={alreadyDone}
+              onChange={(e) => setAlreadyDone(e.target.checked)}
+              className="h-4 w-4 rounded border-input"
+            />
+            <span>
+              Migração já concluída (entra direto na lista 100% TanStack)
+            </span>
+          </label>
+
+          {error && <p className="text-sm text-red-500">{error}</p>}
+
+          <button
+            type="button"
+            onClick={submit}
+            disabled={submitting}
+            className="mt-1 inline-flex items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
+          >
+            {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+            {alreadyDone ? "Cadastrar como concluído" : "Entrar na fila"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tanstack-migrator/web/components/site-card.tsx
+++ b/tanstack-migrator/web/components/site-card.tsx
@@ -1,0 +1,122 @@
+import { ExternalLink, GitBranch, Github, Globe } from "lucide-react";
+import { ParityBar } from "@/components/parity-bar.tsx";
+import { StatusBadge } from "@/components/status-badge.tsx";
+import { cn, duration, timeAgo } from "@/lib/utils.ts";
+import type { SiteView } from "@/types.ts";
+
+function RepoLink({
+  repo,
+  label,
+  icon: Icon,
+}: {
+  repo: string | null;
+  label: string;
+  icon: typeof Github;
+}) {
+  if (!repo) return null;
+  const isUrl = repo.startsWith("http");
+  const href = isUrl ? repo : `https://github.com/${repo}`;
+  const text = isUrl ? label : repo;
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      onClick={(e) => e.stopPropagation()}
+      className="inline-flex max-w-full items-center gap-1 truncate text-xs text-muted-foreground hover:text-foreground hover:underline"
+      title={text}
+    >
+      <Icon className="h-3 w-3 shrink-0" />
+      <span className="truncate">{text}</span>
+    </a>
+  );
+}
+
+export function SiteCard({
+  site,
+  onClick,
+  simulation,
+}: {
+  site: SiteView;
+  onClick: () => void;
+  simulation?: boolean;
+}) {
+  const isDone = site.status === "done";
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex w-full flex-col gap-2.5 rounded-lg border border-border bg-card p-4 text-left transition-shadow hover:shadow-md",
+        site.status === "needs_human" && "border-amber-500/40",
+        site.status === "failed" && "border-red-500/40",
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="flex min-w-0 items-center gap-1.5">
+          <span className="truncate text-sm font-semibold">{site.name}</span>
+          {simulation && !isDone && (
+            <span className="shrink-0 rounded-full border border-dashed border-amber-500/60 px-1.5 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400">
+              simulação
+            </span>
+          )}
+        </span>
+        <StatusBadge status={site.status} />
+      </div>
+
+      <ParityBar score={site.parityScore} target={site.parityTarget} />
+
+      {site.phaseDetail && !isDone && (
+        <p className="line-clamp-2 text-xs text-muted-foreground">
+          {site.phaseDetail}
+        </p>
+      )}
+      {site.needsHumanReason && (
+        <p className="line-clamp-2 text-xs text-amber-600 dark:text-amber-400">
+          {site.needsHumanReason}
+        </p>
+      )}
+      {site.error && site.status === "failed" && (
+        <p className="line-clamp-2 text-xs text-red-600 dark:text-red-400">
+          {site.error}
+        </p>
+      )}
+
+      <div className="flex flex-col gap-1">
+        <RepoLink repo={site.sourceRepo} label="source" icon={Github} />
+        <RepoLink repo={site.targetRepo} label="tanstack" icon={GitBranch} />
+        <div className="flex items-center gap-3">
+          <RepoLink repo={site.prodUrl} label="produção" icon={Globe} />
+          {site.previewUrl && (
+            <RepoLink
+              repo={site.previewUrl}
+              label="preview"
+              icon={ExternalLink}
+            />
+          )}
+          {site.cfDeployUrl && (
+            <RepoLink
+              repo={site.cfDeployUrl}
+              label="deploy"
+              icon={ExternalLink}
+            />
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+        <span>
+          {site.status === "validating" || isDone
+            ? `iteração ${site.iterationsDone}/${site.maxIterations}`
+            : `cadastrado ${timeAgo(site.createdAt)}`}
+        </span>
+        <span>
+          {isDone
+            ? `durou ${duration(site.startedAt, site.finishedAt)}`
+            : `atualizado ${timeAgo(site.updatedAt)}`}
+        </span>
+      </div>
+    </button>
+  );
+}

--- a/tanstack-migrator/web/components/site-detail.tsx
+++ b/tanstack-migrator/web/components/site-detail.tsx
@@ -1,0 +1,460 @@
+import {
+  Archive,
+  CheckCircle2,
+  ExternalLink,
+  FileText,
+  Loader2,
+  Pause,
+  Play,
+  RotateCcw,
+  Trash2,
+  X,
+} from "lucide-react";
+import { useState } from "react";
+import { ParityBar } from "@/components/parity-bar.tsx";
+import { StatusBadge } from "@/components/status-badge.tsx";
+import { usePollingTool, useToolCaller } from "@/hooks/use-tool.ts";
+import { cn, timeAgo } from "@/lib/utils.ts";
+import type { ReportUrls, RunView, SiteDetail } from "@/types.ts";
+
+const SEVERITY_COLOR: Record<string, string> = {
+  critical: "text-red-600 dark:text-red-400",
+  high: "text-orange-600 dark:text-orange-400",
+  medium: "text-amber-600 dark:text-amber-400",
+  low: "text-muted-foreground",
+};
+
+function ActionButton({
+  icon: Icon,
+  label,
+  onClick,
+  busy,
+  danger,
+}: {
+  icon: typeof Play;
+  label: string;
+  onClick: () => void;
+  busy: boolean;
+  danger?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={busy}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium hover:bg-muted disabled:opacity-50",
+        danger && "border-red-500/40 text-red-600 dark:text-red-400",
+      )}
+    >
+      {busy ? (
+        <Loader2 className="h-3 w-3 animate-spin" />
+      ) : (
+        <Icon className="h-3 w-3" />
+      )}
+      {label}
+    </button>
+  );
+}
+
+function RunRow({ run }: { run: RunView }) {
+  const callTool = useToolCaller();
+  const [expanded, setExpanded] = useState(false);
+  const [loadingReport, setLoadingReport] = useState(false);
+  const [heatmaps, setHeatmaps] = useState<ReportUrls["heatmaps"] | null>(null);
+
+  const openReport = async () => {
+    setLoadingReport(true);
+    try {
+      const urls = await callTool<ReportUrls>("PARITY_REPORT_URLS", {
+        runId: run.id,
+      });
+      setHeatmaps(urls.heatmaps);
+      if (urls.reportHtml) window.open(urls.reportHtml, "_blank");
+    } catch (err) {
+      console.error("report urls failed", err);
+    } finally {
+      setLoadingReport(false);
+    }
+  };
+
+  const kindLabel: Record<string, string> = {
+    migrate: "migração inicial",
+    fix_iteration: `iteração ${run.iteration}`,
+    parity: `parity ${run.iteration}`,
+    install_sync: "instalação do sync",
+    deploy_cf: "deploy CF",
+  };
+
+  return (
+    <div className="rounded-md border border-border">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left"
+      >
+        <div className="flex items-center gap-2 text-xs">
+          <span
+            className={cn(
+              "h-2 w-2 rounded-full",
+              run.status === "succeeded"
+                ? "bg-emerald-500"
+                : run.status === "failed"
+                  ? "bg-red-500"
+                  : "animate-pulse bg-blue-500",
+            )}
+          />
+          <span className="font-medium">{kindLabel[run.kind] ?? run.kind}</span>
+          <span className="text-muted-foreground">
+            {timeAgo(run.startedAt)}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          {run.parityScore !== null && (
+            <span className="font-semibold tabular-nums">
+              {Math.round(run.parityScore)}%
+            </span>
+          )}
+          {run.hasArtifacts && (
+            <span
+              role="button"
+              tabIndex={0}
+              onClick={(e) => {
+                e.stopPropagation();
+                openReport();
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.stopPropagation();
+                  openReport();
+                }
+              }}
+              className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 hover:bg-muted"
+              title="Abrir report HTML completo"
+            >
+              {loadingReport ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <FileText className="h-3 w-3" />
+              )}
+              report
+            </span>
+          )}
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-border px-3 py-2 text-xs">
+          {run.summary?.topIssues && run.summary.topIssues.length > 0 && (
+            <ul className="flex flex-col gap-1">
+              {run.summary.topIssues.map((issue, i) => (
+                <li key={i} className="flex gap-1.5">
+                  <span
+                    className={cn(
+                      "font-semibold uppercase",
+                      SEVERITY_COLOR[issue.severity] ?? "text-muted-foreground",
+                    )}
+                  >
+                    {issue.severity}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {issue.page ? `${issue.page} — ` : ""}
+                    {issue.summary}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+          {heatmaps && heatmaps.length > 0 && (
+            <div className="mt-2 grid grid-cols-3 gap-1.5">
+              {heatmaps.map((h) => (
+                <a key={h.name} href={h.url} target="_blank" rel="noreferrer">
+                  <img
+                    src={h.url}
+                    alt={h.name}
+                    className="h-20 w-full rounded border border-border object-cover object-top"
+                  />
+                </a>
+              ))}
+            </div>
+          )}
+          {run.logsTail && (
+            <pre className="mt-2 max-h-32 overflow-auto rounded bg-muted p-2 text-[10px] leading-snug whitespace-pre-wrap">
+              {run.logsTail}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function SiteDetailPanel({
+  siteId,
+  onClose,
+  onChanged,
+  simulation,
+}: {
+  siteId: string;
+  onClose: () => void;
+  onChanged: () => void;
+  simulation?: boolean;
+}) {
+  const callTool = useToolCaller();
+  const { data, refresh } = usePollingTool<SiteDetail>(
+    "SITE_GET",
+    { siteId },
+    10_000,
+  );
+  const [busy, setBusy] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const action = async (tool: string, extra?: Record<string, unknown>) => {
+    setBusy(tool);
+    setError(null);
+    try {
+      await callTool(tool, { siteId, ...extra });
+      refresh();
+      onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Ação falhou");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const removeSite = async () => {
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      setTimeout(() => setConfirmDelete(false), 4000);
+      return;
+    }
+    setBusy("SITE_DELETE");
+    setError(null);
+    try {
+      await callTool("SITE_DELETE", { siteId });
+      onChanged();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Exclusão falhou");
+      setBusy(null);
+    }
+  };
+
+  const site = data?.site;
+
+  return (
+    <div className="fixed inset-0 z-40 flex justify-end bg-black/30">
+      <div className="flex h-full w-full max-w-lg flex-col overflow-hidden border-l border-border bg-background shadow-2xl">
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <div className="flex items-center gap-2">
+            <h2 className="text-sm font-semibold">{site?.name ?? "…"}</h2>
+            {site && <StatusBadge status={site.status} />}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 text-muted-foreground hover:bg-muted"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {!site ? (
+          <div className="flex flex-1 items-center justify-center">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
+            {simulation && site.status !== "done" && (
+              <div className="rounded-md border border-dashed border-amber-500/50 bg-amber-500/10 p-2.5 text-xs text-amber-700 dark:text-amber-300">
+                Modo simulação (SANDBOX_PROVIDER=manual): nenhum efeito externo
+                — repos, sandbox e deploy são fictícios. Troque para{" "}
+                <code>decopilot</code> no state pra migrar de verdade.
+              </div>
+            )}
+            <div>
+              <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground">
+                <span>Paridade (alvo {site.parityTarget}%)</span>
+                <span>
+                  iteração {site.iterationsDone}/{site.maxIterations}
+                  {site.bestScore !== null &&
+                    ` · melhor ${Math.round(site.bestScore)}%`}
+                </span>
+              </div>
+              <ParityBar score={site.parityScore} target={site.parityTarget} />
+            </div>
+
+            {site.needsHumanReason && (
+              <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs whitespace-pre-wrap">
+                {site.needsHumanReason}
+              </div>
+            )}
+            {site.error && (
+              <div className="rounded-md border border-red-500/40 bg-red-500/10 p-3 text-xs whitespace-pre-wrap">
+                {site.error}
+              </div>
+            )}
+
+            <div className="flex flex-wrap gap-2">
+              {(site.status === "queued" ||
+                ![
+                  "done",
+                  "paused",
+                  "failed",
+                  "needs_human",
+                  "archived",
+                ].includes(site.status)) && (
+                <ActionButton
+                  icon={Pause}
+                  label="Pausar"
+                  busy={busy === "SITE_PAUSE"}
+                  onClick={() => action("SITE_PAUSE")}
+                />
+              )}
+              {site.status === "paused" && (
+                <ActionButton
+                  icon={Play}
+                  label="Retomar"
+                  busy={busy === "SITE_RESUME"}
+                  onClick={() => action("SITE_RESUME")}
+                />
+              )}
+              {(site.status === "failed" || site.status === "needs_human") && (
+                <ActionButton
+                  icon={RotateCcw}
+                  label="Retry"
+                  busy={busy === "SITE_RETRY"}
+                  onClick={() => action("SITE_RETRY")}
+                />
+              )}
+              {site.status !== "done" && site.status !== "archived" && (
+                <ActionButton
+                  icon={CheckCircle2}
+                  label="Marcar concluído"
+                  busy={busy === "SITE_MARK_DONE"}
+                  onClick={() => action("SITE_MARK_DONE")}
+                />
+              )}
+              {["done", "failed", "paused", "needs_human", "queued"].includes(
+                site.status,
+              ) && (
+                <ActionButton
+                  icon={Archive}
+                  label="Arquivar"
+                  busy={busy === "SITE_ARCHIVE"}
+                  onClick={() => action("SITE_ARCHIVE")}
+                />
+              )}
+              {[
+                "done",
+                "failed",
+                "paused",
+                "needs_human",
+                "queued",
+                "archived",
+              ].includes(site.status) && (
+                <ActionButton
+                  icon={Trash2}
+                  label={confirmDelete ? "Confirmar exclusão?" : "Excluir"}
+                  busy={busy === "SITE_DELETE"}
+                  danger
+                  onClick={removeSite}
+                />
+              )}
+            </div>
+
+            {error && (
+              <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2.5 text-xs">
+                {error}
+              </div>
+            )}
+
+            <div className="flex flex-col gap-1 text-xs">
+              {[
+                [
+                  "Source",
+                  site.sourceRepo,
+                  `https://github.com/${site.sourceRepo}`,
+                ],
+                site.targetRepo
+                  ? [
+                      "TanStack",
+                      site.targetRepo,
+                      `https://github.com/${site.targetRepo}`,
+                    ]
+                  : null,
+                ["Produção", site.prodUrl, site.prodUrl],
+                site.previewUrl
+                  ? ["Preview", site.previewUrl, site.previewUrl]
+                  : null,
+                site.cfDeployUrl
+                  ? ["Deploy", site.cfDeployUrl, site.cfDeployUrl]
+                  : null,
+              ]
+                .filter((x): x is [string, string, string] => !!x)
+                .map(([label, text, href]) => (
+                  <div key={label} className="flex items-center gap-2">
+                    <span className="w-16 shrink-0 text-muted-foreground">
+                      {label}
+                    </span>
+                    <a
+                      href={href}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center gap-1 truncate hover:underline"
+                    >
+                      <span className="truncate">{text}</span>
+                      <ExternalLink className="h-3 w-3 shrink-0" />
+                    </a>
+                  </div>
+                ))}
+            </div>
+
+            <div>
+              <h3 className="mb-2 text-xs font-semibold text-muted-foreground uppercase">
+                Runs
+              </h3>
+              <div className="flex flex-col gap-1.5">
+                {data.runs.length === 0 && (
+                  <p className="text-xs text-muted-foreground">
+                    Nenhum run ainda.
+                  </p>
+                )}
+                {data.runs.map((run) => (
+                  <RunRow key={run.id} run={run} />
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <h3 className="mb-2 text-xs font-semibold text-muted-foreground uppercase">
+                Atividade
+              </h3>
+              <ul className="flex flex-col gap-1">
+                {data.events.map((event) => (
+                  <li key={event.id} className="flex gap-2 text-xs">
+                    <span className="shrink-0 text-muted-foreground">
+                      {timeAgo(event.createdAt)}
+                    </span>
+                    <span
+                      className={cn(
+                        event.level === "error" &&
+                          "text-red-600 dark:text-red-400",
+                        event.level === "warn" &&
+                          "text-amber-600 dark:text-amber-400",
+                      )}
+                    >
+                      {event.message}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/tanstack-migrator/web/components/status-badge.tsx
+++ b/tanstack-migrator/web/components/status-badge.tsx
@@ -1,0 +1,75 @@
+import { cn } from "@/lib/utils.ts";
+
+export const STATUS_META: Record<
+  string,
+  { label: string; className: string; active?: boolean }
+> = {
+  queued: { label: "Na fila", className: "bg-muted text-muted-foreground" },
+  creating_repo: {
+    label: "Criando repo",
+    className: "bg-blue-500/15 text-blue-600 dark:text-blue-400",
+    active: true,
+  },
+  provisioning_sandbox: {
+    label: "Subindo sandbox",
+    className: "bg-blue-500/15 text-blue-600 dark:text-blue-400",
+    active: true,
+  },
+  migrating: {
+    label: "Migrando",
+    className: "bg-violet-500/15 text-violet-600 dark:text-violet-400",
+    active: true,
+  },
+  installing_sync: {
+    label: "Instalando sync",
+    className: "bg-blue-500/15 text-blue-600 dark:text-blue-400",
+    active: true,
+  },
+  validating: {
+    label: "Validando paridade",
+    className: "bg-indigo-500/15 text-indigo-600 dark:text-indigo-400",
+    active: true,
+  },
+  deploying_cf: {
+    label: "Deploy CF",
+    className: "bg-sky-500/15 text-sky-600 dark:text-sky-400",
+    active: true,
+  },
+  done: {
+    label: "100% TanStack",
+    className: "bg-primary/20 text-emerald-700 dark:text-emerald-300",
+  },
+  needs_human: {
+    label: "Precisa de humano",
+    className: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+  },
+  paused: { label: "Pausado", className: "bg-muted text-muted-foreground" },
+  failed: {
+    label: "Falhou",
+    className: "bg-red-500/15 text-red-600 dark:text-red-400",
+  },
+  archived: { label: "Arquivado", className: "bg-muted text-muted-foreground" },
+};
+
+export function StatusBadge({ status }: { status: string }) {
+  const meta = STATUS_META[status] ?? {
+    label: status,
+    className: "bg-muted text-muted-foreground",
+  };
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium whitespace-nowrap",
+        meta.className,
+      )}
+    >
+      {meta.active && (
+        <span className="relative flex h-1.5 w-1.5">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-current opacity-60" />
+          <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-current" />
+        </span>
+      )}
+      {meta.label}
+    </span>
+  );
+}

--- a/tanstack-migrator/web/context.tsx
+++ b/tanstack-migrator/web/context.tsx
@@ -1,0 +1,111 @@
+import {
+  type App,
+  type McpUiHostContext,
+  useApp,
+  useHostStyles,
+} from "@modelcontextprotocol/ext-apps/react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useState,
+} from "react";
+import { INITIAL_STATE, type McpState } from "./types.ts";
+
+const McpStateContext = createContext<McpState>(INITIAL_STATE);
+const McpAppContext = createContext<App | null>(null);
+const McpHostContext = createContext<McpUiHostContext | undefined>(undefined);
+
+export function McpProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<McpState>(INITIAL_STATE);
+  const [hostContext, setHostContext] = useState<McpUiHostContext | undefined>(
+    undefined,
+  );
+
+  const onAppCreated = useCallback((app: App) => {
+    app.ontoolinput = (params) => {
+      setState((prev) => {
+        const toolName =
+          prev.toolName ?? app.getHostContext()?.toolInfo?.tool.name;
+        return {
+          ...prev,
+          status: "tool-input",
+          toolInput: params.arguments,
+          ...(toolName ? { toolName } : {}),
+        };
+      });
+    };
+
+    app.ontoolresult = (result) => {
+      if (result.isError) {
+        const textBlock = result.content?.find((c) => c.type === "text");
+        const errorText =
+          (textBlock?.type === "text" ? textBlock.text : undefined) ??
+          "Tool returned an error";
+        setState((prev) => ({ ...prev, status: "error", error: errorText }));
+        return;
+      }
+      setState((prev) => ({
+        ...prev,
+        status: "tool-result",
+        toolResult: result.structuredContent,
+      }));
+    };
+
+    app.ontoolcancelled = () => {
+      setState((prev) => ({ ...prev, status: "tool-cancelled" }));
+    };
+
+    app.onerror = (err) => {
+      console.error("MCP App error:", err);
+    };
+
+    app.onhostcontextchanged = (ctx) => {
+      setHostContext((prev) => ({ ...prev, ...ctx }));
+      const toolName = ctx.toolInfo?.tool.name;
+      if (toolName) {
+        setState((prev) => ({ ...prev, toolName }));
+      }
+    };
+  }, []);
+
+  const { app, isConnected } = useApp({
+    appInfo: { name: "TanStack Migrator", version: "1.0.0" },
+    capabilities: {},
+    onAppCreated,
+  });
+
+  useHostStyles(app, app?.getHostContext());
+
+  if (isConnected && state.status === "initializing") {
+    const ctx = app?.getHostContext();
+    if (ctx) setHostContext(ctx);
+    const toolName = ctx?.toolInfo?.tool.name;
+    setState({ status: "connected", toolName });
+  }
+
+  return (
+    <McpAppContext.Provider value={app}>
+      <McpHostContext.Provider value={hostContext}>
+        <McpStateContext.Provider value={state}>
+          {children}
+        </McpStateContext.Provider>
+      </McpHostContext.Provider>
+    </McpAppContext.Provider>
+  );
+}
+
+export function useMcpState<TInput = unknown, TResult = unknown>() {
+  return useContext(McpStateContext) as McpState<TInput, TResult>;
+}
+
+export function useMcpApp() {
+  return useContext(McpAppContext);
+}
+
+export function useMcpHostContext() {
+  return useContext(McpHostContext);
+}
+
+export { useDocumentTheme as useTheme } from "@modelcontextprotocol/ext-apps/react";

--- a/tanstack-migrator/web/globals.css
+++ b/tanstack-migrator/web/globals.css
@@ -1,0 +1,93 @@
+@import "tailwindcss";
+
+@custom-variant dark (&:is([data-theme="dark"] *));
+
+:root {
+	/* Host variable fallbacks (light) */
+	--color-background-primary: hsl(0 0% 100%);
+	--color-background-secondary: hsl(240 4.8% 95.9%);
+	--color-background-tertiary: hsl(240 4.8% 95.9%);
+	--color-background-danger: hsl(0 84.2% 60.2%);
+	--color-text-primary: hsl(240 10% 3.9%);
+	--color-text-secondary: hsl(240 3.8% 46.1%);
+	--color-border-primary: hsl(240 5.9% 90%);
+	--color-border-secondary: hsl(240 5.9% 90%);
+	--color-ring-primary: hsl(240 5.9% 10%);
+
+	/* deco brand */
+	--primary: #02f67c;
+	--primary-foreground: #07401a;
+	--color-ring-primary: #02f67c;
+}
+
+[data-theme="dark"] {
+	/* Host variable fallbacks (dark) */
+	--color-background-primary: hsl(240 10% 3.9%);
+	--color-background-secondary: hsl(240 3.7% 15.9%);
+	--color-background-tertiary: hsl(240 3.7% 15.9%);
+	--color-background-danger: hsl(0 62.8% 30.6%);
+	--color-text-primary: hsl(0 0% 98%);
+	--color-text-secondary: hsl(240 5% 64.9%);
+	--color-border-primary: hsl(240 3.7% 15.9%);
+	--color-border-secondary: hsl(240 3.7% 15.9%);
+	--color-ring-primary: hsl(240 4.9% 83.9%);
+
+	--primary: #02f67c;
+	--primary-foreground: #07401a;
+	--color-ring-primary: #02f67c;
+}
+
+@layer base {
+	html {
+		height: 100%;
+	}
+
+	body {
+		height: 100%;
+		margin: 0;
+		overflow: hidden;
+		@apply bg-background text-foreground;
+	}
+
+	#root {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+		height: 100dvh;
+		min-height: 0;
+		overflow: hidden;
+	}
+
+	button,
+	a,
+	select,
+	summary,
+	[role="button"],
+	[role="tab"],
+	label[for] {
+		cursor: pointer;
+	}
+}
+
+@theme inline {
+	--color-background: var(--color-background-primary);
+	--color-foreground: var(--color-text-primary);
+	--color-card: var(--color-background-primary);
+	--color-card-foreground: var(--color-text-primary);
+	--color-popover: var(--color-background-primary);
+	--color-popover-foreground: var(--color-text-primary);
+	--color-primary: var(--primary);
+	--color-primary-foreground: var(--primary-foreground);
+	--color-secondary: var(--color-background-secondary);
+	--color-secondary-foreground: var(--color-text-primary);
+	--color-muted: var(--color-background-secondary);
+	--color-muted-foreground: var(--color-text-secondary);
+	--color-accent: var(--color-background-tertiary);
+	--color-accent-foreground: var(--color-text-primary);
+	--color-destructive: var(--color-background-danger);
+	--color-border: var(--color-border-primary);
+	--color-input: var(--color-border-secondary);
+	--color-ring: var(--color-ring-primary);
+
+	--radius-DEFAULT: var(--border-radius-md, 0.375rem);
+}

--- a/tanstack-migrator/web/hooks/use-tool.ts
+++ b/tanstack-migrator/web/hooks/use-tool.ts
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useMcpApp } from "@/context.tsx";
+
+interface ToolCallResult {
+  structuredContent?: unknown;
+  isError?: boolean;
+  content?: Array<{ type: string; text?: string }>;
+}
+
+function extractToolError(result: ToolCallResult): string | null {
+  if (!result.isError) return null;
+  const text = (result.content ?? [])
+    .filter((c) => c.type === "text" && typeof c.text === "string")
+    .map((c) => c.text ?? "")
+    .join("\n")
+    .trim();
+  return text || "Tool returned an error";
+}
+
+/** Imperative tool caller for mutations (register, pause, retry...). */
+export function useToolCaller() {
+  const app = useMcpApp();
+
+  return useCallback(
+    async <T>(name: string, args: Record<string, unknown>): Promise<T> => {
+      if (!app?.callServerTool) {
+        throw new Error("Host bridge not ready yet");
+      }
+      const result = (await app.callServerTool({
+        name,
+        arguments: args,
+      })) as ToolCallResult;
+      const error = extractToolError(result);
+      if (error) throw new Error(error);
+      return result.structuredContent as T;
+    },
+    [app],
+  );
+}
+
+interface UsePollingToolResult<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+/**
+ * Fetch tool data and keep it fresh: refetches every `intervalMs` and on
+ * demand via refresh() (used right after mutations).
+ */
+export function usePollingTool<T>(
+  name: string,
+  args: Record<string, unknown>,
+  intervalMs = 8000,
+): UsePollingToolResult<T> {
+  const app = useMcpApp();
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [nonce, setNonce] = useState(0);
+  const argsKey = JSON.stringify(args);
+  const inFlight = useRef(false);
+
+  const refresh = useCallback(() => setNonce((n) => n + 1), []);
+
+  useEffect(() => {
+    if (!app?.callServerTool) return;
+    let cancelled = false;
+
+    const fetchOnce = async () => {
+      if (inFlight.current) return;
+      inFlight.current = true;
+      try {
+        const result = (await app.callServerTool({
+          name,
+          arguments: JSON.parse(argsKey),
+        })) as ToolCallResult;
+        if (cancelled) return;
+        const toolError = extractToolError(result);
+        if (toolError) {
+          setError(toolError);
+        } else {
+          setData(result.structuredContent as T);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Tool call failed");
+        }
+      } finally {
+        inFlight.current = false;
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchOnce();
+    const interval = setInterval(fetchOnce, intervalMs);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [app, name, argsKey, intervalMs, nonce]);
+
+  return { data, loading, error, refresh };
+}

--- a/tanstack-migrator/web/lib/utils.ts
+++ b/tanstack-migrator/web/lib/utils.ts
@@ -1,0 +1,28 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+export function timeAgo(iso: string | null): string {
+  if (!iso) return "—";
+  const diff = Date.now() - Date.parse(iso);
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "agora";
+  if (minutes < 60) return `${minutes}min atrás`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h atrás`;
+  return `${Math.floor(hours / 24)}d atrás`;
+}
+
+export function duration(
+  startIso: string | null,
+  endIso: string | null,
+): string {
+  if (!startIso) return "—";
+  const end = endIso ? Date.parse(endIso) : Date.now();
+  const minutes = Math.floor((end - Date.parse(startIso)) / 60_000);
+  if (minutes < 60) return `${minutes}min`;
+  return `${Math.floor(minutes / 60)}h${minutes % 60 ? ` ${minutes % 60}min` : ""}`;
+}

--- a/tanstack-migrator/web/tools/dashboard/index.tsx
+++ b/tanstack-migrator/web/tools/dashboard/index.tsx
@@ -1,0 +1,166 @@
+import { Loader2, Plus, RefreshCw } from "lucide-react";
+import { useMemo, useState } from "react";
+import { RegisterModal } from "@/components/register-modal.tsx";
+import { SiteCard } from "@/components/site-card.tsx";
+import { SiteDetailPanel } from "@/components/site-detail.tsx";
+import { usePollingTool } from "@/hooks/use-tool.ts";
+import { cn } from "@/lib/utils.ts";
+import type { DashboardData, SiteView } from "@/types.ts";
+
+type Tab = "migrating" | "needs_human" | "done";
+
+const TAB_META: Array<{ id: Tab; label: string }> = [
+  { id: "migrating", label: "Em migração" },
+  { id: "needs_human", label: "Precisa de humano" },
+  { id: "done", label: "100% TanStack" },
+];
+
+function bucketOf(site: SiteView): Tab {
+  if (site.status === "done") return "done";
+  if (site.status === "needs_human" || site.status === "failed") {
+    return "needs_human";
+  }
+  return "migrating";
+}
+
+export default function DashboardPage() {
+  const { data, loading, error, refresh } = usePollingTool<DashboardData>(
+    "TANSTACK_MIGRATOR_DASHBOARD",
+    {},
+    8000,
+  );
+  const [tab, setTab] = useState<Tab>("migrating");
+  const [showRegister, setShowRegister] = useState(false);
+  const [selectedSiteId, setSelectedSiteId] = useState<string | null>(null);
+
+  const buckets = useMemo(() => {
+    const result: Record<Tab, SiteView[]> = {
+      migrating: [],
+      needs_human: [],
+      done: [],
+    };
+    for (const site of data?.sites ?? []) {
+      result[bucketOf(site)].push(site);
+    }
+    result.done.sort((a, b) =>
+      (b.finishedAt ?? b.updatedAt).localeCompare(a.finishedAt ?? a.updatedAt),
+    );
+    return result;
+  }, [data]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3">
+        <div className="flex items-center gap-3">
+          <h1 className="text-base font-bold">TanStack Migrator</h1>
+          {data && (
+            <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+              {data.queue.active}/{data.queue.maxConcurrent} slots ·{" "}
+              {data.queue.queued} na fila
+              {data.queue.provider === "manual" ? " · simulação" : ""}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={refresh}
+            className="rounded-md border border-border p-2 text-muted-foreground hover:bg-muted"
+            title="Atualizar"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowRegister(true)}
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-xs font-semibold text-primary-foreground hover:opacity-90"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Cadastrar site
+          </button>
+        </div>
+      </header>
+
+      <nav className="flex gap-1 border-b border-border px-4 pt-2">
+        {TAB_META.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            onClick={() => setTab(t.id)}
+            className={cn(
+              "rounded-t-md px-3 py-2 text-xs font-medium",
+              tab === t.id
+                ? "border border-b-0 border-border bg-card"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {t.label}
+            <span className="ml-1.5 rounded-full bg-muted px-1.5 text-[10px] tabular-nums">
+              {buckets[t.id].length}
+            </span>
+          </button>
+        ))}
+      </nav>
+
+      <main className="min-h-0 flex-1 overflow-y-auto p-4">
+        {loading && !data && (
+          <div className="flex h-40 items-center justify-center">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        )}
+        {error && !data && (
+          <div className="rounded-md border border-red-500/40 bg-red-500/10 p-4 text-sm">
+            {error}
+          </div>
+        )}
+
+        {data && buckets[tab].length === 0 && (
+          <div className="flex h-40 flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
+            {tab === "migrating" ? (
+              <>
+                <p>Nenhuma migração em andamento.</p>
+                <button
+                  type="button"
+                  onClick={() => setShowRegister(true)}
+                  className="text-primary-foreground rounded-md bg-primary px-3 py-1.5 text-xs font-semibold"
+                >
+                  Cadastrar o primeiro site
+                </button>
+              </>
+            ) : tab === "needs_human" ? (
+              <p>Nada esperando humano. 🙌</p>
+            ) : (
+              <p>Nenhum site 100% TanStack ainda.</p>
+            )}
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {buckets[tab].map((site) => (
+            <SiteCard
+              key={site.id}
+              site={site}
+              simulation={data?.queue.provider === "manual"}
+              onClick={() => setSelectedSiteId(site.id)}
+            />
+          ))}
+        </div>
+      </main>
+
+      {showRegister && (
+        <RegisterModal
+          onClose={() => setShowRegister(false)}
+          onRegistered={refresh}
+        />
+      )}
+      {selectedSiteId && (
+        <SiteDetailPanel
+          siteId={selectedSiteId}
+          simulation={data?.queue.provider === "manual"}
+          onClose={() => setSelectedSiteId(null)}
+          onChanged={refresh}
+        />
+      )}
+    </div>
+  );
+}

--- a/tanstack-migrator/web/tools/dashboard/main.tsx
+++ b/tanstack-migrator/web/tools/dashboard/main.tsx
@@ -1,0 +1,4 @@
+import { mountMcpApp } from "@/bootstrap.tsx";
+import DashboardPage from "./index.tsx";
+
+mountMcpApp(DashboardPage);

--- a/tanstack-migrator/web/types.ts
+++ b/tanstack-migrator/web/types.ts
@@ -1,0 +1,116 @@
+export type McpStatus =
+  | "initializing"
+  | "connected"
+  | "tool-input"
+  | "tool-result"
+  | "tool-cancelled"
+  | "error";
+
+export interface McpState<TInput = unknown, TResult = unknown> {
+  status: McpStatus;
+  toolName?: string;
+  error?: string;
+  toolInput?: TInput;
+  toolResult?: TResult;
+}
+
+export const INITIAL_STATE: McpState = { status: "initializing" };
+
+/* ---- mirrors of the server view shapes (server/tools/views.ts) ---- */
+
+export interface SiteView {
+  id: string;
+  name: string;
+  sourceRepo: string;
+  sourceBranch: string;
+  targetRepo: string | null;
+  prodUrl: string;
+  status: string;
+  phaseDetail: string | null;
+  parityScore: number | null;
+  parityTarget: number;
+  bestScore: number | null;
+  iterationsDone: number;
+  maxIterations: number;
+  previewUrl: string | null;
+  cfDeployUrl: string | null;
+  error: string | null;
+  needsHumanReason: string | null;
+  createdAt: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+  updatedAt: string;
+}
+
+export interface DashboardData {
+  sites: SiteView[];
+  queue: {
+    active: number;
+    queued: number;
+    needsHuman: number;
+    done: number;
+    maxConcurrent: number;
+    provider: string;
+  };
+  updatedAt: string;
+}
+
+export interface ParityIssue {
+  severity: string;
+  category?: string;
+  page?: string;
+  summary: string;
+  suggestedFix?: string;
+}
+
+export interface ParitySummary {
+  verdict?: {
+    status: string;
+    score: number;
+    critical?: number;
+    high?: number;
+    medium?: number;
+    low?: number;
+  };
+  parityOk?: boolean;
+  topIssues?: ParityIssue[];
+  perPage?: Array<{
+    pagePath: string;
+    viewport?: string;
+    pctDiff?: number;
+    verdict?: string;
+    sectionsOnlyInProd?: string[];
+  }>;
+}
+
+export interface RunView {
+  id: string;
+  kind: string;
+  iteration: number;
+  status: string;
+  parityScore: number | null;
+  summary: ParitySummary | null;
+  hasArtifacts: boolean;
+  logsTail: string | null;
+  startedAt: string;
+  finishedAt: string | null;
+}
+
+export interface EventView {
+  id: number;
+  level: string;
+  message: string;
+  createdAt: string;
+}
+
+export interface SiteDetail {
+  site: SiteView;
+  runs: RunView[];
+  events: EventView[];
+}
+
+export interface ReportUrls {
+  reportHtml: string | null;
+  reportJson: string | null;
+  heatmaps: Array<{ name: string; url: string }>;
+}


### PR DESCRIPTION
## O que é

MCP **tanstack-migrator**: orquestrador autônomo de migrações de storefronts Deco (Fresh/Deno → TanStack Start), com dashboard (MCP App) pra cadastrar sites, acompanhar fase + parity % e listar os sites 100% TanStack.

## Como funciona

```
cadastro → fila FIFO (1-2 slots) → creating_repo → provisioning_sandbox → migrating
        → installing_sync → validating (loop parity→fix) → deploying_cf → done
```

- **Worker em background** (tick 30s, leases por site, watchdog de 30min) com todo estado no Supabase (`sitemig_*`, já aplicado no projeto `decocms-mcps`) — sobrevive a restart de pod.
- **Sandbox**: driver `manual` (simulação end-to-end pra demo, default) e `decopilot` (live) — `COLLECTION_VIRTUAL_MCP_CREATE` + `SANDBOX_START`/`SANDBOX_DELETE` no `/mcp/self` com API key auto-mintada (mint lazy em qualquer request), sessões claude-code bounded por fase/iteração, keepalive do TTL.
- **% de progresso = `verdict.score` da `@decocms/parity`**; report.html + heatmaps sobem via presigned PUT pro binding OBJECT_STORAGE e aparecem na UI.
- **GitHub via binding com contrato inline de tools** (matcha qualquer conexão GitHub, independente do `app_name` do registry); grant de push (`MINT_REPO_TOKEN`) opcional — sem ele o sandbox usa as credenciais git sincronizadas pelo mesh; 403 de criação de repo degrada pra `needs_human` com instrução.
- Instala o workflow de **sync do `.deco`** (padrão granadobr: cron 30min buscando `/.decofile` da produção) no repo `-tanstack`.
- **Cloudflare Workers Builds** via API com fallback de instruções manuais.

## Validação

- 15 testes unitários (`bun test`), typecheck limpo, `bun run build` (web single-file + server) ok.
- Testado end-to-end no studio local (mesh main): fluxo simulado completo no dashboard; em modo live criou **repo real** + **virtualMcp real** e parou exatamente na fronteira de RBAC do k8s local (`sandboxclaims`) — em produção o mesh usa o service account com permissão.

## Pós-merge

1. `publish-registry.yml` publica e a plataforma kubernetes-bun sobe o server (build roda `build:web` + `build:server`).
2. Instalar no studio, conectar GitHub + Object Storage, `SANDBOX_PROVIDER=decopilot` e rodar um piloto.
3. Pendências conhecidas (degradam bonito): permissão de criação de repo na GitHub App (Administration write), shape da API de Workers Builds, validação live da sessão claude-code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `tanstack-migrator`, an autonomous MCP that migrates Deco storefronts from Fresh/Deno to TanStack Start with a FIFO queue, sandboxed migrate + parity loop, Cloudflare deploy, and a dashboard. Includes a full simulation driver and a live `decopilot` driver, and is wired into `deploy.json` for `kubernetes-bun`.

- **New Features**
  - Background worker (30s tick, leases, 30min stall watchdog) with restart-safe state in Supabase.
  - Phases: queued → creating_repo → provisioning_sandbox → migrating → installing_sync → validating (parity loop) → deploying_cf → done.
  - Sandbox drivers: `manual` (simulation) and `decopilot` (live via mesh `COLLECTION_VIRTUAL_MCP_CREATE` + `SANDBOX_START/DELETE`, bounded claude-code sessions, idle TTL keepalive). Mesh API key is auto-minted and persisted.
  - Parity via `@decocms/parity`; report and heatmaps uploaded with presigned PUTs from `OBJECT_STORAGE`; dashboard links to artifacts.
  - GitHub via binding with inline tool contract; creates `<repo>-tanstack`, optional `MINT_REPO_TOKEN` for pushes, installs `.deco` sync workflow (30m cron).
  - Cloudflare Workers Builds project creation with a needs-human fallback when missing API creds.
  - MCP App dashboard to register sites, track phase and parity %, review activity, and manage pause/resume/retry/archive.

- **Migration**
  - Deploy the new service: `deploy.json` adds `tanstack-migrator` (entrypoint `./dist/server/main.js`, platform `kubernetes-bun`, watches `tanstack-migrator/**`), and root `package.json` includes the workspace.
  - In Studio, connect `GITHUB` and `OBJECT_STORAGE` bindings and install the MCP App.
  - Set `SANDBOX_PROVIDER=decopilot` for live runs; `manual` simulates end-to-end.
  - Ensure the GitHub App has org repo-create and `workflows:write`; set `MINT_REPO_TOKEN` if you want MCP-side pushes.
  - Provide Cloudflare account id and API token in MCP state for Workers Builds auto-setup; otherwise follow the manual steps exposed by the tool.

<sup>Written for commit 7303668e96243866a6c62f37f623d9fc5e0b05ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

