### PR TITLE
fix(vtex): fall back to per-hour OMS aggregation for orders timeline

### DIFF
--- a/vtex/server/tools/custom/orders-timeline.ts
+++ b/vtex/server/tools/custom/orders-timeline.ts
@@ -4,7 +4,10 @@ import { VTEX_ORDERS_TIMELINE_RESOURCE_URI } from "../../constants.ts";
 import type { Env } from "../../types/env.ts";
 import { fetchAnalyticsConsumption } from "./analytics-consumption.ts";
 import {
+  buildOmsHeaders,
+  buildOmsOrdersUrl,
   DEFAULT_STORE_TIMEZONE,
+  fetchHourlyBuckets,
   getTodayWindowInTimezone,
 } from "./orders-oms.ts";
 import {
@@ -30,7 +33,7 @@ export const ordersTimeline = (_env: Env) =>
   createTool({
     id: "VTEX_ORDERS_TIMELINE",
     description:
-      "Fetch today's orders aggregated by hour for a bar chart. Uses the admin home orders trend analytics endpoint (single request).",
+      "Fetch today's orders aggregated by hour for a bar chart. Uses the admin home orders trend analytics endpoint (single request), falling back to per-hour OMS order-list aggregation when analytics is unavailable.",
     inputSchema: z.object({}),
     outputSchema,
     _meta: { ui: { resourceUri: VTEX_ORDERS_TIMELINE_RESOURCE_URI } },
@@ -42,34 +45,53 @@ export const ordersTimeline = (_env: Env) =>
       const timezone = DEFAULT_STORE_TIMEZONE;
       const storeCurrency = currency ?? DEFAULT_STORE_CURRENCY;
       const { date } = getTodayWindowInTimezone(timezone);
-      const params = resolveOrdersTrendParams({
-        agg: "hour",
-        currency: storeCurrency,
-        timezone,
-      });
 
-      const trend = await fetchAnalyticsConsumption(
-        { accountName, appKey, appToken },
-        "home-orders-trend",
-        {
-          an: accountName,
-          currency: params.currency,
-          startDate: params.startDate,
-          endDate: params.endDate,
-          agg: params.agg,
-          timezone: params.timezone,
-        },
-      );
-
-      if (!hasUsableTrendChartData(trend)) {
-        throw new Error(
-          "VTEX analytics returned empty trend data (null placeholders). Check store currency and app key access to admin analytics.",
+      const fallbackToOms = async () => {
+        const hours = await fetchHourlyBuckets(
+          buildOmsOrdersUrl(accountName),
+          buildOmsHeaders({ accountName, appKey, appToken }),
+          date,
+          timezone,
         );
-      }
-
-      return {
-        hours: parseAnalyticsHourlyBuckets(trend, timezone),
-        date,
+        return { hours, date };
       };
+
+      // Primary: the admin home trend analytics endpoint (single request, fast).
+      // It requires the app key to have admin analytics access and the store
+      // currency to be configured; when either is missing it returns null
+      // placeholders. In that case we fall back to aggregating the OMS orders
+      // list one hour at a time (24 parallel requests) which only needs
+      // standard OMS access and also yields per-hour totalValue.
+      try {
+        const params = resolveOrdersTrendParams({
+          agg: "hour",
+          currency: storeCurrency,
+          timezone,
+        });
+
+        const trend = await fetchAnalyticsConsumption(
+          { accountName, appKey, appToken },
+          "home-orders-trend",
+          {
+            an: accountName,
+            currency: params.currency,
+            startDate: params.startDate,
+            endDate: params.endDate,
+            agg: params.agg,
+            timezone: params.timezone,
+          },
+        );
+
+        if (!hasUsableTrendChartData(trend)) {
+          return await fallbackToOms();
+        }
+
+        return {
+          hours: parseAnalyticsHourlyBuckets(trend, timezone),
+          date,
+        };
+      } catch (_error) {
+        return await fallbackToOms();
+      }
     },
   });


### PR DESCRIPTION
## Problem

The `VTEX_ORDERS_TIMELINE` tool renders a hard error on the timeline chart:

> VTEX analytics returned empty trend data (null placeholders). Check store currency and app key access to admin analytics.

The tool depends on the admin home orders trend analytics endpoint (`/api/analytics/consumption/home-orders-trend`), which returns null placeholders when the app key lacks admin analytics access or the store currency isn't configured.

## Change

Keep analytics as the fast primary path (single request), but when it throws or returns unusable data, fall back to aggregating the OMS orders list **one hour at a time** via the existing `fetchHourlyBuckets` helper in `orders-oms.ts`.

- Fallback uses standard OMS access (`X-VTEX-API-AppKey`/`AppToken`) that stores already have.
- Runs the per-hour queries in parallel, only up to the current local hour, then pads to 24.
- Bonus: the OMS path yields real per-hour `totalValue` (the analytics path zeroed it).

Output schema is unchanged, so the chart UI needs no changes.

## Testing

- `bunx oxfmt --check` passes on the changed file.
- TypeScript check could not run locally (workspace deps not installed); change only uses already-exported helpers with matching signatures and the return shape matches `outputSchema`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a fallback in `VTEX_ORDERS_TIMELINE` to aggregate today’s orders per hour from OMS when the admin analytics trend is empty or errors, so the timeline renders reliably. Analytics remains the primary fast path; output schema is unchanged.

- **Bug Fixes**
  - Fall back to OMS per-hour aggregation via `fetchHourlyBuckets` when analytics returns null placeholders or throws.
  - Run per-hour OMS queries in parallel up to the current local hour and pad to 24; uses standard OMS app key/token.
  - Preserve the existing output shape and include accurate per-hour `totalValue`, so the chart needs no changes.

<sup>Written for commit 0265e636a0b0785b48283017c13cfb6daeeff398. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

