### PR TITLE
fix(tanstack-migrator): widgets de home mais densos (v0.6.1)

### DIFF
--- a/tanstack-migrator/package.json
+++ b/tanstack-migrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tanstack-migrator",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Orchestrates Fresh/Deno → TanStack Start storefront migrations: issue-driven pipeline, mesh sandboxes running Claude, branch+PR flow, parity via Playwright, visual dashboard + home widgets",
   "private": true,
   "type": "module",

--- a/tanstack-migrator/web/components/pipeline-stepper.tsx
+++ b/tanstack-migrator/web/components/pipeline-stepper.tsx
@@ -89,90 +89,105 @@ export function PipelineStepper({
     ? phaseIndexFor(resumeStatus ?? "")
     : phaseIndexFor(status);
   const currentIdx = isBlocked && rawIdx < 0 ? 0 : rawIdx;
-  const iconSize = compact ? "h-3 w-3" : "h-3.5 w-3.5";
-  const dot = compact ? "h-6 w-6" : "h-7 w-7";
+  const iconSize = compact ? "h-2.5 w-2.5" : "h-3.5 w-3.5";
+  const dot = compact ? "h-5 w-5" : "h-7 w-7";
+  const blockedColor =
+    status === "failed"
+      ? "border-red-500 bg-red-500/15 text-red-600 dark:text-red-400"
+      : "border-amber-500 bg-amber-500/15 text-amber-600 dark:text-amber-400";
+
+  // compact (home widgets): dots-only row + one caption for the current phase,
+  // so 9 phases never overflow a narrow card or overlap their labels.
+  const currentPhase = PIPELINE_PHASES[currentIdx];
 
   return (
-    <div
-      className={cn("flex w-full items-start overflow-x-auto pb-1", className)}
-    >
-      {PIPELINE_PHASES.map((phase, i) => {
-        const concluded = isDone || i < currentIdx;
-        const current = !isDone && i === currentIdx;
-        const Icon = phase.icon;
+    <div className={cn("flex w-full flex-col gap-1", className)}>
+      <div className="flex w-full items-center">
+        {PIPELINE_PHASES.map((phase, i) => {
+          const concluded = isDone || i < currentIdx;
+          const current = !isDone && i === currentIdx;
+          const Icon = phase.icon;
 
-        const ring = concluded
-          ? "border-primary bg-primary/15 text-emerald-600 dark:text-emerald-400"
-          : current
-            ? isBlocked
-              ? status === "failed"
-                ? "border-red-500 bg-red-500/15 text-red-600 dark:text-red-400"
-                : "border-amber-500 bg-amber-500/15 text-amber-600 dark:text-amber-400"
-              : "border-indigo-500 bg-indigo-500/15 text-indigo-600 dark:text-indigo-400"
-            : "border-border bg-muted text-muted-foreground/50";
+          const ring = concluded
+            ? "border-primary bg-primary/15 text-emerald-600 dark:text-emerald-400"
+            : current
+              ? isBlocked
+                ? blockedColor
+                : "border-indigo-500 bg-indigo-500/15 text-indigo-600 dark:text-indigo-400"
+              : "border-border bg-muted text-muted-foreground/50";
 
-        return (
-          <div
-            key={phase.key}
-            className="flex min-w-0 flex-1 flex-col items-center gap-1"
-            title={current && phaseDetail ? phaseDetail : phase.label}
-          >
-            <div className="flex w-full items-center">
-              {/* connector left */}
-              <span
-                className={cn(
-                  "h-0.5 flex-1",
-                  i === 0
-                    ? "bg-transparent"
-                    : concluded || current
-                      ? "bg-primary/60"
-                      : "bg-border",
-                )}
-              />
-              <span
-                className={cn(
-                  "relative flex shrink-0 items-center justify-center rounded-full border-2",
-                  dot,
-                  ring,
-                )}
-              >
-                {concluded ? (
-                  <Check className={iconSize} />
-                ) : (
-                  <Icon className={iconSize} />
-                )}
-                {current && !isBlocked && (
-                  <span className="absolute inset-0 animate-ping rounded-full border-2 border-indigo-500 opacity-40" />
-                )}
-              </span>
-              {/* connector right */}
-              <span
-                className={cn(
-                  "h-0.5 flex-1",
-                  i === PIPELINE_PHASES.length - 1
-                    ? "bg-transparent"
-                    : concluded
-                      ? "bg-primary/60"
-                      : "bg-border",
-                )}
-              />
-            </div>
-            <span
-              className={cn(
-                "truncate text-center leading-tight",
-                compact ? "text-[9px]" : "text-[10px]",
-                current
-                  ? "font-semibold text-foreground"
-                  : concluded
-                    ? "text-muted-foreground"
-                    : "text-muted-foreground/50",
-              )}
+          return (
+            <div
+              key={phase.key}
+              className="flex min-w-0 flex-1 flex-col items-center gap-1"
+              title={current && phaseDetail ? phaseDetail : phase.label}
             >
-              {phase.label}
-            </span>
-          </div>
-        );
-      })}
+              <div className="flex w-full items-center">
+                <span
+                  className={cn(
+                    "h-0.5 flex-1",
+                    i === 0
+                      ? "bg-transparent"
+                      : concluded || current
+                        ? "bg-primary/60"
+                        : "bg-border",
+                  )}
+                />
+                <span
+                  className={cn(
+                    "relative flex shrink-0 items-center justify-center rounded-full border-2",
+                    dot,
+                    ring,
+                  )}
+                >
+                  {concluded ? (
+                    <Check className={iconSize} />
+                  ) : (
+                    <Icon className={iconSize} />
+                  )}
+                  {current && !isBlocked && (
+                    <span className="absolute inset-0 animate-ping rounded-full border-2 border-indigo-500 opacity-40" />
+                  )}
+                </span>
+                <span
+                  className={cn(
+                    "h-0.5 flex-1",
+                    i === PIPELINE_PHASES.length - 1
+                      ? "bg-transparent"
+                      : concluded
+                        ? "bg-primary/60"
+                        : "bg-border",
+                  )}
+                />
+              </div>
+              {!compact && (
+                <span
+                  className={cn(
+                    "truncate text-center text-[10px] leading-tight",
+                    current
+                      ? "font-semibold text-foreground"
+                      : concluded
+                        ? "text-muted-foreground"
+                        : "text-muted-foreground/50",
+                  )}
+                >
+                  {phase.label}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {compact && (
+        <span className="text-center text-[10px] font-medium text-muted-foreground">
+          {isDone
+            ? "concluído"
+            : currentPhase
+              ? `${currentPhase.label} · ${Math.min(currentIdx + 1, PIPELINE_PHASES.length)}/${PIPELINE_PHASES.length}`
+              : "na fila"}
+        </span>
+      )}
     </div>
   );
 }

--- a/tanstack-migrator/web/tools/widget-active/index.tsx
+++ b/tanstack-migrator/web/tools/widget-active/index.tsx
@@ -48,10 +48,21 @@ export default function WidgetActivePage() {
   const isDone = site.status === "done";
 
   return (
-    <div className="flex h-full flex-col gap-3 p-4">
-      <div className="flex items-center justify-between gap-2">
-        <span className="truncate text-sm font-semibold">{site.name}</span>
-        <StatusBadge status={site.status} />
+    // compact, top-aligned (no h-full/mt-auto) so the card hugs its content
+    <div className="flex flex-col gap-2.5 p-3">
+      {/* name on its own line, badge below — avoids the truncate+badge clash */}
+      <div className="flex flex-col gap-1">
+        <span className="truncate text-sm font-semibold" title={site.name}>
+          {site.name}
+        </span>
+        <div className="flex items-center gap-2">
+          <StatusBadge status={site.status} />
+          {site.parityScore !== null && (
+            <span className="text-[11px] text-muted-foreground tabular-nums">
+              {Math.round(site.parityScore)}%
+            </span>
+          )}
+        </div>
       </div>
 
       <PipelineStepper
@@ -61,15 +72,15 @@ export default function WidgetActivePage() {
         compact
       />
 
-      <ParityBar score={site.parityScore} target={site.parityTarget} />
+      <ParityBar score={site.parityScore} target={site.parityTarget} compact />
 
       {site.phaseDetail && !isDone && (
-        <p className="line-clamp-2 text-xs text-muted-foreground">
+        <p className="line-clamp-1 text-[11px] text-muted-foreground">
           {site.phaseDetail}
         </p>
       )}
 
-      <div className="mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground tabular-nums">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground tabular-nums">
         {site.issuesTotal > 0 && (
           <span>
             issues {site.issuesClosed}/{site.issuesTotal}

--- a/tanstack-migrator/web/tools/widget-queue/index.tsx
+++ b/tanstack-migrator/web/tools/widget-queue/index.tsx
@@ -27,7 +27,8 @@ export default function WidgetQueuePage() {
   const q = data?.queue;
 
   return (
-    <div className="flex h-full flex-col gap-2 p-4">
+    // top-aligned + compact; scroll only if the list gets long
+    <div className="flex flex-col gap-2 p-3">
       <div className="flex items-center justify-between">
         <span className="text-sm font-semibold">Fila de migração</span>
         {q && (
@@ -38,15 +39,18 @@ export default function WidgetQueuePage() {
         )}
       </div>
 
-      <div className="flex flex-col divide-y divide-border">
+      <div className="flex max-h-48 flex-col divide-y divide-border overflow-y-auto">
         {sites.length === 0 && (
-          <p className="py-3 text-xs text-muted-foreground">
+          <p className="py-2 text-xs text-muted-foreground">
             Nenhum site em migração.
           </p>
         )}
         {sites.map((s) => (
           <div key={s.id} className="flex items-center gap-2 py-1.5">
-            <span className="flex-1 truncate text-xs font-medium">
+            <span
+              className="flex-1 truncate text-xs font-medium"
+              title={s.name}
+            >
               {s.name}
             </span>
             <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
@@ -58,7 +62,7 @@ export default function WidgetQueuePage() {
       </div>
 
       {q && (
-        <div className="mt-auto flex flex-wrap gap-x-3 gap-y-1 pt-1 text-[11px] text-muted-foreground tabular-nums">
+        <div className="flex flex-wrap gap-x-3 gap-y-0.5 border-t border-border pt-1.5 text-[11px] text-muted-foreground tabular-nums">
           <span>{q.active} migrando</span>
           <span>{q.queued} na fila</span>
           <span className="text-emerald-600 dark:text-emerald-400">


### PR DESCRIPTION
Ajuste de densidade nos widgets de home pra funcionarem bem em slots pequenos (feedback do print).

- **Pipeline stepper compacto**: no modo widget mostra só as bolinhas + **uma legenda da fase atual** (`Fixes · 6/9`) em vez dos 9 labels que se sobrepunham (`RepoSandboxScript` grudados)
- **Removido `h-full`/`mt-auto`** dos dois widgets — era o que criava o **espaço morto no meio** do card; agora o conteúdo é top-aligned e denso
- **widget-active**: nome e badge em linhas separadas (evita o clash truncate+badge), parity bar compacta, phaseDetail 1 linha
- **widget-queue**: lista com `max-h` + scroll, rodapé com borda

Build gera os 3 htmls single-file; 76 testes verdes; tsc limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make home widgets denser and top-aligned so they fit small dashboard slots without overflow or dead space. Ships a compact dots-only pipeline stepper and UI tweaks in `widget-active` and `widget-queue` (v0.6.1).

- **Bug Fixes**
  - Pipeline stepper (compact): dots-only row with a single caption for the current phase (e.g., "Fixes · 6/9"); removed per-phase labels and reduced dot/icon sizes.
  - `widget-active`: removed full-height spacing; name and status badge on separate lines; compact parity bar; phase detail clamped to 1 line; tighter footer stats.
  - `widget-queue`: top-aligned content; list with max-height and scroll; added item titles for long names; footer gets a border and tighter spacing.
  - Bump `tanstack-migrator` to v0.6.1.

<sup>Written for commit 5b414ffcd84c36610312840ef159959696e2beb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

