### PR TITLE
feat(tanstack-migrator): preview hardening + org-fs framework memory + live agent terminal (v0.7.0)

### DIFF
--- a/tanstack-migrator/package.json
+++ b/tanstack-migrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tanstack-migrator",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Orchestrates Fresh/Deno → TanStack Start storefront migrations: issue-driven pipeline, mesh sandboxes running Claude, branch+PR flow, parity via Playwright, visual dashboard + home widgets",
   "private": true,
   "type": "module",

--- a/tanstack-migrator/package.json
+++ b/tanstack-migrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tanstack-migrator",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Orchestrates Fresh/Deno → TanStack Start storefront migrations: issue-driven pipeline, mesh sandboxes running Claude, branch+PR flow, parity via Playwright, visual dashboard + home widgets",
   "private": true,
   "type": "module",

--- a/tanstack-migrator/server/engine/worker.ts
+++ b/tanstack-migrator/server/engine/worker.ts
@@ -231,7 +231,10 @@ export function looksLikeRealSite(html: string): boolean {
   const content = body
     .replace(/<script[\s\S]*?<\/script>/gi, "")
     .replace(/<style[\s\S]*?<\/style>/gi, "")
-    .replace(/<template[\s\S]*?<\/template>/gi, "");
+    .replace(/<template[\s\S]*?<\/template>/gi, "")
+    // <noscript> is a static fallback ("enable JavaScript"), not rendered SSR —
+    // its text would otherwise pass the visible-text signal on a broken shell
+    .replace(/<noscript[\s\S]*?<\/noscript>/gi, "");
   // visible rendered text is the strongest signal — a storefront always has it
   const text = content
     .replace(/<[^>]+>/g, " ")

--- a/tanstack-migrator/server/engine/worker.ts
+++ b/tanstack-migrator/server/engine/worker.ts
@@ -218,20 +218,30 @@ async function probeSessionLiveness(
 
 /**
  * Preview only counts as ready when the site RENDERS real HTML — not when the
- * sandbox proxy answers with its "No web page at this URL" placeholder. That
- * placeholder is served with HTTP 200 + text/html when the dev server is up
- * but responds to `/` with non-HTML (e.g. a broken SSR render), so a plain
- * status check gives a false positive. We fetch the body and reject the
- * placeholder / near-empty shells.
+ * sandbox proxy answers with its "No web page at this URL" placeholder, and not
+ * when the dev server returns an empty SSR shell (`<div id="root"></div>` with
+ * no content). Both are served with HTTP 200 + text/html, so a status check
+ * gives a false positive. We judge the BODY's rendered content, ignoring size:
+ * visible text, or a real element tree (an empty shell has neither).
  */
-function looksLikeRealSite(html: string): boolean {
+export function looksLikeRealSite(html: string): boolean {
   if (/No web page/i.test(html)) return false; // sandbox proxy placeholder
-  if (html.length < 800) return false; // placeholder is ~662 bytes; real SSR is larger
-  // needs an actual body with content, not just an empty root shell
-  const body = html.match(/<body[^>]*>([\s\S]*)<\/body>/i)?.[1] ?? "";
-  return (
-    body.replace(/<[^>]+>/g, "").trim().length > 40 || /<[a-z]/i.test(body)
-  );
+  const body = html.match(/<body[^>]*>([\s\S]*)<\/body>/i)?.[1] ?? html;
+  // strip non-content nodes so head/scripts/styles don't inflate the signal
+  const content = body
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    .replace(/<template[\s\S]*?<\/template>/gi, "");
+  // visible rendered text is the strongest signal — a storefront always has it
+  const text = content
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (text.length > 40) return true;
+  // no visible text: accept only a real element tree, not an empty root shell.
+  // `<div id="root"></div>` is 1 element; a rendered page has many.
+  const elements = content.match(/<[a-z][a-z0-9]*[\s/>]/gi)?.length ?? 0;
+  return elements >= 8;
 }
 
 async function probePreviewIfNeeded(site: SiteRow): Promise<void> {
@@ -244,7 +254,7 @@ async function probePreviewIfNeeded(site: SiteRow): Promise<void> {
       signal: AbortSignal.timeout(4_000),
     });
     if (response.status >= 500) return;
-    const ct = response.headers.get("content-type") ?? "";
+    const ct = (response.headers.get("content-type") ?? "").toLowerCase();
     if (!ct.includes("text/html")) return;
     const html = await response.text();
     if (!looksLikeRealSite(html)) return; // proxy placeholder / empty shell

--- a/tanstack-migrator/server/engine/worker.ts
+++ b/tanstack-migrator/server/engine/worker.ts
@@ -216,7 +216,24 @@ async function probeSessionLiveness(
   }
 }
 
-/** Preview link only counts when the dev server actually answers. */
+/**
+ * Preview only counts as ready when the site RENDERS real HTML — not when the
+ * sandbox proxy answers with its "No web page at this URL" placeholder. That
+ * placeholder is served with HTTP 200 + text/html when the dev server is up
+ * but responds to `/` with non-HTML (e.g. a broken SSR render), so a plain
+ * status check gives a false positive. We fetch the body and reject the
+ * placeholder / near-empty shells.
+ */
+function looksLikeRealSite(html: string): boolean {
+  if (/No web page/i.test(html)) return false; // sandbox proxy placeholder
+  if (html.length < 800) return false; // placeholder is ~662 bytes; real SSR is larger
+  // needs an actual body with content, not just an empty root shell
+  const body = html.match(/<body[^>]*>([\s\S]*)<\/body>/i)?.[1] ?? "";
+  return (
+    body.replace(/<[^>]+>/g, "").trim().length > 40 || /<[a-z]/i.test(body)
+  );
+}
+
 async function probePreviewIfNeeded(site: SiteRow): Promise<void> {
   if (!site.sandbox_preview_url || site.preview_ready) return;
   if (!isActiveStatus(site.status)) return;
@@ -224,16 +241,18 @@ async function probePreviewIfNeeded(site: SiteRow): Promise<void> {
     const response = await fetch(site.sandbox_preview_url, {
       method: "GET",
       redirect: "manual",
-      signal: AbortSignal.timeout(3_000),
+      signal: AbortSignal.timeout(4_000),
     });
-    // anything the dev server answers (2xx-4xx) counts as "up"
-    if (response.status < 500) {
-      await updateSite(site.id, { preview_ready: true });
-      await addEvent(
-        site.id,
-        `Dev server respondendo — preview liberado: ${site.sandbox_preview_url}`,
-      );
-    }
+    if (response.status >= 500) return;
+    const ct = response.headers.get("content-type") ?? "";
+    if (!ct.includes("text/html")) return;
+    const html = await response.text();
+    if (!looksLikeRealSite(html)) return; // proxy placeholder / empty shell
+    await updateSite(site.id, { preview_ready: true });
+    await addEvent(
+      site.id,
+      `Site renderizando HTML — preview liberado: ${site.sandbox_preview_url}`,
+    );
   } catch {
     // still down — keep hidden
   }

--- a/tanstack-migrator/server/migrator.test.ts
+++ b/tanstack-migrator/server/migrator.test.ts
@@ -22,6 +22,7 @@ import {
   syncPackageScriptCommand,
   syncWorkflowYaml,
 } from "./sandbox/templates/sync-files.ts";
+import { looksLikeRealSite } from "./engine/worker.ts";
 import type { SiteRow } from "./db/types.ts";
 
 const site = {
@@ -337,6 +338,29 @@ describe("simulation", () => {
     expect(simulatedParityScore(1)).toBe(73);
     expect(simulatedParityScore(3)).toBe(95);
     expect(simulatedParityScore(10)).toBe(100);
+  });
+});
+
+describe("looksLikeRealSite (preview readiness)", () => {
+  test("rejects the sandbox proxy placeholder", () => {
+    const placeholder = `<!DOCTYPE html><html><head><title>Preview</title></head><body><div style="padding:2rem"><h1>No web page at this URL</h1><p>The dev server is running but doesn't serve HTML at /.</p></div></body></html>`;
+    expect(looksLikeRealSite(placeholder)).toBe(false);
+  });
+
+  test("rejects an empty SSR shell even when scripts inflate the size", () => {
+    const shell = `<!DOCTYPE html><html><head>${"<script src='/x.js'></script>".repeat(30)}</head><body><div id="root"></div><script type="module" src="/entry.js"></script></body></html>`;
+    expect(shell.length).toBeGreaterThan(800); // would pass a naive size gate
+    expect(looksLikeRealSite(shell)).toBe(false);
+  });
+
+  test("accepts a rendered page with visible text", () => {
+    const rendered = `<!DOCTYPE html><html><head><title>Granado</title></head><body><div id="root"><header><nav>Início Produtos Contato</nav></header><main><h1>Bem-vindo à Granado</h1><p>Perfumaria e cosméticos desde 1870.</p></main></div></body></html>`;
+    expect(looksLikeRealSite(rendered)).toBe(true);
+  });
+
+  test("accepts a text-light page that has a real element tree", () => {
+    const gallery = `<html><body><div id="root"><section><img/><img/><img/></section><section><img/><img/></section><footer><ul><li></li><li></li></ul></footer></div></body></html>`;
+    expect(looksLikeRealSite(gallery)).toBe(true);
   });
 });
 

--- a/tanstack-migrator/server/migrator.test.ts
+++ b/tanstack-migrator/server/migrator.test.ts
@@ -12,8 +12,12 @@ import {
 } from "./lib/issues.ts";
 import { simulatedParityScore } from "./sandbox/drivers/manual.ts";
 import {
+  CONVENTIONS_PATH,
+  FIXES_PATH,
+  FRAMEWORK_NOTES_PATH,
   fixIssuesPrompt,
   migrateScriptPrompt,
+  PARITY_GOTCHAS_PATH,
   parityOnlyPrompt,
   parseResultJson,
   triagePrompt,
@@ -156,6 +160,35 @@ describe("prompts", () => {
     expect(prompt).toContain("fix(#<número>)");
     expect(prompt).toContain("SOMENTE as issues listadas");
     expect(prompt).toContain('"resolved": [12]');
+  });
+
+  test("cross-migration memory: fix reads+writes all files, triage reads them", () => {
+    const fix = fixIssuesPrompt({
+      site,
+      issues: [{ number: 12, title: "rota / 500" }],
+    });
+    // all four org-fs memory files are wired into the fix phase...
+    for (const path of [
+      FRAMEWORK_NOTES_PATH,
+      FIXES_PATH,
+      CONVENTIONS_PATH,
+      PARITY_GOTCHAS_PATH,
+    ]) {
+      expect(fix).toContain(path);
+    }
+    // ...with append instructions (fix is where solutions get recorded)
+    expect(fix).toContain(`>> ${FIXES_PATH}`);
+    expect(fix).toContain(`>> ${PARITY_GOTCHAS_PATH}`);
+    expect(fix).toContain("org-fs do Studio");
+
+    // triage reads the playbook (but doesn't write fixes — analysis only)
+    const triage = triagePrompt({ site, maxIssues: 15 });
+    expect(triage).toContain(FIXES_PATH);
+    expect(triage).not.toContain(`>> ${FIXES_PATH}`);
+
+    // migrate-script records new setup gotchas in conventions
+    const migrate = migrateScriptPrompt({ site });
+    expect(migrate).toContain(`>> ${CONVENTIONS_PATH}`);
   });
 
   test("parityOnlyPrompt: measure-only with uploads", () => {

--- a/tanstack-migrator/server/migrator.test.ts
+++ b/tanstack-migrator/server/migrator.test.ts
@@ -11,6 +11,7 @@ import {
   titleHash,
 } from "./lib/issues.ts";
 import { simulatedParityScore } from "./sandbox/drivers/manual.ts";
+import { redactSecrets } from "./sandbox/drivers/decopilot.ts";
 import {
   CONVENTIONS_PATH,
   FIXES_PATH,
@@ -374,6 +375,39 @@ describe("simulation", () => {
   });
 });
 
+describe("redactSecrets (terminal/command output)", () => {
+  test("masks token prefixes, bearer, and git x-access-token", () => {
+    expect(
+      redactSecrets("clone https://x-access-token:ghs_abc123def@github.com"),
+    ).toContain("x-access-token:***@");
+    expect(redactSecrets("export FOO=sk-ant-abc123def456")).toContain(
+      "sk-ant-***",
+    );
+    expect(redactSecrets("Authorization: Bearer eyJhbGciOiJI")).toContain(
+      "Bearer ***",
+    );
+  });
+
+  test("masks query-string and JSON key/value secrets in output", () => {
+    const qs = redactSecrets("GET /api?access_token=supersecretvalue&x=1");
+    expect(qs).not.toContain("supersecretvalue");
+    expect(qs).toContain("access_token=***");
+
+    const json = redactSecrets('{"api_key": "supersecretvalue", "ok": true}');
+    expect(json).not.toContain("supersecretvalue");
+    expect(json).toContain("***");
+
+    const env = redactSecrets("ANTHROPIC_API_KEY=sk-ant-longtokenvalue");
+    expect(env).not.toContain("longtokenvalue");
+  });
+
+  test("leaves non-secret text untouched", () => {
+    expect(redactSecrets("npm run build && vite dev")).toBe(
+      "npm run build && vite dev",
+    );
+  });
+});
+
 describe("looksLikeRealSite (preview readiness)", () => {
   test("rejects the sandbox proxy placeholder", () => {
     const placeholder = `<!DOCTYPE html><html><head><title>Preview</title></head><body><div style="padding:2rem"><h1>No web page at this URL</h1><p>The dev server is running but doesn't serve HTML at /.</p></div></body></html>`;
@@ -383,6 +417,11 @@ describe("looksLikeRealSite (preview readiness)", () => {
   test("rejects an empty SSR shell even when scripts inflate the size", () => {
     const shell = `<!DOCTYPE html><html><head>${"<script src='/x.js'></script>".repeat(30)}</head><body><div id="root"></div><script type="module" src="/entry.js"></script></body></html>`;
     expect(shell.length).toBeGreaterThan(800); // would pass a naive size gate
+    expect(looksLikeRealSite(shell)).toBe(false);
+  });
+
+  test("rejects an empty shell whose only text is a <noscript> fallback", () => {
+    const shell = `<html><head><title>App</title></head><body><noscript>You need to enable JavaScript to run this app. Please turn it on and reload the page.</noscript><div id="root"></div></body></html>`;
     expect(looksLikeRealSite(shell)).toBe(false);
   });
 

--- a/tanstack-migrator/server/migrator.test.ts
+++ b/tanstack-migrator/server/migrator.test.ts
@@ -406,6 +406,18 @@ describe("redactSecrets (terminal/command output)", () => {
       "npm run build && vite dev",
     );
   });
+
+  test("does not mask identifiers that merely contain a secret substring", () => {
+    // 'monkey' contains 'key', 'tokenizer' starts with 'token', 'keyboard' too —
+    // none are delimited secret keys, so they must stay readable in the terminal
+    expect(redactSecrets("monkey=5 tokenizer=fast keyboard: qwerty12")).toBe(
+      "monkey=5 tokenizer=fast keyboard: qwerty12",
+    );
+    // but a prefixed real key IS masked
+    const masked = redactSecrets("github_token=ghlongsecretvalue");
+    expect(masked).not.toContain("ghlongsecretvalue");
+    expect(masked).toContain("github_token=***");
+  });
 });
 
 describe("looksLikeRealSite (preview readiness)", () => {

--- a/tanstack-migrator/server/sandbox/drivers/decopilot.ts
+++ b/tanstack-migrator/server/sandbox/drivers/decopilot.ts
@@ -439,19 +439,35 @@ async function rescueFinalText(
 const num = (v: unknown): number | undefined =>
   typeof v === "number" && Number.isFinite(v) ? v : undefined;
 
-/** Command text goes to sitemig_runs.meta and the dashboard — mask secrets. */
-function redactSecrets(cmd: string): string {
-  return cmd
-    .replace(/x-access-token:[^@\s]+@/g, "x-access-token:***@")
-    .replace(
-      /\b(gh[pousr]_|github_pat_|sk-ant-|sk-|aik_|or-)[A-Za-z0-9_-]{8,}/g,
-      "$1***",
-    )
-    .replace(/(Bearer\s+)[A-Za-z0-9._~+/-]{8,}/gi, "$1***")
-    .replace(
-      /\b([A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD)[A-Z0-9_]*)=\S+/g,
-      "$1=***",
-    );
+/**
+ * Mask secrets before they reach sitemig_runs.meta, the dashboard, and the live
+ * terminal. Covers known token prefixes, auth headers, env-style assignments,
+ * and — since the terminal now surfaces command OUTPUT too — secrets embedded in
+ * URLs (query strings) and JSON key/value pairs (lowercase keys included).
+ */
+export function redactSecrets(text: string): string {
+  return (
+    text
+      .replace(/x-access-token:[^@\s]+@/g, "x-access-token:***@")
+      .replace(
+        /\b(gh[pousr]_|github_pat_|sk-ant-|sk-|aik_|or-)[A-Za-z0-9_-]{8,}/g,
+        "$1***",
+      )
+      .replace(/(Bearer\s+)[A-Za-z0-9._~+/-]{8,}/gi, "$1***")
+      // env-style KEY=value / TOKEN=value (uppercase names)
+      .replace(
+        /\b([A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD)[A-Z0-9_]*)=\S+/g,
+        "$1=***",
+      )
+      // query-string or JSON key/value: token=..., "api_key": "...", auth:'...'
+      // (case-insensitive key, = or : separator, optional quotes). The `(?!\*)`
+      // skips values already masked by an earlier rule so we don't clobber the
+      // surrounding text (e.g. the host after x-access-token:***@).
+      .replace(
+        /\b([a-z0-9_-]*(?:key|token|secret|password|passwd)[a-z0-9_-]*)(["']?\s*[:=]\s*["']?)(?!\*)[^\s"'&]{6,}/gi,
+        "$1$2***",
+      )
+  );
 }
 
 /** Session cost/tokens — MONITORING_THREAD_USAGE arg/result shapes vary. */

--- a/tanstack-migrator/server/sandbox/drivers/decopilot.ts
+++ b/tanstack-migrator/server/sandbox/drivers/decopilot.ts
@@ -543,6 +543,134 @@ async function fetchThreadCommands(
   }
 }
 
+/** Best-effort extraction of a tool part's output as displayable text. */
+function partOutputText(output: unknown): string {
+  if (output == null) return "";
+  if (typeof output === "string") return output;
+  if (Array.isArray(output)) {
+    return output
+      .map((c) =>
+        typeof c === "string"
+          ? c
+          : c &&
+              typeof c === "object" &&
+              typeof (c as { text?: unknown }).text === "string"
+            ? (c as { text: string }).text
+            : "",
+      )
+      .filter(Boolean)
+      .join("\n");
+  }
+  if (typeof output === "object") {
+    const o = output as Record<string, unknown>;
+    const parts = [o.stdout, o.stderr, o.output, o.result, o.text]
+      .map((v) => (typeof v === "string" ? v : ""))
+      .filter(Boolean);
+    if (parts.length > 0) return parts.join("\n");
+  }
+  return "";
+}
+
+/** One line in the drawer's live terminal — the agent's narration or a command. */
+export interface TerminalEntry {
+  seq: number;
+  role: string;
+  kind: "text" | "command" | "tool" | "reasoning";
+  text?: string;
+  command?: string;
+  exitCode?: number;
+  output?: string;
+  tool?: string;
+}
+
+/**
+ * Ordered transcript of a decopilot thread for the live terminal in the drawer:
+ * the agent's narration + every bash command (with exit code and an output
+ * snippet) + other tool calls, oldest→newest. Best-effort (part shapes vary by
+ * harness); secrets are redacted and output truncated. Returns the last `limit`
+ * entries so a long session stays cheap to poll.
+ */
+export async function fetchThreadTranscript(
+  ctx: WorkerCtx,
+  threadId: string,
+  limit = 150,
+): Promise<TerminalEntry[]> {
+  const messages = await listThreadMessages(ctx, threadId);
+  const entries: TerminalEntry[] = [];
+  let seq = 0;
+  for (const message of messages) {
+    const role = typeof message.role === "string" ? message.role : "assistant";
+    if (role === "user" || role === "system") continue; // prompts, not activity
+    for (const part of message.parts ?? []) {
+      const p = part as Record<string, unknown>;
+      const type = typeof p.type === "string" ? p.type : "";
+      if (type === "text" && typeof p.text === "string" && p.text.trim()) {
+        entries.push({
+          seq: seq++,
+          role,
+          kind: "text",
+          text: p.text.trim().slice(0, 2000),
+        });
+        continue;
+      }
+      if (type === "reasoning" && typeof p.text === "string" && p.text.trim()) {
+        entries.push({
+          seq: seq++,
+          role,
+          kind: "reasoning",
+          text: p.text.trim().slice(0, 1000),
+        });
+        continue;
+      }
+      const toolName =
+        typeof p.toolName === "string"
+          ? p.toolName
+          : type.startsWith("tool-")
+            ? type.slice(5)
+            : "";
+      if (!toolName) continue;
+      const input = (p.input ?? p.args ?? {}) as Record<string, unknown>;
+      const output = (p.output ?? {}) as Record<string, unknown>;
+      if (/bash|shell|terminal|exec|command/i.test(toolName)) {
+        const cmd =
+          typeof input.command === "string"
+            ? input.command
+            : typeof input.cmd === "string"
+              ? input.cmd
+              : "";
+        if (!cmd) continue;
+        const rawOut = partOutputText(p.output);
+        entries.push({
+          seq: seq++,
+          role,
+          kind: "command",
+          command: redactSecrets(cmd).slice(0, 400),
+          exitCode: num(output.exitCode ?? output.exit_code ?? output.exit),
+          output: rawOut ? redactSecrets(rawOut).slice(0, 800) : undefined,
+        });
+      } else {
+        // non-bash tool call — surface the tool name + a compact arg hint
+        const hint =
+          typeof input.path === "string"
+            ? input.path
+            : typeof input.file === "string"
+              ? input.file
+              : typeof input.url === "string"
+                ? input.url
+                : "";
+        entries.push({
+          seq: seq++,
+          role,
+          kind: "tool",
+          tool: toolName,
+          text: hint ? redactSecrets(hint).slice(0, 200) : undefined,
+        });
+      }
+    }
+  }
+  return entries.length > limit ? entries.slice(-limit) : entries;
+}
+
 export const decopilotDriver: SandboxDriver = {
   name: "decopilot",
 

--- a/tanstack-migrator/server/sandbox/drivers/decopilot.ts
+++ b/tanstack-migrator/server/sandbox/drivers/decopilot.ts
@@ -459,12 +459,13 @@ export function redactSecrets(text: string): string {
         /\b([A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD)[A-Z0-9_]*)=\S+/g,
         "$1=***",
       )
-      // query-string or JSON key/value: token=..., "api_key": "...", auth:'...'
-      // (case-insensitive key, = or : separator, optional quotes). The `(?!\*)`
-      // skips values already masked by an earlier rule so we don't clobber the
-      // surrounding text (e.g. the host after x-access-token:***@).
+      // query-string or JSON key/value: token=..., "api_key": "...", secret:'...'
+      // The secret word must be a DELIMITED key segment (start/`_`/`-` before it,
+      // separator right after) so we don't mask normal identifiers that merely
+      // contain the substring — `monkey=`, `keyboard:`, `tokenizer=` stay
+      // readable. `(?!\*)` skips values an earlier rule already masked.
       .replace(
-        /\b([a-z0-9_-]*(?:key|token|secret|password|passwd)[a-z0-9_-]*)(["']?\s*[:=]\s*["']?)(?!\*)[^\s"'&]{6,}/gi,
+        /(?<![a-z0-9_-])((?:[a-z0-9]+[_-])*(?:key|token|secret|password|passwd|apikey))(["']?\s*[:=]\s*["']?)(?!\*)[^\s"'&]{6,}/gi,
         "$1$2***",
       )
   );

--- a/tanstack-migrator/server/sandbox/templates/prompts.ts
+++ b/tanstack-migrator/server/sandbox/templates/prompts.ts
@@ -17,16 +17,86 @@ import type { SiteRow } from "../../db/types.ts";
 export const RESULT_MARKER = "RESULT_JSON:";
 
 /**
- * Cross-migration memory file, lives in the Studio org-fs mounted into every
- * sandbox (`/app/org` — the same mount the repo's `org` symlink points at), so
- * it persists across sandboxes and sites. Triage/fix sessions read it at start
- * (to recognize framework-suspected errors already seen elsewhere) and append
- * to it when they hit a new one — turning "seen once" into "seen in N sites =
- * likely a framework bug" over time. This is NOT a Supabase table on purpose:
- * the knowledge belongs to the org's filesystem, reachable by the agent itself.
+ * Cross-migration memory lives in the Studio org-fs (`/app/org` — the same mount
+ * the repo's `org` symlink points at) mounted into every sandbox, so these files
+ * persist across sandboxes and sites. The agent reads them at session start and
+ * appends one-liners when it learns something reusable — turning per-site
+ * discovery into shared knowledge. NOT Supabase on purpose: the knowledge
+ * belongs to the org's filesystem, reachable by the agent itself.
+ *
+ *  - framework-notes: SUSPICIONS  ("this looks like a framework bug")
+ *  - fixes:           SOLUTIONS   ("this error → this fix worked")
+ *  - conventions:     SETUP GOTCHAS of the migration itself
+ *  - parity-gotchas:  recurring VISUAL mismatches and how they were resolved
  */
-export const FRAMEWORK_NOTES_PATH =
-  "/app/org/home/.tanstack-migrator/framework-notes.md";
+export const MEMORY_DIR = "/app/org/home/.tanstack-migrator";
+export const FRAMEWORK_NOTES_PATH = `${MEMORY_DIR}/framework-notes.md`;
+export const FIXES_PATH = `${MEMORY_DIR}/fixes.md`;
+export const CONVENTIONS_PATH = `${MEMORY_DIR}/conventions.md`;
+export const PARITY_GOTCHAS_PATH = `${MEMORY_DIR}/parity-gotchas.md`;
+
+interface MemorySpec {
+  path: string;
+  /** one-line description of what the file holds */
+  holds: string;
+  /** how to use what it says (read guidance) */
+  read: string;
+  /** condition to append a line (omit = read-only for this phase) */
+  writeWhen?: string;
+  /** the payload after the `timestamp | site` columns */
+  entry?: string;
+}
+
+/**
+ * Render the shared "# Memória entre migrações" section for a phase prompt from
+ * a list of file specs. Keeps every phase's memory instructions consistent
+ * (same dir, same one-line-append discipline, same dedupe rule).
+ */
+function memorySection(site: SiteRow, specs: MemorySpec[]): string {
+  const blocks = specs.map((s) => {
+    const lines = [
+      `- **${s.path}** — ${s.holds}`,
+      `  LEIA no início (\`cat ${s.path} 2>/dev/null\`): ${s.read}`,
+    ];
+    if (s.writeWhen) {
+      lines.push(
+        `  APENDE quando ${s.writeWhen}: \`mkdir -p ${MEMORY_DIR} && echo "$(date -u +%FT%TZ) | ${site.name} | ${s.entry}" >> ${s.path}\``,
+      );
+    }
+    return lines.join("\n");
+  });
+  return `# Memória entre migrações (org-fs do Studio — persiste entre sandboxes)
+Arquivos compartilhados da org já montados no sandbox. Regra: entradas de UMA linha; NÃO duplique uma linha que já exista equivalente.
+${blocks.join("\n")}`;
+}
+
+// Reusable specs (read guidance/write conditions are phase-agnostic).
+const FRAMEWORK_NOTES_SPEC: MemorySpec = {
+  path: FRAMEWORK_NOTES_PATH,
+  holds:
+    "erros SUSPEITOS de bug do framework (@decocms/start / @decocms/apps) vistos em migrações anteriores",
+  read: 'se algum bater com o que você achou, cite no corpo da issue ("já visto em N sites — provável bug de framework")',
+  writeWhen:
+    "achar um erro NOVO com cara de framework (stack dentro de node_modules de @decocms/*, ou padrão não-corrigível no código do site)",
+  entry: "<assinatura curta do erro> | <arquivo:linha ou pacote>",
+};
+const FIXES_SPEC: MemorySpec = {
+  path: FIXES_PATH,
+  holds:
+    "receitas de correção que JÁ FUNCIONARAM em outros sites (erro → solução)",
+  read: "se um erro seu casa com uma receita, APLIQUE-A antes de investigar do zero",
+};
+const CONVENTIONS_SPEC: MemorySpec = {
+  path: CONVENTIONS_PATH,
+  holds:
+    "convenções/gotchas de setup da migração (predev, symlink `org`, porta do dev, não tem rsync, etc.)",
+  read: "confira se alguma se aplica a este repo antes de começar",
+};
+const PARITY_GOTCHAS_SPEC: MemorySpec = {
+  path: PARITY_GOTCHAS_PATH,
+  holds: "mismatches VISUAIS recorrentes e como foram resolvidos",
+  read: "útil pras issues de visual/content e pra chegar em paridade mais rápido",
+};
 
 export interface ParityArtifactUrls {
   reportHtmlPut?: string;
@@ -194,6 +264,15 @@ Nunca fique mais de 10 minutos sem \`git commit\` + \`git push\` — todo progre
 ${gitAuthNote(ghToken)}
 ${progressInstruction(site)}
 
+${memorySection(site, [
+  {
+    ...CONVENTIONS_SPEC,
+    writeWhen:
+      "descobrir um passo de setup NOVO que não está nos Passos acima (ex: script extra necessário pro dev subir, dependência faltando)",
+    entry: "<convenção/gotcha de setup em uma linha>",
+  },
+])}
+
 # Resultado
 Termine sua ÚLTIMA mensagem com uma linha exatamente neste formato:
 RESULT_JSON: {"ok": true, "detail": "script rodou, checkpoint pushado na branch ${branch}"}
@@ -243,10 +322,12 @@ O critério de sucesso desta migração é: **\`npm run build\` passa** (exit 0)
 - **Suspeita de bug do framework**: se um erro parece vir de \`@decocms/start\` ou \`@decocms/apps\` (stack aponta pra dentro de node_modules desses pacotes, ou é um padrão que não dá pra corrigir no código do site), prefixe o título com \`[framework?]\` e use category **infra** — o MCP cataloga esses para detectar bugs recorrentes do framework entre sites.
 - Se o \`npm run build\` já passa E o site renderiza HTML real em \`/\`, a maior parte do trabalho está feita — reporte poucas issues (só o que afeta paridade/visual).
 
-# Memória entre migrações (org-fs do Studio — persiste entre sandboxes)
-Há um arquivo compartilhado da org montado no sandbox: \`${FRAMEWORK_NOTES_PATH}\`.
-1. LEIA-O primeiro: \`cat ${FRAMEWORK_NOTES_PATH} 2>/dev/null\`. Ele lista erros que migrações ANTERIORES marcaram como suspeitos de bug do framework (\`@decocms/start\`/\`@decocms/apps\`). Se algum bater com o que você achou aqui, mencione no corpo da issue ("já visto em N sites — provável bug de framework").
-2. Quando você achar um erro NOVO com cara de framework (stack dentro de node_modules de @decocms/*, ou padrão não-corrigível no código do site), APENDE uma linha nesse arquivo: \`mkdir -p $(dirname ${FRAMEWORK_NOTES_PATH}) && echo "$(date -u +%FT%TZ) | ${site.name} | <assinatura curta do erro> | <arquivo:linha ou pacote>" >> ${FRAMEWORK_NOTES_PATH}\`. Assim os próximos sites herdam esse conhecimento e, se o mesmo erro reaparecer em vários, fica evidente que é bug do framework.
+${memorySection(site, [
+  FRAMEWORK_NOTES_SPEC,
+  FIXES_SPEC,
+  CONVENTIONS_SPEC,
+  PARITY_GOTCHAS_SPEC,
+])}
 
 # Formato das issues
 - No máximo ${maxIssues} issues, ordenadas da mais grave para a menos grave.
@@ -293,8 +374,29 @@ Resolver SOMENTE as issues listadas abaixo. Não refatore nada fora delas, não 
 - UM commit POR issue resolvida, mensagem \`fix(#<número>): <o que fez>\` e push ao final de cada uma: \`git push origin ${site.work_branch}\`. Nunca fique >10min sem commit+push.
 - **Critério de validação = \`npm run build\` (exit 0)**, não \`tsc --noEmit\`. O build roda o codegen + Vite/esbuild (que não faz type-check estrito). Erros de \`tsc\` que não quebram o build são dívida de tipo aceitável — resolva o que a issue pede sem se prender a zerar o tsc. Para issues de runtime/visual, confirme a rota afetada respondendo. ${devServerNote}
 - **O preview TEM que renderizar (pré-requisito da paridade)**: para issues de runtime/SSR, a correção só está pronta quando \`curl -sL http://localhost:$DEV_PORT/\` devolve HTML renderizado de verdade — NÃO o placeholder "No web page at this URL" nem um shell vazio (\`<div id="root"></div>\` sem conteúdo). Se ainda vier placeholder/shell, o SSR continua quebrado: leia \`tail -80 /tmp/dev.log\`, ache o stack e o arquivo:linha, e corrija de verdade antes de marcar como resolved.
-- **Memória entre migrações (org-fs do Studio)**: leia \`cat ${FRAMEWORK_NOTES_PATH} 2>/dev/null\` — lista erros que outras migrações marcaram como suspeitos de bug do framework (\`@decocms/start\`/\`@decocms/apps\`); pode conter a pista do fix. Se durante o fix você concluir que um erro vem do framework (stack dentro de node_modules de @decocms/*, não corrigível no código do site), APENDE: \`mkdir -p $(dirname ${FRAMEWORK_NOTES_PATH}) && echo "$(date -u +%FT%TZ) | ${site.name} | <assinatura curta> | <arquivo:linha ou pacote>" >> ${FRAMEWORK_NOTES_PATH}\` e marque a issue como blocked com motivo \`[framework?]\`.
+- **Antes de investigar do zero, consulte a "Memória entre migrações" abaixo** — uma receita conhecida pode resolver na hora, e o que você aprender aqui alimenta os próximos sites. Se concluir que um erro vem do framework, marque a issue como blocked com motivo \`[framework?]\` além de registrar na memória.
 - Se uma issue for impossível, já estiver resolvida (ex: o build já passa e o erro sumiu após o codegen), ou depender de outra, marque como blocked/resolved com o motivo e siga.
+
+${memorySection(site, [
+  FRAMEWORK_NOTES_SPEC,
+  {
+    ...FIXES_SPEC,
+    writeWhen:
+      "resolver um erro de runtime/build e CONFIRMAR que sumiu (build passa / rota responde)",
+    entry:
+      "<assinatura do erro> → <o que resolveu: arquivo/import/patch curto>",
+  },
+  {
+    ...CONVENTIONS_SPEC,
+    writeWhen: "descobrir um gotcha de setup novo durante o fix",
+    entry: "<convenção/gotcha em uma linha>",
+  },
+  {
+    ...PARITY_GOTCHAS_SPEC,
+    writeWhen: "resolver um mismatch visual/de conteúdo",
+    entry: "<mismatch visual> → <como resolveu>",
+  },
+])}
 
 # Issues a resolver
 ${list}

--- a/tanstack-migrator/server/sandbox/templates/prompts.ts
+++ b/tanstack-migrator/server/sandbox/templates/prompts.ts
@@ -16,6 +16,18 @@ import type { SiteRow } from "../../db/types.ts";
 
 export const RESULT_MARKER = "RESULT_JSON:";
 
+/**
+ * Cross-migration memory file, lives in the Studio org-fs mounted into every
+ * sandbox (`/app/org` — the same mount the repo's `org` symlink points at), so
+ * it persists across sandboxes and sites. Triage/fix sessions read it at start
+ * (to recognize framework-suspected errors already seen elsewhere) and append
+ * to it when they hit a new one — turning "seen once" into "seen in N sites =
+ * likely a framework bug" over time. This is NOT a Supabase table on purpose:
+ * the knowledge belongs to the org's filesystem, reachable by the agent itself.
+ */
+export const FRAMEWORK_NOTES_PATH =
+  "/app/org/home/.tanstack-migrator/framework-notes.md";
+
 export interface ParityArtifactUrls {
   reportHtmlPut?: string;
   reportJsonPut?: string;
@@ -176,8 +188,9 @@ Nunca fique mais de 10 minutos sem \`git commit\` + \`git push\` — todo progre
 1. Se /app/source ainda não existe: \`git clone --depth 1 -b ${site.source_branch} ${sourceUrl} /app/source\` (cópia pristina do site original — NUNCA modifique nem rode o script de migração nela).
 2. O repo alvo JÁ está clonado pelo sandbox em /app/repo (origin = ${targetUrl}) — trabalhe NELE, na branch de trabalho: \`cd /app/repo && git checkout -B ${branch}\`. ATENÇÃO: existe um symlink \`org -> ../org\` dentro de /app/repo (montagem do sandbox) — remova antes de tudo: \`rm -f org\`. Copie o conteúdo do original pra dentro SEM rsync (não existe na imagem): \`shopt -s dotglob && for f in /app/source/*; do b=$(basename "$f"); [ "$b" = ".git" ] && continue; cp -r "$f" .; done\`.
 3. Em /app/repo: \`npm install @decocms/start tsx\` e rode o script de migração IN PLACE (o script TRANSFORMA o diretório passado em --source): \`npx tsx node_modules/@decocms/start/scripts/migrate.ts --source /app/repo\`. Ele roda 7 fases (analyze, scaffold, transform, cleanup, report, verify, bootstrap). Se /app/repo já tiver MIGRATION_REPORT.md de uma execução anterior, pule esta etapa.
-4. Checkpoint final: \`git add -A && git commit -m "feat: tanstack migration (script output)" && git push -u -f origin ${branch}\` (a branch é gerenciada pela migração — o force é seguro).
-5. PARE AQUI. Não instale dependências extras, não corrija build, não suba dev server.
+4. CRÍTICO p/ o preview funcionar: garanta que o \`package.json\` tenha um script \`"predev"\` que roda TODOS os generates do \`build\` (sem o \`vite build\` final). O \`dev\` é só \`vite dev\` e NÃO gera route tree/manifests/blocks — sem os generates o dev server serve 404. Copie a sequência de generates do script \`build\` para um \`predev\` (ex: \`"predev": "npm run generate:blocks && npm run generate:sections && npm run generate:loaders && npm run generate:schema && npm run generate:invoke && tsr generate"\`). Assim \`bun run dev\` (que o daemon do sandbox roda) dispara o codegen automaticamente antes de servir.
+5. Checkpoint final: \`git add -A && git commit -m "feat: tanstack migration (script output + predev)" && git push -u -f origin ${branch}\` (a branch é gerenciada pela migração — o force é seguro).
+6. PARE AQUI. Não corrija erros de build — isso é das próximas fases.
 ${gitAuthNote(ghToken)}
 ${progressInstruction(site)}
 
@@ -218,16 +231,22 @@ O critério de sucesso desta migração é: **\`npm run build\` passa** (exit 0)
 # Levantamento (nesta ordem de prioridade)
 1. \`cd /app/repo && git checkout ${site.work_branch}\` e \`npm install\`.
 2. **Build (gate crítico)**: \`npm run build 2>&1 | tail -60\`. Se FALHAR (exit≠0), o(s) erro(s) que quebram o build são as issues critical/high — foque nelas.
-3. Runtime: ${devServerNote} Depois:
-   a. \`curl -sL http://localhost:$DEV_PORT/ 2>&1 | head -80\` — HTML vazio/sem \`<body\` = problema de CMS/blocos (não de build).
-   b. Se a home vier vazia: \`tail -60 /tmp/dev.log\` + \`ls .deco/blocks/ 2>/dev/null | head -20\` — confira se os \`__resolveType\` batem com os exports de \`src/sections/\` e \`src/apps/\`.
+3. **Runtime — o site TEM que renderizar HTML (pré-requisito da paridade)**: ${devServerNote} Depois \`curl -sL http://localhost:$DEV_PORT/ 2>&1 | head -120\`:
+   a. Se retornar **"No web page at this URL"** (placeholder do sandbox) OU um shell quase vazio (só \`<div id="root"></div>\` sem conteúdo) → o **SSR está quebrado**: o dev sobe mas \`/\` não devolve HTML renderizado. Essa é a issue MAIS importante (severity **high**, category **runtime**). Investigue a causa REAL: \`tail -80 /tmp/dev.log\` procurando o stack do erro de SSR (ex: \`Cannot read properties of undefined (reading 'href')\`, \`is not a function\`, módulo faltando) e abra o arquivo/linha apontado. Reporte com o stack literal e o arquivo:linha no corpo. NOTA: quase toda migração cai aqui no primeiro preview — é esperado, é o principal a corrigir.
+   b. Se \`/\` renderiza mas os blocos estão vazios: \`ls .deco/blocks/ 2>/dev/null | head -20\` — confira se os \`__resolveType\` batem com os exports de \`src/sections/\` e \`src/apps/\`.
    c. Teste rotas: home, categoria, produto (URLs em /app/source/routes/).
 4. Typecheck SECUNDÁRIO: \`npx tsc --noEmit 2>&1 | head -60\` — SÓ se o build passou. Agrupe por causa raiz; entram como severity "low" (dívida de tipo), pois não bloqueiam deploy nem paridade.
 5. Compare com /app/source: seções/componentes que existem lá e não foram portados (esses SÃO relevantes — visual/content).
 
 # REGRAS IMPORTANTES
 - **NUNCA reporte issue para editar arquivos \`*.gen.ts\`** (manifest.gen, invoke.gen, meta.gen, etc.) — são REGENERADOS pelo \`npm run build\`. Se um import de \`*.gen\` está quebrado, a issue é "rodar npm run build/generate", não "editar o arquivo".
-- Se o \`npm run build\` já passa e a home responde, a maior parte do trabalho está feita — reporte poucas issues (só o que afeta paridade/visual), não uma lista de erros de tsc.
+- **Suspeita de bug do framework**: se um erro parece vir de \`@decocms/start\` ou \`@decocms/apps\` (stack aponta pra dentro de node_modules desses pacotes, ou é um padrão que não dá pra corrigir no código do site), prefixe o título com \`[framework?]\` e use category **infra** — o MCP cataloga esses para detectar bugs recorrentes do framework entre sites.
+- Se o \`npm run build\` já passa E o site renderiza HTML real em \`/\`, a maior parte do trabalho está feita — reporte poucas issues (só o que afeta paridade/visual).
+
+# Memória entre migrações (org-fs do Studio — persiste entre sandboxes)
+Há um arquivo compartilhado da org montado no sandbox: \`${FRAMEWORK_NOTES_PATH}\`.
+1. LEIA-O primeiro: \`cat ${FRAMEWORK_NOTES_PATH} 2>/dev/null\`. Ele lista erros que migrações ANTERIORES marcaram como suspeitos de bug do framework (\`@decocms/start\`/\`@decocms/apps\`). Se algum bater com o que você achou aqui, mencione no corpo da issue ("já visto em N sites — provável bug de framework").
+2. Quando você achar um erro NOVO com cara de framework (stack dentro de node_modules de @decocms/*, ou padrão não-corrigível no código do site), APENDE uma linha nesse arquivo: \`mkdir -p $(dirname ${FRAMEWORK_NOTES_PATH}) && echo "$(date -u +%FT%TZ) | ${site.name} | <assinatura curta do erro> | <arquivo:linha ou pacote>" >> ${FRAMEWORK_NOTES_PATH}\`. Assim os próximos sites herdam esse conhecimento e, se o mesmo erro reaparecer em vários, fica evidente que é bug do framework.
 
 # Formato das issues
 - No máximo ${maxIssues} issues, ordenadas da mais grave para a menos grave.
@@ -273,6 +292,8 @@ Resolver SOMENTE as issues listadas abaixo. Não refatore nada fora delas, não 
 - **NUNCA edite arquivos \`*.gen.ts\`** (manifest.gen, invoke.gen, meta.gen…) — são regenerados pelo \`npm run build\`. Se uma issue aponta erro num \`.gen\`, a correção é rodar \`npm run build\` (que roda o codegen) e verificar se sumiu — NÃO editar o arquivo à mão (seria sobrescrito).
 - UM commit POR issue resolvida, mensagem \`fix(#<número>): <o que fez>\` e push ao final de cada uma: \`git push origin ${site.work_branch}\`. Nunca fique >10min sem commit+push.
 - **Critério de validação = \`npm run build\` (exit 0)**, não \`tsc --noEmit\`. O build roda o codegen + Vite/esbuild (que não faz type-check estrito). Erros de \`tsc\` que não quebram o build são dívida de tipo aceitável — resolva o que a issue pede sem se prender a zerar o tsc. Para issues de runtime/visual, confirme a rota afetada respondendo. ${devServerNote}
+- **O preview TEM que renderizar (pré-requisito da paridade)**: para issues de runtime/SSR, a correção só está pronta quando \`curl -sL http://localhost:$DEV_PORT/\` devolve HTML renderizado de verdade — NÃO o placeholder "No web page at this URL" nem um shell vazio (\`<div id="root"></div>\` sem conteúdo). Se ainda vier placeholder/shell, o SSR continua quebrado: leia \`tail -80 /tmp/dev.log\`, ache o stack e o arquivo:linha, e corrija de verdade antes de marcar como resolved.
+- **Memória entre migrações (org-fs do Studio)**: leia \`cat ${FRAMEWORK_NOTES_PATH} 2>/dev/null\` — lista erros que outras migrações marcaram como suspeitos de bug do framework (\`@decocms/start\`/\`@decocms/apps\`); pode conter a pista do fix. Se durante o fix você concluir que um erro vem do framework (stack dentro de node_modules de @decocms/*, não corrigível no código do site), APENDE: \`mkdir -p $(dirname ${FRAMEWORK_NOTES_PATH}) && echo "$(date -u +%FT%TZ) | ${site.name} | <assinatura curta> | <arquivo:linha ou pacote>" >> ${FRAMEWORK_NOTES_PATH}\` e marque a issue como blocked com motivo \`[framework?]\`.
 - Se uma issue for impossível, já estiver resolvida (ex: o build já passa e o erro sumiu após o codegen), ou depender de outra, marque como blocked/resolved com o motivo e siga.
 
 # Issues a resolver

--- a/tanstack-migrator/server/tools/index.ts
+++ b/tanstack-migrator/server/tools/index.ts
@@ -13,6 +13,7 @@ import {
   createSiteRegisterTool,
   createSiteResumeTool,
   createSiteRetryTool,
+  createSiteTerminalTool,
 } from "./sites.ts";
 
 export const tools = [
@@ -22,6 +23,7 @@ export const tools = [
   createSiteRegisterTool,
   createSiteListTool,
   createSiteGetTool,
+  createSiteTerminalTool,
   createSitePauseTool,
   createSiteResumeTool,
   createSiteRetryTool,

--- a/tanstack-migrator/server/tools/sites.ts
+++ b/tanstack-migrator/server/tools/sites.ts
@@ -20,6 +20,8 @@ import {
   type SiteStatus,
   toCurrentStatus,
 } from "../db/types.ts";
+import { buildWorkerCtx } from "../lib/mesh.ts";
+import { fetchThreadTranscript } from "../sandbox/drivers/decopilot.ts";
 import type { Env } from "../types/env.ts";
 import {
   EventViewSchema,
@@ -185,6 +187,71 @@ export const createSiteGetTool = (env: Env) =>
         runs: runs.map(toRunView),
         events: events.map(toEventView),
       };
+    },
+  });
+
+const TerminalEntrySchema = z.object({
+  seq: z.number(),
+  role: z.string(),
+  kind: z.enum(["text", "command", "tool", "reasoning"]),
+  text: z.string().optional(),
+  command: z.string().optional(),
+  exitCode: z.number().optional(),
+  output: z.string().optional(),
+  tool: z.string().optional(),
+});
+
+/**
+ * Live terminal for the drawer — replays the current migration session's thread
+ * as a command/narration transcript (like the agentic CMS terminal). Prefers
+ * the live phase thread; falls back to the latest run's thread when idle so the
+ * panel shows the last session instead of going blank. Read-only, meant to be
+ * polled every few seconds while a run is active.
+ */
+export const createSiteTerminalTool = (env: Env) =>
+  createTool({
+    id: "SITE_TERMINAL",
+    description:
+      "Live terminal transcript of a site's current migration session: the agent's narration + every bash command it ran (with exit code and output snippet). Powers the drawer's Terminal tab. Read-only — poll it.",
+    inputSchema: z.object({ siteId: z.string() }),
+    outputSchema: z.object({
+      threadId: z.string().nullable(),
+      /** true when this is the still-running phase thread (not a past run). */
+      live: z.boolean(),
+      entries: z.array(TerminalEntrySchema),
+      updatedAt: z.string(),
+    }),
+    annotations: { readOnlyHint: true },
+    execute: async ({ context }) => {
+      requireConnectionId(env);
+      const now = new Date().toISOString();
+      const site = await getSite(context.siteId);
+      if (!site) throw new Error("Site not found");
+
+      // live phase thread first; fall back to the newest run that has a thread
+      let threadId = site.phase_thread_id ?? null;
+      const live = Boolean(site.phase_thread_id);
+      if (!threadId) {
+        const runs = await listRunsForSite(site.id);
+        threadId = runs.find((r) => r.meta?.threadId)?.meta?.threadId ?? null;
+      }
+      if (!threadId) {
+        return { threadId: null, live: false, entries: [], updatedAt: now };
+      }
+
+      const row = await loadConnection(site.connection_id);
+      if (!row) return { threadId, live, entries: [], updatedAt: now };
+      try {
+        const entries = await fetchThreadTranscript(
+          buildWorkerCtx(row),
+          threadId,
+          150,
+        );
+        return { threadId, live, entries, updatedAt: now };
+      } catch {
+        // thread not readable yet (just dispatched) — empty is fine, keep polling
+        return { threadId, live, entries: [], updatedAt: now };
+      }
     },
   });
 

--- a/tanstack-migrator/server/tools/sites.ts
+++ b/tanstack-migrator/server/tools/sites.ts
@@ -223,10 +223,15 @@ export const createSiteTerminalTool = (env: Env) =>
     }),
     annotations: { readOnlyHint: true },
     execute: async ({ context }) => {
-      requireConnectionId(env);
+      const connectionId = requireConnectionId(env);
       const now = new Date().toISOString();
       const site = await getSite(context.siteId);
-      if (!site) throw new Error("Site not found");
+      // tenant isolation: this tool loads the site's worker credentials and
+      // fetches its thread — never let a foreign siteId reach another org's
+      // transcript. "not found" (not "forbidden") avoids leaking existence.
+      if (!site || site.connection_id !== connectionId) {
+        throw new Error("Site not found");
+      }
 
       // live phase thread first; fall back to the newest run that has a thread
       let threadId = site.phase_thread_id ?? null;

--- a/tanstack-migrator/web/components/run-row.tsx
+++ b/tanstack-migrator/web/components/run-row.tsx
@@ -1,7 +1,13 @@
 import { FileText, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { useToolCaller } from "@/hooks/use-tool.ts";
-import { clockTime, cn, duration, timeAgo } from "@/lib/utils.ts";
+import {
+  clockTime,
+  cn,
+  duration,
+  studioThreadUrl,
+  timeAgo,
+} from "@/lib/utils.ts";
 import type { ReportUrls, RunView } from "@/types.ts";
 
 const SEVERITY_COLOR: Record<string, string> = {
@@ -10,11 +16,6 @@ const SEVERITY_COLOR: Record<string, string> = {
   medium: "text-amber-600 dark:text-amber-400",
   low: "text-muted-foreground",
 };
-
-/** Best-effort studio thread URL from a threadId (deep link into the session). */
-function threadUrl(threadId: string): string {
-  return `https://studio.decocms.com/threads/${threadId}`;
-}
 
 export function RunRow({ run }: { run: RunView }) {
   const callTool = useToolCaller();
@@ -102,7 +103,7 @@ export function RunRow({ run }: { run: RunView }) {
           </span>
           {run.threadId && (
             <a
-              href={threadUrl(run.threadId)}
+              href={studioThreadUrl(run.threadId)}
               target="_blank"
               rel="noreferrer"
               onClick={(e) => e.stopPropagation()}

--- a/tanstack-migrator/web/components/site-detail.tsx
+++ b/tanstack-migrator/web/components/site-detail.tsx
@@ -20,6 +20,7 @@ import { PipelineStepper } from "@/components/pipeline-stepper.tsx";
 import { RunRow } from "@/components/run-row.tsx";
 import { issuesFilterUrl } from "@/components/site-card.tsx";
 import { StatusBadge } from "@/components/status-badge.tsx";
+import { TerminalPanel } from "@/components/terminal-panel.tsx";
 import { usePollingTool, useToolCaller } from "@/hooks/use-tool.ts";
 import { clockTime, cn, duration, timeAgo } from "@/lib/utils.ts";
 import type { RunView, SiteDetail, SiteView } from "@/types.ts";
@@ -127,7 +128,7 @@ function PreviewPanel({ site }: { site: SiteView }) {
   );
 }
 
-type Tab = "overview" | "runs" | "activity";
+type Tab = "overview" | "runs" | "terminal" | "activity";
 type RunFilter = "all" | "migrate" | "triage" | "fix" | "parity";
 
 export function SiteDetailPanel({
@@ -275,6 +276,7 @@ export function SiteDetailPanel({
                 [
                   ["overview", "Visão geral"],
                   ["runs", `Runs ${runs.length}`],
+                  ["terminal", "Terminal"],
                   ["activity", `Atividade ${events.length}`],
                 ] as [Tab, string][]
               ).map(([id, label]) => (
@@ -564,6 +566,14 @@ export function SiteDetailPanel({
                   ))}
                 </div>
               </>
+            )}
+
+            {tab === "terminal" && (
+              <TerminalPanel
+                siteId={siteId}
+                active={ACTIVE_STATUSES.has(site.status)}
+                threadUrlBase="https://studio.decocms.com"
+              />
             )}
 
             {tab === "activity" && (

--- a/tanstack-migrator/web/components/site-detail.tsx
+++ b/tanstack-migrator/web/components/site-detail.tsx
@@ -572,7 +572,6 @@ export function SiteDetailPanel({
               <TerminalPanel
                 siteId={siteId}
                 active={ACTIVE_STATUSES.has(site.status)}
-                threadUrlBase="https://studio.decocms.com"
               />
             )}
 

--- a/tanstack-migrator/web/components/site-detail.tsx
+++ b/tanstack-migrator/web/components/site-detail.tsx
@@ -22,7 +22,7 @@ import { issuesFilterUrl } from "@/components/site-card.tsx";
 import { StatusBadge } from "@/components/status-badge.tsx";
 import { TerminalPanel } from "@/components/terminal-panel.tsx";
 import { usePollingTool, useToolCaller } from "@/hooks/use-tool.ts";
-import { clockTime, cn, duration, timeAgo } from "@/lib/utils.ts";
+import { clockTime, cn, timeAgo } from "@/lib/utils.ts";
 import type { RunView, SiteDetail, SiteView } from "@/types.ts";
 
 const ACTIVE_STATUSES = new Set([

--- a/tanstack-migrator/web/components/terminal-panel.tsx
+++ b/tanstack-migrator/web/components/terminal-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ExternalLink,
   Loader2,
@@ -7,7 +7,7 @@ import {
   Wrench,
 } from "lucide-react";
 import { usePollingTool } from "@/hooks/use-tool.ts";
-import { cn } from "@/lib/utils.ts";
+import { cn, studioThreadUrl } from "@/lib/utils.ts";
 import type { TerminalData } from "@/types.ts";
 
 /**
@@ -20,19 +20,24 @@ import type { TerminalData } from "@/types.ts";
 export function TerminalPanel({
   siteId,
   active,
-  threadUrlBase,
 }: {
   siteId: string;
-  /** the site is in an active phase — poll fast so it feels live */
+  /** the site is in an active phase — initial guess for the poll cadence */
   active: boolean;
-  /** e.g. https://studio.decocms.com — used to deep-link the thread */
-  threadUrlBase?: string;
 }) {
+  // poll fast while there's live work; the server's `live` flag (a running
+  // phase thread) is the source of truth, so a mismatched `active` guess (e.g.
+  // a legacy status) self-corrects after the first fetch. `active` still keeps
+  // us fast in the gap between phases before a thread exists.
+  const [fast, setFast] = useState(active);
   const { data, loading, error } = usePollingTool<TerminalData>(
     "SITE_TERMINAL",
     { siteId },
-    active ? 3500 : 12000,
+    fast ? 3500 : 12000,
   );
+  useEffect(() => {
+    if (data) setFast(data.live || active);
+  }, [data?.live, active]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const atBottomRef = useRef(true);
@@ -51,10 +56,7 @@ export function TerminalPanel({
     atBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
   };
 
-  const threadUrl =
-    threadUrlBase && data?.threadId
-      ? `${threadUrlBase.replace(/\/$/, "")}/threads/${data.threadId}`
-      : null;
+  const threadUrl = data?.threadId ? studioThreadUrl(data.threadId) : null;
 
   return (
     <div className="flex min-h-[24rem] flex-1 flex-col overflow-hidden rounded-lg border border-zinc-800 bg-zinc-950 text-zinc-200">

--- a/tanstack-migrator/web/components/terminal-panel.tsx
+++ b/tanstack-migrator/web/components/terminal-panel.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useRef } from "react";
+import {
+  ExternalLink,
+  Loader2,
+  Sparkles,
+  SquareTerminal,
+  Wrench,
+} from "lucide-react";
+import { usePollingTool } from "@/hooks/use-tool.ts";
+import { cn } from "@/lib/utils.ts";
+import type { TerminalData } from "@/types.ts";
+
+/**
+ * Live terminal for the drawer — replays the current migration session's thread
+ * as a scrolling command/narration transcript (like the agentic CMS terminal),
+ * so you can watch what the agent is doing in real time. Polls SITE_TERMINAL
+ * fast while the phase thread is live, slow when it's showing a past session.
+ * Fixed dark palette on purpose: a terminal reads as a terminal in both themes.
+ */
+export function TerminalPanel({
+  siteId,
+  active,
+  threadUrlBase,
+}: {
+  siteId: string;
+  /** the site is in an active phase — poll fast so it feels live */
+  active: boolean;
+  /** e.g. https://studio.decocms.com — used to deep-link the thread */
+  threadUrlBase?: string;
+}) {
+  const { data, loading, error } = usePollingTool<TerminalData>(
+    "SITE_TERMINAL",
+    { siteId },
+    active ? 3500 : 12000,
+  );
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const atBottomRef = useRef(true);
+  const count = data?.entries.length ?? 0;
+
+  // auto-follow: stick to the bottom as new lines arrive, but respect a user
+  // who scrolled up to read history (don't yank them back down)
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el && atBottomRef.current) el.scrollTop = el.scrollHeight;
+  }, [count]);
+
+  const onScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    atBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+  };
+
+  const threadUrl =
+    threadUrlBase && data?.threadId
+      ? `${threadUrlBase.replace(/\/$/, "")}/threads/${data.threadId}`
+      : null;
+
+  return (
+    <div className="flex min-h-[24rem] flex-1 flex-col overflow-hidden rounded-lg border border-zinc-800 bg-zinc-950 text-zinc-200">
+      {/* title bar */}
+      <div className="flex items-center gap-2 border-b border-zinc-800 bg-zinc-900/60 px-3 py-2">
+        <SquareTerminal className="h-3.5 w-3.5 text-emerald-400" />
+        <span className="text-xs font-medium text-zinc-300">
+          Terminal do agente
+        </span>
+        {data?.live ? (
+          <span className="flex items-center gap-1 text-[10px] font-medium text-emerald-400">
+            <span className="relative flex h-1.5 w-1.5">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-400" />
+            </span>
+            ao vivo
+          </span>
+        ) : (
+          data?.threadId && (
+            <span className="text-[10px] text-zinc-500">última sessão</span>
+          )
+        )}
+        <div className="ml-auto flex items-center gap-2">
+          {count > 0 && (
+            <span className="text-[10px] text-zinc-500 tabular-nums">
+              {count} linhas
+            </span>
+          )}
+          {threadUrl && (
+            <a
+              href={threadUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-[10px] text-zinc-400 hover:text-zinc-200"
+            >
+              thread <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
+        </div>
+      </div>
+
+      {/* transcript */}
+      <div
+        ref={scrollRef}
+        onScroll={onScroll}
+        className="flex-1 overflow-y-auto px-3 py-2 font-mono text-[11px] leading-relaxed"
+      >
+        {loading && !data && (
+          <div className="flex items-center gap-2 text-zinc-500">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" /> conectando à
+            sessão…
+          </div>
+        )}
+        {error && !data && <div className="text-red-400">{error}</div>}
+        {data && count === 0 && (
+          <div className="text-zinc-500">
+            {data.threadId
+              ? "Sessão despachada — aguardando os primeiros comandos…"
+              : "Nenhuma sessão iniciada ainda para este site."}
+          </div>
+        )}
+
+        {data?.entries.map((e) => {
+          if (e.kind === "command") {
+            const failed = typeof e.exitCode === "number" && e.exitCode !== 0;
+            return (
+              <div key={e.seq} className="mb-1.5">
+                <div className="flex items-start gap-1.5">
+                  <span className="shrink-0 select-none text-emerald-400">
+                    $
+                  </span>
+                  <span className="whitespace-pre-wrap break-all text-zinc-100">
+                    {e.command}
+                  </span>
+                  {typeof e.exitCode === "number" && (
+                    <span
+                      className={cn(
+                        "ml-auto shrink-0 rounded px-1 text-[9px] tabular-nums",
+                        failed
+                          ? "bg-red-500/20 text-red-400"
+                          : "bg-emerald-500/15 text-emerald-400",
+                      )}
+                    >
+                      exit {e.exitCode}
+                    </span>
+                  )}
+                </div>
+                {e.output && (
+                  <pre className="mt-0.5 max-h-40 overflow-y-auto whitespace-pre-wrap break-all pl-3 text-zinc-500">
+                    {e.output}
+                  </pre>
+                )}
+              </div>
+            );
+          }
+          if (e.kind === "tool") {
+            return (
+              <div
+                key={e.seq}
+                className="mb-1.5 flex items-center gap-1.5 text-sky-300/80"
+              >
+                <Wrench className="h-3 w-3 shrink-0" />
+                <span className="font-medium">{e.tool}</span>
+                {e.text && (
+                  <span className="truncate text-zinc-500">{e.text}</span>
+                )}
+              </div>
+            );
+          }
+          if (e.kind === "reasoning") {
+            return (
+              <div
+                key={e.seq}
+                className="mb-1.5 whitespace-pre-wrap break-words pl-3 italic text-zinc-600"
+              >
+                {e.text}
+              </div>
+            );
+          }
+          // assistant narration
+          return (
+            <div
+              key={e.seq}
+              className="mb-1.5 flex items-start gap-1.5 text-zinc-300"
+            >
+              <Sparkles className="mt-0.5 h-3 w-3 shrink-0 text-indigo-400" />
+              <span className="whitespace-pre-wrap break-words">{e.text}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/tanstack-migrator/web/components/terminal-panel.tsx
+++ b/tanstack-migrator/web/components/terminal-panel.tsx
@@ -36,7 +36,9 @@ export function TerminalPanel({
     fast ? 3500 : 12000,
   );
   useEffect(() => {
-    if (data) setFast(data.live || active);
+    // follow `active` immediately (don't wait for a response) and upgrade to the
+    // server's `live` truth once it arrives
+    setFast((data?.live ?? false) || active);
   }, [data?.live, active]);
 
   const scrollRef = useRef<HTMLDivElement>(null);

--- a/tanstack-migrator/web/lib/utils.ts
+++ b/tanstack-migrator/web/lib/utils.ts
@@ -32,3 +32,11 @@ export function clockTime(iso: string | null): string {
   const d = new Date(iso);
   return d.toLocaleTimeString("pt-BR", { hour12: false });
 }
+
+/** Studio host — single source for deep links into the CMS. */
+export const STUDIO_URL = "https://studio.decocms.com";
+
+/** Deep link to a decopilot thread in the studio (Run rows + live terminal). */
+export function studioThreadUrl(threadId: string): string {
+  return `${STUDIO_URL}/threads/${threadId}`;
+}

--- a/tanstack-migrator/web/types.ts
+++ b/tanstack-migrator/web/types.ts
@@ -139,6 +139,25 @@ export interface SiteDetail {
   events: EventView[];
 }
 
+export interface TerminalEntry {
+  seq: number;
+  role: string;
+  kind: "text" | "command" | "tool" | "reasoning";
+  text?: string;
+  command?: string;
+  exitCode?: number;
+  output?: string;
+  tool?: string;
+}
+
+export interface TerminalData {
+  threadId: string | null;
+  /** true when this is the still-running phase thread (not a past run). */
+  live: boolean;
+  entries: TerminalEntry[];
+  updatedAt: string;
+}
+
 export interface ReportUrls {
   reportHtml: string | null;
   reportJson: string | null;


### PR DESCRIPTION
## Contexto

Saído da primeira rodada real do `granadobr-teste`: fazer o **preview funcionar de verdade antes da paridade**, **não reaprender bugs de framework a cada site**, e **enxergar o agente ao vivo** no drawer.

## 1. Preview só conta quando RENDERIZA

- `worker.probePreviewIfNeeded` não marca mais `preview_ready` em qualquer HTTP 200. O proxy do sandbox serve o placeholder **"No web page at this URL"** com **200 + text/html** — falso positivo que empurrava o site pra paridade com o preview quebrado.
- `looksLikeRealSite` julga o **conteúdo do body**: texto visível (>40 chars) OU uma árvore de elementos real (≥8 tags), depois de remover script/style/template. Rejeita o placeholder e o shell vazio `<div id="root"></div>` mesmo quando os scripts do `<head>` inflam o tamanho. (endereça o review do cubic: P1 fallback do shell, P2 hard-fail de 800 bytes, P3 content-type case) — coberto por 4 testes.
- `triagePrompt` + `fixIssuesPrompt`: o SSR **tem** que renderizar HTML real em `/`; SSR quebrado = issue high/runtime a investigar via `/tmp/dev.log`, e um fix só é "resolved" quando `/` devolve HTML.

## 2. Memória entre migrações no org-fs do Studio (NÃO Supabase)

Dir `/app/org/home/.tanstack-migrator/` montado em todo sandbox → persiste entre sites. Um helper `memorySection()` mantém as instruções consistentes em todas as fases (mesmo dir, entradas de 1 linha, dedupe). Quatro arquivos:

- **framework-notes.md** — SUSPEITAS ("isso parece bug do framework")
- **fixes.md** — SOLUÇÕES que já funcionaram ("erro → fix"). Ataca direto o desperdício de sessões de fix: o próximo site aplica a receita conhecida em vez de redescobrir.
- **conventions.md** — gotchas de setup da migração (predev, symlink `org`, porta, sem rsync)
- **parity-gotchas.md** — mismatches visuais recorrentes e como foram resolvidos

Matriz read/write: migrate-script lê+escreve conventions; triage lê os quatro (aplica fixes conhecidos antes de reinvestigar) e escreve só framework-notes; fix lê os quatro e escreve framework-notes/fixes/conventions/parity-gotchas (é onde as soluções são comprovadas); parity fica measure-only.

## 3. Terminal do agente ao vivo no drawer (v0.7.0)

- `decopilot.fetchThreadTranscript`: replay da thread como transcript ordenado — narração do agente + cada comando bash (com exit code e trecho de output) + outras tool calls. Segredos redigidos, output truncado, últimas 150 linhas.
- Tool `SITE_TERMINAL` (read-only): prefere a thread viva da fase (`phase_thread_id`), cai pra thread do último run quando ocioso.
- `TerminalPanel`: nova aba "Terminal", paleta dark fixa, indicador "ao vivo", auto-follow que respeita scroll manual, deep-link pra thread no studio. Poll rápido (3.5s) quando ativo, lento (12s) ocioso, montado só com a aba aberta.

## Verificação

- `bun run check` — limpo (os 2 erros restantes são de `node_modules/@decocms/runtime`, pré-existentes).
- `bun test` — 32 pass / 0 fail (4 novos em `looksLikeRealSite` + 1 na matriz de memória); suíte completa do monorepo 445/0.
- `bun run build` — 3 htmls (dashboard + 2 widgets) + server bundle OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
