### PR TITLE
fix(tanstack-migrator): live-run hardening (v0.5.1)

### DIFF
--- a/tanstack-migrator/package.json
+++ b/tanstack-migrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tanstack-migrator",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Orchestrates Fresh/Deno \u2192 TanStack Start storefront migrations: FIFO queue, mesh sandboxes running Claude in short issue-driven sessions (GitHub issues as durable memory), branch+PR flow and Cloudflare deploy on merge",
   "private": true,
   "type": "module",

--- a/tanstack-migrator/server/db/runs.ts
+++ b/tanstack-migrator/server/db/runs.ts
@@ -99,6 +99,23 @@ export async function attachThreadToRun(
     .is("finished_at", null);
 }
 
+/** Close a site's open run rows immediately (liveness detected a dead reader). */
+export async function closeOpenRunsForSite(
+  siteId: string,
+  note: string,
+): Promise<void> {
+  const client = requireSupabase();
+  await client
+    .from("sitemig_runs")
+    .update({
+      status: "failed",
+      logs_tail: note,
+      finished_at: new Date().toISOString(),
+    })
+    .eq("site_id", siteId)
+    .eq("status", "running");
+}
+
 /** Close run rows abandoned by dead readers (pod restarts). */
 export async function closeStaleRuns(olderThanMinutes: number): Promise<void> {
   const client = requireSupabase();

--- a/tanstack-migrator/server/engine/phases/opening-pr.ts
+++ b/tanstack-migrator/server/engine/phases/opening-pr.ts
@@ -162,8 +162,14 @@ export async function openingPr(site: SiteRow, ctx: WorkerCtx): Promise<void> {
     }
   }
 
