### PR TITLE
feat(tanstack-migrator): proven deco.cx→TanStack loader fix recipes (v0.7.2)

### DIFF
--- a/tanstack-migrator/package.json
+++ b/tanstack-migrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tanstack-migrator",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Orchestrates Fresh/Deno → TanStack Start storefront migrations: issue-driven pipeline, mesh sandboxes running Claude, branch+PR flow, parity via Playwright, visual dashboard + home widgets",
   "private": true,
   "type": "module",

--- a/tanstack-migrator/server/migrator.test.ts
+++ b/tanstack-migrator/server/migrator.test.ts
@@ -201,6 +201,19 @@ describe("prompts", () => {
     expect(migrate).toContain(`>> ${CONVENTIONS_PATH}`);
   });
 
+  test("fixIssuesPrompt ships the proven deco.cx→TanStack loader recipes", () => {
+    const prompt = fixIssuesPrompt({
+      site,
+      issues: [{ number: 1, title: "home em branco" }],
+    });
+    // the ctx-undefined recipe (the empty-page root cause)
+    expect(prompt).toContain("ctx?: AppContext");
+    expect(prompt).toContain("useDevice()");
+    // the SEO defaultLoader recipe
+    expect(prompt).toContain("@decocms/apps/website/components/Seo");
+    expect(prompt).toContain("defaultLoader");
+  });
+
   test("parityOnlyPrompt: measure-only with uploads", () => {
     const prompt = parityOnlyPrompt({
       site,

--- a/tanstack-migrator/server/sandbox/templates/prompts.ts
+++ b/tanstack-migrator/server/sandbox/templates/prompts.ts
@@ -399,6 +399,12 @@ ${memorySection(site, [
   },
 ])}
 
+# Receitas conhecidas (padrões que JÁ funcionaram em migrações deco.cx→TanStack)
+Se o erro bater com um destes, aplique direto — não reinvente nem gaste sessão investigando loader por loader:
+- **Section loader usa \`ctx.algo\` e estoura \`Cannot read properties of undefined\`** (ex: \`ctx.device\`, \`ctx.invoke\`, \`ctx.salesforce\`, \`ctx.features\`): o \`@decocms/start\` invoca o loader como \`(props, req)\` — o 3º arg \`ctx\` quase sempre vem \`undefined\` (o start só compõe device/search params; salesforce/features/invoke NEM sempre são injetados). Fix comprovado: torne \`ctx\` OPCIONAL (\`ctx?: AppContext\`) e use optional-chaining em TODO acesso, com fallback: \`ctx?.device\`, \`ctx?.salesforce?.x\`, \`ctx?.features?.y ?? false\`. Para device no componente, use o hook \`useDevice()\` de \`@decocms/start/sdk/useDevice\` (não \`ctx.device\`). E NÃO faça fetch pesado via \`ctx.invoke\` dentro do section loader — o loader deve só derivar props baratas. (Isso destrava a home inteira: cada loader que estoura deixa a seção vazia → página em branco.)
+- **\`defaultLoader\`/\`DefaultProps\` não definidos** (seções de SEO tipo SeoPDP/SeoPLP): são convenções do deco.cx Fresh que não existem no start. Fix comprovado: importe \`renderTemplateString\`, \`type SEOSection\`, \`type Props as SeoProps\` de \`@decocms/apps/website/components/Seo\` e faça a normalização de title/description/canonical INLINE (assinatura \`(props, req): SeoProps\`, sem \`ctx\` nem \`defaultLoader\`).
+Ambos têm causa raiz no migrate transform do \`@decocms/start\` (não converte a API \`ctx.*\`/\`defaultLoader\` do deco.cx) — registre no \`framework-notes.md\` com prefixo \`[framework?]\`.
+
 # Issues a resolver
 ${list}
 


### PR DESCRIPTION
## Contexto

Diagnóstico feito reproduzindo o granadobr localmente e comparando com a migração **que funciona** (`granadobr-tanstack`). Causa raiz da home vazia/tela preta: **todo section loader do deco.cx** usa a assinatura de 3 args `(props, req, ctx)` com `ctx.invoke/device/salesforce/features`, mas o `@decocms/start` invoca loaders como `(props, req)` — `ctx` é sempre `undefined`, então cada loader estoura e nenhuma seção renderiza. Além disso, seções de SEO usam `defaultLoader`/`DefaultProps` do deco.cx, que não existem no start.

## O que a migração real fez (e agora está no fixIssuesPrompt)

Padrões mecânicos, por-site, pra o fix loop aplicar direto em vez de queimar sessões:

- **ctx undefined**: tornar `ctx` opcional (`ctx?: AppContext`) + optional-chaining em todo read com fallback (`ctx?.device`, `ctx?.salesforce?.x`, `ctx?.features?.y ?? false`); `useDevice()` de `@decocms/start/sdk/useDevice` pro device; tirar `ctx.invoke` pesado do section loader.
- **SEO `defaultLoader`/`DefaultProps`**: importar `renderTemplateString`/`SEOSection`/`SeoProps` de `@decocms/apps/website/components/Seo` e fazer a normalização inline.

Ambos marcados como `[framework?]` — o fix durável é o migrate transform do `@decocms/start` converter a API `ctx.*`/`defaultLoader` (issue aberta no `decocms/deco-start`). Como **todo site deco.cx usa loaders com ctx**, resolver lá faz cada migração futura nascer certa.

## Verificação
- `bun test` 39/0 (novo teste travando as duas receitas no prompt) · `check` limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds proven deco.cx → TanStack loader fix recipes to `tanstack-migrator` so migrations stop rendering blank pages and SEO sections work under `@decocms/start`.

- New Features
  - `fixIssuesPrompt` now suggests two recipes: make `ctx` optional with safe fallbacks and `useDevice()`, and replace SEO `defaultLoader`/`DefaultProps` with imports from `@decocms/apps/website/components/Seo` plus inline normalization.
  - Added tests to lock the prompt content; bumped package to v0.7.2.

<sup>Written for commit 19e70a06cc4189b1917095d4e50d0aab92a14574. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