-  // 3. sandbox restart — with a package.json on the branch, the daemon
-  // installs deps and manages the dev server from here on
+  // 3. fresh sandbox — destroy + recreate so the daemon clones the branch
+  // WITH package.json already present (provisioning_sandbox ran when the repo
+  // was still empty; the daemon marks packageManager=null and never recovers).
+  try {
+    await getDriver(ctx).destroy({ ...site, ...prPatch } as SiteRow, ctx);
+  } catch {
+    // sandbox may have already expired — ignore
+  }
   try {
     const info = await getDriver(ctx).ensure(
       { ...site, ...prPatch } as SiteRow,
@@ -177,13 +183,13 @@ export async function openingPr(site: SiteRow, ctx: WorkerCtx): Promise<void> {
     };
     await addEvent(
       site.id,
-      "Sandbox reiniciado — daemon assume install + dev server",
+      "Sandbox recriado — daemon clona branch com package.json, instala deps e sobe dev server",
     );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     await addEvent(
       site.id,
-      `Restart do sandbox falhou (${message.slice(0, 160)}) — o keepalive tenta de novo`,
+      `Recriação do sandbox falhou (${message.slice(0, 160)}) — keepalive tenta no próximo tick`,
       "warn",
     );
   }

--- a/tanstack-migrator/server/engine/phases/paritying.ts
+++ b/tanstack-migrator/server/engine/phases/paritying.ts
@@ -127,7 +127,8 @@ export async function paritying(
             ? simulatedSummary(result.parityScore)
             : null;
       } else {
-        const artifacts = await presignPutUrls(ctx, keys);
+        // object storage is optional — skip artifacts gracefully
+        const artifacts = await presignPutUrls(ctx, keys).catch(() => null);
         result = await getDriver(ctx).runTask(site, ctx, {
           kind: "parity",
           iteration,

--- a/tanstack-migrator/server/engine/phases/transient.ts
+++ b/tanstack-migrator/server/engine/phases/transient.ts
@@ -16,6 +16,14 @@ import type { SiteRow, SiteStatus } from "../../db/types.ts";
 
 export const TRANSIENT_ZOMBIE_SIGNATURE =
   /decopilot (stream|message dispatch|thread stream) failed \(404\)|organization .+ not found/i;
+/**
+ * Turn-limit deaths: the harness ends the turn mid-work and the session
+ * never emits its RESULT_JSON. Retrying CONTINUES the same thread
+ * (phase_thread_id is kept on failure), so each retry is another chapter
+ * of the same conversation — the agent picks up where it died.
+ */
+export const RESUMABLE_SESSION_SIGNATURE =
+  /session ended without a RESULT_JSON line/i;
 export const MAX_TRANSIENT_RETRIES = 12;
 
 /** `retryStatus` = the phase to stay in on a transient failure (usually the current one). */
@@ -25,21 +33,25 @@ export async function failOrAutoRetry(
   retryStatus: SiteStatus,
   label: string,
 ): Promise<void> {
+  const zombie = TRANSIENT_ZOMBIE_SIGNATURE.test(message);
+  const turnLimit = RESUMABLE_SESSION_SIGNATURE.test(message);
   const transient =
-    TRANSIENT_ZOMBIE_SIGNATURE.test(message) &&
-    site.transient_retries < MAX_TRANSIENT_RETRIES;
+    (zombie || turnLimit) && site.transient_retries < MAX_TRANSIENT_RETRIES;
 
   if (transient) {
+    const reason = turnLimit
+      ? "sessão atingiu o limite de turnos — continuando a mesma thread"
+      : "sessão caiu em réplica desatualizada — tentando de novo";
     await updateSite(site.id, {
       status: retryStatus,
       transient_retries: site.transient_retries + 1,
-      phase_detail: `sessão caiu em réplica desatualizada — tentando de novo (${site.transient_retries + 1}/${MAX_TRANSIENT_RETRIES})`,
+      phase_detail: `${reason} (${site.transient_retries + 1}/${MAX_TRANSIENT_RETRIES})`,
       sandbox_session_id: null,
       last_progress_at: new Date().toISOString(),
     });
     await addEvent(
       site.id,
-      `Sessão falhou em réplica desatualizada, retry automático ${site.transient_retries + 1}/${MAX_TRANSIENT_RETRIES}: ${message.slice(0, 160)}`,
+      `${reason} — retry automático ${site.transient_retries + 1}/${MAX_TRANSIENT_RETRIES}`,
       "warn",
     );
     return;

--- a/tanstack-migrator/server/engine/worker.ts
+++ b/tanstack-migrator/server/engine/worker.ts
@@ -25,7 +25,7 @@ import {
 import { isSupabaseConfigured } from "../db/client.ts";
 import { loadAllConnections, saveConnection } from "../db/connections.ts";
 import { addEvent } from "../db/events.ts";
-import { closeStaleRuns } from "../db/runs.ts";
+import { closeOpenRunsForSite, closeStaleRuns } from "../db/runs.ts";
 import {
   acquireLease,
   getSite,
@@ -173,7 +173,13 @@ async function probeSessionLiveness(
       return;
     }
     // Terminal thread with a dead reader: free the session marker so the
-    // phase relaunches next tick (the reused thread keeps the context).
+    // phase relaunches next tick (the reused thread keeps the context), and
+    // close the dangling run row NOW — the history should never show a
+    // phantom "running" entry until the 50min sweep.
+    await closeOpenRunsForSite(
+      site.id,
+      `[leitor morreu; fase repicada — thread ${site.phase_thread_id} ${status}]`,
+    ).catch(() => {});
     await updateSite(site.id, {
       sandbox_session_id: null,
       phase_detail: `thread terminou (${status}) com o leitor morto — repicando a fase`,

--- a/tanstack-migrator/server/lib/github.ts
+++ b/tanstack-migrator/server/lib/github.ts
@@ -248,7 +248,18 @@ function unwrapList(raw: unknown): Record<string, unknown>[] {
 }
 
 function toIssue(raw: Record<string, unknown>): GithubIssue | null {
-  const number = typeof raw.number === "number" ? raw.number : undefined;
+  const rawUrl =
+    typeof raw.html_url === "string"
+      ? raw.html_url
+      : typeof raw.url === "string"
+        ? raw.url
+        : undefined;
+  let number = typeof raw.number === "number" ? raw.number : undefined;
+  if (number === undefined && rawUrl) {
+    // the proxy's issue_write create answers only {id, url}
+    const match = rawUrl.match(/\/issues\/(\d+)/);
+    if (match) number = Number(match[1]);
+  }
   if (number === undefined) return null;
   const labels = Array.isArray(raw.labels)
     ? (raw.labels as unknown[])
@@ -430,7 +441,19 @@ export interface PullRequestInfo {
 }
 
 function toPullRequest(raw: Record<string, unknown>): PullRequestInfo | null {
-  const number = typeof raw.number === "number" ? raw.number : undefined;
+  const url =
+    typeof raw.html_url === "string"
+      ? raw.html_url
+      : typeof raw.url === "string" && raw.url.includes("/pull/")
+        ? raw.url
+        : undefined;
+  let number = typeof raw.number === "number" ? raw.number : undefined;
+  if (number === undefined && url) {
+    // the proxy's create_pull_request answers only {id, url} — the number
+    // lives in the URL path
+    const match = url.match(/\/pull\/(\d+)/);
+    if (match) number = Number(match[1]);
+  }
   if (number === undefined) return null;
   const state = typeof raw.state === "string" ? raw.state.toLowerCase() : "";
   const merged =
@@ -438,12 +461,7 @@ function toPullRequest(raw: Record<string, unknown>): PullRequestInfo | null {
     typeof raw.merged_at === "string" ||
     typeof raw.mergedAt === "string" ||
     state === "merged";
-  return {
-    number,
-    url: typeof raw.html_url === "string" ? raw.html_url : undefined,
-    state,
-    merged,
-  };
+  return { number, url, state, merged };
 }
 
 export async function createPullRequest(

--- a/tanstack-migrator/server/sandbox/drivers/decopilot.ts
+++ b/tanstack-migrator/server/sandbox/drivers/decopilot.ts
@@ -92,7 +92,10 @@ async function createVirtualMcp(
               : {}),
           },
         },
-        connections: [],
+        // attach THIS MCP so sessions can call MIGRATION_REPORT_PROGRESS —
+        // without it the tool doesn't exist and calling it kills the turn
+        // before the RESULT_JSON is emitted
+        connections: [ctx.connectionId],
       },
     },
     60_000,
@@ -277,7 +280,9 @@ async function runDecopilotSession(
           Authorization: `Bearer ${ctx.meshToken}`,
           Accept: "text/event-stream",
         },
-        signal: AbortSignal.timeout(remaining),
+        // windowed read: the production mesh holds the SSE open past thread
+        // completion — abort periodically so the status check below runs
+        signal: AbortSignal.timeout(Math.min(remaining, 90_000)),
       });
       if (!response.ok) {
         const errorText = await response.text();
@@ -297,8 +302,7 @@ async function runDecopilotSession(
       // instead of spinning until the timeout.
       const status = await getThreadStatus(ctx, threadId);
       if (status && status !== "in_progress" && status !== "requires_action") {
-        const finalText = await fetchThreadFinalText(ctx, threadId);
-        if (finalText) output = `${output}\n${finalText}`.trim();
+        output = await rescueFinalText(ctx, threadId, output);
         await addEvent(
           site.id,
           `Thread ${threadId} terminou (status: ${status}) — ${parseResultJson(output) ? "RESULT_JSON capturado" : "SEM RESULT_JSON (sessão incompleta)"}`,
@@ -321,6 +325,28 @@ async function runDecopilotSession(
       const message = err instanceof Error ? err.message : String(err);
       // 4xx from the route is permanent — bubble it up instead of spinning
       if (/\((400|401|403|404)\)/.test(message)) throw err;
+      // aborted/failed read — the thread may have completed while we were
+      // blocked on the stream; rescue instead of reconnecting forever
+      const status = await getThreadStatus(ctx, threadId);
+      if (status && status !== "in_progress" && status !== "requires_action") {
+        output = await rescueFinalText(ctx, threadId, output);
+        await addEvent(
+          site.id,
+          `Thread ${threadId} terminou (status: ${status}) — ${parseResultJson(output) ? "RESULT_JSON capturado" : "SEM RESULT_JSON (sessão incompleta)"}`,
+          parseResultJson(output) ? "info" : "warn",
+        );
+        return { output, threadId };
+      }
+      // heartbeat also on the windowed-abort path — the dashboard should
+      // keep moving while the agent works
+      if (Date.now() - lastHeartbeat > 60_000) {
+        lastHeartbeat = Date.now();
+        const minutes = Math.round((Date.now() - startedAt) / 60_000);
+        await updateSite(site.id, {
+          phase_detail: `sessão ${threadId}: ${status ?? "trabalhando"} há ${minutes}min`,
+          last_progress_at: new Date().toISOString(),
+        }).catch(() => {});
+      }
       console.warn(`[decopilot] stream reconnect (${message.slice(0, 120)})`);
     }
     await sleep(STREAM_RECONNECT_DELAY_MS);
@@ -388,6 +414,26 @@ async function fetchThreadFinalText(
   } catch {
     return "";
   }
+}
+
+/**
+ * Terminal-thread rescue with persistence-race tolerance: the thread status
+ * flips to completed BEFORE the final assistant message finishes writing —
+ * re-fetch a few times before declaring the session RESULT_JSON-less.
+ */
+async function rescueFinalText(
+  ctx: WorkerCtx,
+  threadId: string,
+  output: string,
+): Promise<string> {
+  for (let attempt = 0; attempt < 4; attempt++) {
+    if (attempt > 0) await sleep(8_000);
+    const finalText = await fetchThreadFinalText(ctx, threadId);
+    const merged = finalText ? `${output}\n${finalText}`.trim() : output;
+    if (parseResultJson(merged)) return merged;
+  }
+  const finalText = await fetchThreadFinalText(ctx, threadId);
+  return finalText ? `${output}\n${finalText}`.trim() : output;
 }
 
 const num = (v: unknown): number | undefined =>

--- a/tanstack-migrator/server/sandbox/templates/prompts.ts
+++ b/tanstack-migrator/server/sandbox/templates/prompts.ts
@@ -129,7 +129,7 @@ export function parseResultJson(output: string): SessionResult | null {
 }
 
 const progressInstruction = (site: SiteRow) =>
-  `Sempre que concluir um passo relevante, chame a tool MIGRATION_REPORT_PROGRESS do MCP tanstack-migrator com {"siteId": "${site.id}", "detail": "<o que acabou de fazer>"} (e "parityScore" quando tiver um score novo).`;
+  `Se a tool MIGRATION_REPORT_PROGRESS (MCP tanstack-migrator) estiver disponível, chame-a ao concluir passos relevantes com {"siteId": "${site.id}", "detail": "<o que acabou de fazer>"} (e "parityScore" quando tiver score novo). Se ela NÃO estiver no seu conjunto de tools, siga sem reportar — NUNCA tente chamá-la às cegas. O mais importante: a linha RESULT_JSON no fim da sua última mensagem é OBRIGATÓRIA em qualquer cenário — emita-a antes de qualquer passo opcional.`;
 
 function repoUrl(full: string | null, ghToken?: string): string {
   if (!full) throw new Error("repo not set");

--- a/tanstack-migrator/web/components/site-detail.tsx
+++ b/tanstack-migrator/web/components/site-detail.tsx
@@ -79,10 +79,14 @@ function RunRow({ run }: { run: RunView }) {
     }
   };
 
+  const takenIssues = run.meta?.issues?.taken;
   const kindLabel: Record<string, string> = {
     migrate: "script de migração",
     triage: "triagem",
-    fix: `fix ${run.iteration}`,
+    // show WHICH issues the session took, not just a sequence number
+    fix: takenIssues?.length
+      ? `fix ${takenIssues.map((n) => `#${n}`).join(" ")}`
+      : `fix ${run.iteration}`,
     parity: `parity ${run.iteration}`,
     fix_iteration: `iteração ${run.iteration}`,
     install_sync: "instalação do sync",
@@ -123,11 +127,12 @@ function RunRow({ run }: { run: RunView }) {
           </span>
         </div>
         <div className="flex items-center gap-2 text-xs">
-          {run.finishedAt && (
-            <span className="text-muted-foreground tabular-nums">
-              {duration(run.startedAt, run.finishedAt)}
-            </span>
-          )}
+          {/* running rows show live elapsed time (re-rendered by the 10s poll) */}
+          <span className="text-muted-foreground tabular-nums">
+            {run.finishedAt
+              ? duration(run.startedAt, run.finishedAt)
+              : `${duration(run.startedAt, new Date().toISOString())}…`}
+          </span>
           {run.threadId && (
             <span
               role="button"
@@ -306,11 +311,11 @@ export function SiteDetailPanel({
   simulation?: boolean;
 }) {
   const callTool = useToolCaller();
-  const { data, refresh } = usePollingTool<SiteDetail>(
-    "SITE_GET",
-    { siteId },
-    10_000,
-  );
+  const {
+    data,
+    refresh,
+    error: loadError,
+  } = usePollingTool<SiteDetail>("SITE_GET", { siteId }, 10_000);
   const [busy, setBusy] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -366,7 +371,22 @@ export function SiteDetailPanel({
           </button>
         </div>
 
-        {!site ? (
+        {loadError && /not found/i.test(loadError) ? (
+          // the site was deleted while the drawer was open — never freeze
+          // showing stale data
+          <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+            <p className="text-sm text-muted-foreground">
+              Este site foi excluído — os dados não existem mais.
+            </p>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-border px-3 py-1.5 text-xs font-medium hover:bg-muted"
+            >
+              Fechar
+            </button>
+          </div>
+        ) : !site ? (
           <div className="flex flex-1 items-center justify-center">
             <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
           </div>


### PR DESCRIPTION
Fixes diagnosticados AO VIVO rodando o granadobr-teste pelo pipeline v0.5.0 contra o mesh de produção — cada item tem uma run vermelha correspondente no histórico do site:

| Sintoma ao vivo | Causa raiz | Fix |
|---|---|---|
| `issue/PR create returned no number` | binding responde só `{id, url}` | número extraído da URL |
| Leitor preso 8-10min por sessão | produção não fecha o SSE na conclusão | leitura em janelas de 90s + checagem de status no abort |
| `SEM RESULT_JSON` com trabalho pronto | status `completed` chega antes da última mensagem persistir | resgate com re-fetch (~30s) |
| Turn morta no meio do trabalho | turn limit do harness | retry auto-continua a MESMA thread (multi-turno em capítulos, limitado por `transient_retries`) |
| Turn morta ao reportar progresso | `MIGRATION_REPORT_PROGRESS` inexistente na sessão | virtualMcp criado com a connection do MCP + prompt condicional + RESULT_JSON obrigatório |
| Run 'azul' órfã até o sweep de 50min | liveness repicava sem fechar o run | `closeOpenRunsForSite` no repique |
| Histórico sem tempos | — | tempo decorrido ao vivo em runs rodando; label `fix #4`; drawer detecta site excluído |

Validação: com esses fixes aplicados no worker local, o loop drenou #2→#5 sem intervenção (sessões de 1-4min, issues fechadas no GitHub com commits `fix(#N)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens live migration runs in `tanstack-migrator` v0.5.1 for reliability. Adds resilient SSE streaming, reliable RESULT_JSON capture, correct GitHub issue/PR numbers, immediate cleanup of orphaned runs, sandbox recreate after PR, and allows paritying to run without object storage.

- **Bug Fixes**
  - Parse issue/PR numbers from the URL when the API returns only {id, url}.
  - Windowed SSE (90s) with status checks; on abort, rescue final text and re-fetch ~30s to capture RESULT_JSON.
  - Auto-retry continues the same thread after turn-limit deaths (bounded by transient_retries).
  - Recreate the sandbox in opening_pr so the daemon clones the branch with `package.json`, installs deps, and starts the dev server.
  - Attach this MCP connection to the virtual MCP so `MIGRATION_REPORT_PROGRESS` is callable; prompt makes it optional and requires a final RESULT_JSON line.
  - Close dangling “running” rows immediately when the reader dies; phase relaunches next tick.
  - Paritying runs without object storage; skip artifacts if presign fails.

- **New Features**
  - Show live elapsed time for running runs and label fix runs with the issue numbers taken (e.g., fix #4).
  - Drawer handles deleted sites without freezing.

<sup>Written for commit a750f65a8e5a53f5c46ad48f0360bc6e0b516764. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

