### PR TITLE
feat(youtube-channel-admin): full Data API v3 coverage — lives, premieres, playlists, delete, rate, search

### DIFF
--- a/youtube-channel-admin/server/constants.ts
+++ b/youtube-channel-admin/server/constants.ts
@@ -25,3 +25,5 @@ export const WIDGET_PERFORMANCE_RESOURCE_URI =
   "ui://youtube-channel-admin/widget-performance";
 export const WIDGET_ALERTS_RESOURCE_URI =
   "ui://youtube-channel-admin/widget-alerts";
+export const WIDGET_LIVES_RESOURCE_URI =
+  "ui://youtube-channel-admin/widget-lives";

--- a/youtube-channel-admin/server/main.ts
+++ b/youtube-channel-admin/server/main.ts
@@ -14,6 +14,7 @@ import { GOOGLE_SCOPES } from "./constants.ts";
 import {
   dashboardResource,
   widgetAlertsResource,
+  widgetLivesResource,
   widgetPerformanceResource,
   widgetTopVideosResource,
 } from "./resources/index.ts";
@@ -37,6 +38,7 @@ const runtime = withRuntime<Env, typeof StateSchema>({
     widgetTopVideosResource,
     widgetPerformanceResource,
     widgetAlertsResource,
+    widgetLivesResource,
   ],
 });
 

--- a/youtube-channel-admin/server/resources/index.ts
+++ b/youtube-channel-admin/server/resources/index.ts
@@ -1,6 +1,7 @@
 import {
   DASHBOARD_RESOURCE_URI,
   WIDGET_ALERTS_RESOURCE_URI,
+  WIDGET_LIVES_RESOURCE_URI,
   WIDGET_PERFORMANCE_RESOURCE_URI,
   WIDGET_TOP_VIDEOS_RESOURCE_URI,
 } from "../constants.ts";
@@ -34,4 +35,12 @@ export const widgetAlertsResource = createMcpAppResource({
   description:
     "Home widget: videos with upload/processing problems and comments held for review.",
   htmlFile: "widget-alerts.html",
+});
+
+export const widgetLivesResource = createMcpAppResource({
+  uri: WIDGET_LIVES_RESOURCE_URI,
+  name: "YouTube — Lives & Estreias",
+  description:
+    "Home widget: upcoming and active live broadcasts and Premieres.",
+  htmlFile: "widget-lives.html",
 });

--- a/youtube-channel-admin/server/tools/captions.ts
+++ b/youtube-channel-admin/server/tools/captions.ts
@@ -232,6 +232,102 @@ export const createUploadCaptionTool = (env: Env) =>
     },
   });
 
+export const createUpdateCaptionTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_UPDATE_CAPTION",
+    description:
+      "Replace the content of an existing caption track. Quota: 450 units.",
+    inputSchema: z.object({
+      captionId: z.string(),
+      content: z.string().describe("New full SRT or VTT content"),
+      format: z.enum(["srt", "vtt"]).default("srt"),
+      isDraft: z.boolean().optional(),
+    }),
+    outputSchema: z.object({
+      captionId: z.string(),
+      language: z.string().optional(),
+      name: z.string().optional(),
+      isDraft: z.boolean().optional(),
+    }),
+    execute: async ({ context }) => {
+      const { getAccessToken } = await import("../lib/auth.ts");
+      const token = getAccessToken(env);
+
+      const snippet = {
+        id: context.captionId,
+        isDraft: context.isDraft,
+      };
+
+      const boundary = `caption_boundary_${Date.now()}`;
+      const body = [
+        `--${boundary}`,
+        "Content-Type: application/json; charset=UTF-8",
+        "",
+        JSON.stringify({ snippet }),
+        `--${boundary}`,
+        `Content-Type: text/${context.format === "vtt" ? "vtt" : "plain"}`,
+        "",
+        context.content,
+        `--${boundary}--`,
+      ].join("\r\n");
+
+      const response = await fetch(
+        `https://www.googleapis.com/upload/youtube/v3/captions?uploadType=multipart&part=snippet`,
+        {
+          method: "PUT",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": `multipart/related; boundary=${boundary}`,
+          },
+          body,
+        },
+      );
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(
+          `Caption update failed (${response.status}): ${text.slice(0, 500)}`,
+        );
+      }
+
+      const result = (await response.json()) as {
+        id: string;
+        snippet?: {
+          language?: string;
+          name?: string;
+          isDraft?: boolean;
+        };
+      };
+
+      return {
+        captionId: result.id,
+        language: result.snippet?.language,
+        name: result.snippet?.name,
+        isDraft: result.snippet?.isDraft,
+      };
+    },
+  });
+
+export const createDeleteCaptionTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_DELETE_CAPTION",
+    description: "Delete a caption track from a video.",
+    inputSchema: z.object({
+      captionId: z.string(),
+    }),
+    outputSchema: z.object({
+      captionId: z.string(),
+      deleted: z.boolean(),
+    }),
+    execute: async ({ context }) => {
+      await dataApi(env, "/captions", {
+        method: "DELETE",
+        params: { id: context.captionId },
+      });
+      return { captionId: context.captionId, deleted: true };
+    },
+  });
+
 /** Strips SRT indexes/timestamps, leaving one caption line per row. */
 function srtToPlainText(srt: string): string {
   return srt

--- a/youtube-channel-admin/server/tools/channel-sections.ts
+++ b/youtube-channel-admin/server/tools/channel-sections.ts
@@ -1,0 +1,190 @@
+import { createPrivateTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { dataApi } from "../lib/yt-client.ts";
+import type { Env } from "../types/env.ts";
+
+interface ChannelSectionItem {
+  id: string;
+  snippet?: {
+    type?: string;
+    title?: string;
+    position?: number;
+  };
+  contentDetails?: {
+    playlists?: string[];
+    channels?: string[];
+  };
+}
+
+type ChannelSectionResponse = { items?: ChannelSectionItem[] };
+
+const sectionOutputSchema = z.object({
+  sectionId: z.string(),
+  type: z.string(),
+  title: z.string().optional(),
+  position: z.number().optional(),
+  playlistIds: z.array(z.string()),
+  channelIds: z.array(z.string()),
+});
+
+function mapSection(item: ChannelSectionItem) {
+  return {
+    sectionId: item.id,
+    type: item.snippet?.type ?? "",
+    title: item.snippet?.title,
+    position: item.snippet?.position,
+    playlistIds: item.contentDetails?.playlists ?? [],
+    channelIds: item.contentDetails?.channels ?? [],
+  };
+}
+
+export const createListChannelSectionsTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_LIST_CHANNEL_SECTIONS",
+    description:
+      "List the channel's sections as they appear on the channel page (e.g. playlists, featured channels, recent uploads rows).",
+    inputSchema: z.object({}),
+    outputSchema: z.object({
+      sections: z.array(sectionOutputSchema),
+    }),
+    execute: async () => {
+      const result = await dataApi<ChannelSectionResponse>(
+        env,
+        "/channelSections",
+        {
+          params: { part: "snippet,contentDetails", mine: true },
+        },
+      );
+
+      return {
+        sections: (result.items ?? []).map(mapSection),
+      };
+    },
+  });
+
+export const createCreateChannelSectionTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_CREATE_CHANNEL_SECTION",
+    description:
+      "Create a new section on the channel page. Common types: singlePlaylist, multipleChannels, singleChannel, allPlaylists, recentUploads, featuredPlaylists.",
+    inputSchema: z.object({
+      type: z
+        .string()
+        .describe(
+          "Section type, e.g. singlePlaylist, multipleChannels, recentUploads",
+        ),
+      title: z.string().optional(),
+      position: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe("Display position (0-indexed)"),
+      playlistIds: z.array(z.string()).optional(),
+      channelIds: z.array(z.string()).optional(),
+    }),
+    outputSchema: sectionOutputSchema,
+    execute: async ({ context }) => {
+      const result = await dataApi<ChannelSectionItem>(
+        env,
+        "/channelSections",
+        {
+          method: "POST",
+          params: { part: "snippet,contentDetails" },
+          body: {
+            snippet: {
+              type: context.type,
+              title: context.title,
+              defaultLanguage: "pt",
+            },
+            contentDetails: {
+              playlists: context.playlistIds,
+              channels: context.channelIds,
+            },
+          },
+        },
+      );
+
+      return mapSection(result);
+    },
+  });
+
+export const createUpdateChannelSectionTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_UPDATE_CHANNEL_SECTION",
+    description:
+      "Update a channel section's title, position or playlist/channel list.",
+    inputSchema: z.object({
+      sectionId: z.string(),
+      title: z.string().optional(),
+      position: z.number().int().min(0).optional(),
+      playlistIds: z.array(z.string()).optional(),
+      channelIds: z.array(z.string()).optional(),
+    }),
+    outputSchema: sectionOutputSchema,
+    execute: async ({ context }) => {
+      const current = await dataApi<ChannelSectionResponse>(
+        env,
+        "/channelSections",
+        {
+          params: { part: "snippet,contentDetails", id: context.sectionId },
+        },
+      );
+
+      const existing = current.items?.[0];
+      if (!existing) {
+        throw new Error(`Channel section not found: ${context.sectionId}`);
+      }
+
+      const mergedSnippet = {
+        ...existing.snippet,
+        ...(context.title !== undefined && { title: context.title }),
+        ...(context.position !== undefined && { position: context.position }),
+      };
+
+      const mergedContentDetails = {
+        playlists: context.playlistIds ?? existing.contentDetails?.playlists,
+        channels: context.channelIds ?? existing.contentDetails?.channels,
+      };
+
+      const result = await dataApi<ChannelSectionItem>(
+        env,
+        "/channelSections",
+        {
+          method: "PUT",
+          params: { part: "snippet,contentDetails" },
+          body: {
+            id: context.sectionId,
+            snippet: mergedSnippet,
+            contentDetails: mergedContentDetails,
+          },
+        },
+      );
+
+      return mapSection(result);
+    },
+  });
+
+export const createDeleteChannelSectionTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_DELETE_CHANNEL_SECTION",
+    description: "Delete a channel section.",
+    inputSchema: z.object({
+      sectionId: z.string(),
+    }),
+    outputSchema: z.object({
+      sectionId: z.string(),
+      deleted: z.boolean(),
+    }),
+    execute: async ({ context }) => {
+      await dataApi<undefined>(env, "/channelSections", {
+        method: "DELETE",
+        params: { id: context.sectionId },
+      });
+
+      return {
+        sectionId: context.sectionId,
+        deleted: true,
+      };
+    },
+  });

--- a/youtube-channel-admin/server/tools/channel.ts
+++ b/youtube-channel-admin/server/tools/channel.ts
@@ -1,6 +1,7 @@
 import { createPrivateTool } from "@decocms/runtime/tools";
 import { z } from "zod";
-import { dataApi } from "../lib/yt-client.ts";
+import { UPLOAD_API_BASE } from "../constants.ts";
+import { dataApi, googleFetch } from "../lib/yt-client.ts";
 import { getMyChannel } from "../lib/yt-data.ts";
 import type { Env } from "../types/env.ts";
 import { MyChannelSchema } from "./views.ts";
@@ -219,5 +220,126 @@ export const createListSubscribersTool = (env: Env) =>
       }));
 
       return { subscribers, nextPageToken: data.nextPageToken };
+    },
+  });
+
+const MAX_WATERMARK_BYTES = 1 * 1024 * 1024; // 1 MB API limit
+
+export const createSetWatermarkTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_SET_WATERMARK",
+    description:
+      "Set the channel watermark (branding overlay / subscribe button) shown on all videos. Provide an imageUrl (publicly accessible PNG/JPG, ≤1 MB). The watermark appears in the bottom-right corner by default. Use position.type='offset' with cornerPosition and offsetUnit for custom placement.",
+    inputSchema: z.object({
+      channelId: z.string().describe("Your channel's ID (from GET_MY_CHANNEL)"),
+      imageUrl: z
+        .string()
+        .url()
+        .describe("Public URL of a PNG or JPG image (≤1 MB)"),
+      startTimeMs: z
+        .number()
+        .int()
+        .min(0)
+        .default(0)
+        .describe("When the watermark starts appearing (ms into video)"),
+      durationMs: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe(
+          "How long to show the watermark (ms); omit for rest of video",
+        ),
+      cornerPosition: z
+        .enum(["topLeft", "topRight", "bottomLeft", "bottomRight"])
+        .default("bottomRight")
+        .describe("Corner where watermark appears"),
+    }),
+    outputSchema: z.object({ channelId: z.string(), set: z.boolean() }),
+    execute: async ({ context }) => {
+      const imgRes = await fetch(context.imageUrl);
+      if (!imgRes.ok) {
+        throw new Error(
+          `Could not fetch watermark image from URL (${imgRes.status})`,
+        );
+      }
+      const contentType = imgRes.headers.get("content-type") ?? "image/png";
+      if (!/^image\/(jpeg|png)/.test(contentType)) {
+        throw new Error(
+          `Unsupported watermark content-type "${contentType}" — use JPEG or PNG.`,
+        );
+      }
+      const imgBytes = new Uint8Array(await imgRes.arrayBuffer());
+      if (imgBytes.byteLength > MAX_WATERMARK_BYTES) {
+        throw new Error(
+          `Watermark image is ${(imgBytes.byteLength / 1024 / 1024).toFixed(1)}MB — the API limit is 1MB.`,
+        );
+      }
+
+      const invideoTiming: Record<string, unknown> = {
+        type: "offsetFromStart",
+        offsetMs: context.startTimeMs,
+      };
+      if (context.durationMs !== undefined) {
+        invideoTiming.durationMs = context.durationMs;
+      }
+
+      const metadata = {
+        position: {
+          type: "corner",
+          cornerPosition: context.cornerPosition,
+        },
+        timing: invideoTiming,
+      };
+
+      const boundary = "youtubeWatermarkBoundary";
+      const metadataJson = JSON.stringify(metadata);
+      const enc = new TextEncoder();
+      const parts = [
+        enc.encode(
+          `--${boundary}\r\nContent-Type: application/json\r\n\r\n${metadataJson}\r\n`,
+        ),
+        enc.encode(`--${boundary}\r\nContent-Type: ${contentType}\r\n\r\n`),
+        imgBytes,
+        enc.encode(`\r\n--${boundary}--`),
+      ];
+      const totalLength = parts.reduce((s, p) => s + p.byteLength, 0);
+      const combined = new Uint8Array(totalLength);
+      let offset = 0;
+      for (const p of parts) {
+        combined.set(p, offset);
+        offset += p.byteLength;
+      }
+
+      await googleFetch<void>(
+        env,
+        `${UPLOAD_API_BASE}/watermarks/set?uploadType=multipart&channelId=${encodeURIComponent(context.channelId)}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": `multipart/related; boundary=${boundary}`,
+          },
+          body: combined,
+        },
+      );
+
+      return { channelId: context.channelId, set: true };
+    },
+  });
+
+export const createUnsetWatermarkTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_UNSET_WATERMARK",
+    description: "Remove the channel watermark overlay.",
+    inputSchema: z.object({
+      channelId: z.string(),
+    }),
+    outputSchema: z.object({ channelId: z.string(), removed: z.boolean() }),
+    execute: async ({ context }) => {
+      await dataApi(env, "/watermarks/unset", {
+        method: "POST",
+        params: { channelId: context.channelId },
+      });
+      return { channelId: context.channelId, removed: true };
     },
   });

--- a/youtube-channel-admin/server/tools/channel.ts
+++ b/youtube-channel-admin/server/tools/channel.ts
@@ -119,3 +119,105 @@ export const createUpdateChannelTool = (env: Env) =>
       };
     },
   });
+
+export const createListVideoCategoryTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_LIST_VIDEO_CATEGORIES",
+    description:
+      "List available YouTube video categories for a region. Useful for getting categoryId values for UPDATE_VIDEO.",
+    inputSchema: z.object({
+      regionCode: z
+        .string()
+        .length(2)
+        .default("BR")
+        .describe("ISO 3166-1 alpha-2 country code"),
+    }),
+    outputSchema: z.object({
+      categories: z.array(
+        z.object({
+          id: z.string(),
+          title: z.string(),
+          assignable: z.boolean(),
+        }),
+      ),
+    }),
+    execute: async ({ context }) => {
+      const data = await dataApi<{
+        items?: Array<{
+          id: string;
+          snippet?: { title?: string; assignable?: boolean };
+        }>;
+      }>(env, "/videoCategories", {
+        params: {
+          part: "snippet",
+          regionCode: context.regionCode,
+          hl: "pt_BR",
+        },
+      });
+
+      const categories = (data.items ?? [])
+        .filter((item) => item.snippet?.assignable === true)
+        .map((item) => ({
+          id: item.id,
+          title: item.snippet?.title ?? "",
+          assignable: true,
+        }))
+        .sort((a, b) => a.id.localeCompare(b.id));
+
+      return { categories };
+    },
+  });
+
+export const createListSubscribersTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_LIST_SUBSCRIBERS",
+    description:
+      "List the channel's most recent subscribers. Note: the YouTube API only returns subscribers who have made their subscriptions public.",
+    inputSchema: z.object({
+      maxResults: z.coerce.number().int().min(1).max(1000).default(50),
+      pageToken: z.string().optional(),
+    }),
+    outputSchema: z.object({
+      subscribers: z.array(
+        z.object({
+          subscriberChannelId: z.string(),
+          subscriberTitle: z.string().optional(),
+          subscriberThumbnailUrl: z.string().optional(),
+          subscribedAt: z.string().optional(),
+        }),
+      ),
+      nextPageToken: z.string().optional(),
+    }),
+    execute: async ({ context }) => {
+      const data = await dataApi<{
+        items?: Array<{
+          snippet?: {
+            subscriberSnippet?: {
+              title?: string;
+              thumbnails?: { default?: { url?: string } };
+            };
+            publishedAt?: string;
+            resourceId?: { channelId?: string };
+          };
+        }>;
+        nextPageToken?: string;
+      }>(env, "/subscriptions", {
+        params: {
+          part: "snippet",
+          mySubscribers: true,
+          maxResults: context.maxResults,
+          pageToken: context.pageToken,
+        },
+      });
+
+      const subscribers = (data.items ?? []).map((item) => ({
+        subscriberChannelId: item.snippet?.resourceId?.channelId ?? "",
+        subscriberTitle: item.snippet?.subscriberSnippet?.title,
+        subscriberThumbnailUrl:
+          item.snippet?.subscriberSnippet?.thumbnails?.default?.url,
+        subscribedAt: item.snippet?.publishedAt,
+      }));
+
+      return { subscribers, nextPageToken: data.nextPageToken };
+    },
+  });

--- a/youtube-channel-admin/server/tools/comments.ts
+++ b/youtube-channel-admin/server/tools/comments.ts
@@ -201,3 +201,55 @@ export const createModerateCommentTool = (env: Env) =>
       };
     },
   });
+
+export const createUpdateCommentTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_UPDATE_COMMENT",
+    description:
+      "Edit the text of a comment you posted (top-level or reply). Only the comment author can edit.",
+    inputSchema: z.object({
+      commentId: z.string(),
+      text: z.string().min(1).max(10000),
+    }),
+    outputSchema: z.object({
+      commentId: z.string(),
+      text: z.string(),
+      updatedAt: z.string().optional(),
+    }),
+    execute: async ({ context }) => {
+      const result = await dataApi<RawComment>(env, "/comments", {
+        method: "PUT",
+        params: { part: "snippet" },
+        body: {
+          id: context.commentId,
+          snippet: { textOriginal: context.text },
+        },
+      });
+      return {
+        commentId: result.id,
+        text: result.snippet?.textOriginal ?? context.text,
+        updatedAt: result.snippet?.updatedAt,
+      };
+    },
+  });
+
+export const createDeleteCommentTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_DELETE_COMMENT",
+    description:
+      "Delete a comment or reply. Only the comment author or the video owner can delete.",
+    inputSchema: z.object({
+      commentId: z.string(),
+    }),
+    outputSchema: z.object({
+      commentId: z.string(),
+      deleted: z.boolean(),
+    }),
+    execute: async ({ context }) => {
+      await dataApi<undefined>(env, "/comments", {
+        method: "DELETE",
+        params: { id: context.commentId },
+      });
+      return { commentId: context.commentId, deleted: true };
+    },
+  });

--- a/youtube-channel-admin/server/tools/index.ts
+++ b/youtube-channel-admin/server/tools/index.ts
@@ -1,25 +1,56 @@
 import { createQueryAnalyticsTool } from "./analytics.ts";
 import {
+  createDeleteCaptionTool,
   createGetMyVideoTranscriptTool,
   createListMyCaptionsTool,
+  createUpdateCaptionTool,
   createUploadCaptionTool,
 } from "./captions.ts";
-import { createGetMyChannelTool, createUpdateChannelTool } from "./channel.ts";
 import {
-  createAddToPlaylistTool,
-  createCreatePlaylistTool,
-} from "./playlists.ts";
+  createGetMyChannelTool,
+  createListSubscribersTool,
+  createListVideoCategoryTool,
+  createUpdateChannelTool,
+} from "./channel.ts";
 import {
+  createDeleteCommentTool,
   createCommentOnVideoTool,
   createListCommentsTool,
   createModerateCommentTool,
   createReplyCommentTool,
+  createUpdateCommentTool,
 } from "./comments.ts";
 import { createDashboardTool } from "./dashboard.ts";
+import {
+  createBindBroadcastTool,
+  createCreateBroadcastTool,
+  createCreateLiveStreamTool,
+  createDeleteBroadcastTool,
+  createDeleteLiveChatMessageTool,
+  createDeleteLiveStreamTool,
+  createListBroadcastsTool,
+  createListLiveChatMessagesTool,
+  createListLiveStreamsTool,
+  createSendLiveChatMessageTool,
+  createTransitionBroadcastTool,
+  createUpdateBroadcastTool,
+} from "./live.ts";
+import {
+  createAddToPlaylistTool,
+  createCreatePlaylistTool,
+  createDeletePlaylistTool,
+  createListPlaylistItemsTool,
+  createListPlaylistsTool,
+  createRemoveFromPlaylistTool,
+  createUpdatePlaylistTool,
+} from "./playlists.ts";
+import { createSearchMyVideosTool } from "./search.ts";
 import { createUploadVideoTool } from "./upload.ts";
 import {
+  createDeleteVideoTool,
   createGetVideosTool,
   createListMyVideosTool,
+  createRateVideoTool,
   createSetThumbnailTool,
   createUpdateVideoTool,
 } from "./videos.ts";
@@ -33,24 +64,52 @@ export const tools = [
   // channel
   createGetMyChannelTool,
   createUpdateChannelTool,
+  createListVideoCategoryTool,
+  createListSubscribersTool,
+  // search
+  createSearchMyVideosTool,
   // videos
   createListMyVideosTool,
   createGetVideosTool,
   createUpdateVideoTool,
   createSetThumbnailTool,
   createUploadVideoTool,
+  createDeleteVideoTool,
+  createRateVideoTool,
   // captions
   createListMyCaptionsTool,
   createGetMyVideoTranscriptTool,
   createUploadCaptionTool,
+  createUpdateCaptionTool,
+  createDeleteCaptionTool,
   // playlists
+  createListPlaylistsTool,
   createCreatePlaylistTool,
+  createUpdatePlaylistTool,
+  createDeletePlaylistTool,
   createAddToPlaylistTool,
+  createListPlaylistItemsTool,
+  createRemoveFromPlaylistTool,
   // comments
   createListCommentsTool,
-  createReplyCommentTool,
   createCommentOnVideoTool,
+  createReplyCommentTool,
+  createUpdateCommentTool,
+  createDeleteCommentTool,
   createModerateCommentTool,
+  // live streaming
+  createListBroadcastsTool,
+  createCreateBroadcastTool,
+  createUpdateBroadcastTool,
+  createDeleteBroadcastTool,
+  createBindBroadcastTool,
+  createTransitionBroadcastTool,
+  createListLiveStreamsTool,
+  createCreateLiveStreamTool,
+  createDeleteLiveStreamTool,
+  createListLiveChatMessagesTool,
+  createSendLiveChatMessageTool,
+  createDeleteLiveChatMessageTool,
   // analytics
   createQueryAnalyticsTool,
   // ui

--- a/youtube-channel-admin/server/tools/index.ts
+++ b/youtube-channel-admin/server/tools/index.ts
@@ -10,8 +10,16 @@ import {
   createGetMyChannelTool,
   createListSubscribersTool,
   createListVideoCategoryTool,
+  createSetWatermarkTool,
+  createUnsetWatermarkTool,
   createUpdateChannelTool,
 } from "./channel.ts";
+import {
+  createCreateChannelSectionTool,
+  createDeleteChannelSectionTool,
+  createListChannelSectionsTool,
+  createUpdateChannelSectionTool,
+} from "./channel-sections.ts";
 import {
   createDeleteCommentTool,
   createCommentOnVideoTool,
@@ -22,6 +30,8 @@ import {
 } from "./comments.ts";
 import { createDashboardTool } from "./dashboard.ts";
 import {
+  createAddLiveChatModeratorTool,
+  createBanLiveChatUserTool,
   createBindBroadcastTool,
   createCreateBroadcastTool,
   createCreateLiveStreamTool,
@@ -29,11 +39,16 @@ import {
   createDeleteLiveChatMessageTool,
   createDeleteLiveStreamTool,
   createListBroadcastsTool,
+  createListLiveChatBansTool,
   createListLiveChatMessagesTool,
+  createListLiveChatModeratorsTool,
   createListLiveStreamsTool,
+  createRemoveLiveChatModeratorTool,
   createSendLiveChatMessageTool,
   createTransitionBroadcastTool,
+  createUnbanLiveChatUserTool,
   createUpdateBroadcastTool,
+  createUpdateLiveStreamTool,
 } from "./live.ts";
 import {
   createAddToPlaylistTool,
@@ -56,6 +71,7 @@ import {
 } from "./videos.ts";
 import {
   createAlertsWidgetTool,
+  createLivesWidgetTool,
   createPerformanceWidgetTool,
   createTopVideosWidgetTool,
 } from "./widgets.ts";
@@ -66,6 +82,13 @@ export const tools = [
   createUpdateChannelTool,
   createListVideoCategoryTool,
   createListSubscribersTool,
+  createSetWatermarkTool,
+  createUnsetWatermarkTool,
+  // channel sections
+  createListChannelSectionsTool,
+  createCreateChannelSectionTool,
+  createUpdateChannelSectionTool,
+  createDeleteChannelSectionTool,
   // search
   createSearchMyVideosTool,
   // videos
@@ -106,10 +129,17 @@ export const tools = [
   createTransitionBroadcastTool,
   createListLiveStreamsTool,
   createCreateLiveStreamTool,
+  createUpdateLiveStreamTool,
   createDeleteLiveStreamTool,
   createListLiveChatMessagesTool,
   createSendLiveChatMessageTool,
   createDeleteLiveChatMessageTool,
+  createListLiveChatBansTool,
+  createBanLiveChatUserTool,
+  createUnbanLiveChatUserTool,
+  createListLiveChatModeratorsTool,
+  createAddLiveChatModeratorTool,
+  createRemoveLiveChatModeratorTool,
   // analytics
   createQueryAnalyticsTool,
   // ui
@@ -117,4 +147,5 @@ export const tools = [
   createTopVideosWidgetTool,
   createPerformanceWidgetTool,
   createAlertsWidgetTool,
+  createLivesWidgetTool,
 ];

--- a/youtube-channel-admin/server/tools/live.ts
+++ b/youtube-channel-admin/server/tools/live.ts
@@ -678,3 +678,347 @@ export const createDeleteLiveChatMessageTool = (env: Env) =>
       return { messageId: context.messageId, deleted: true };
     },
   });
+
+// ---------------------------------------------------------------------------
+// Shared response interfaces (bans & moderators)
+// ---------------------------------------------------------------------------
+
+interface LiveChatBanResponse {
+  items?: LiveChatBanItem[];
+  nextPageToken?: string;
+}
+
+interface LiveChatBanItem {
+  id: string;
+  snippet?: {
+    liveChatId?: string;
+    type?: string; // "permanent" | "temporary"
+    banDurationSeconds?: number;
+    bannedUserDetails?: {
+      channelId?: string;
+      displayName?: string;
+      channelUrl?: string;
+    };
+  };
+}
+
+interface LiveChatModeratorResponse {
+  items?: LiveChatModeratorItem[];
+  nextPageToken?: string;
+}
+
+interface LiveChatModeratorItem {
+  id: string;
+  snippet?: {
+    liveChatId?: string;
+    moderatorDetails?: {
+      channelId?: string;
+      displayName?: string;
+      channelUrl?: string;
+    };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 13. createUpdateLiveStreamTool
+// ---------------------------------------------------------------------------
+
+export const createUpdateLiveStreamTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_UPDATE_LIVE_STREAM",
+    description: "Update a live stream's title, resolution or frame rate.",
+    inputSchema: z.object({
+      streamId: z.string(),
+      title: z.string().max(128).optional(),
+      resolution: z
+        .enum(["1080p", "720p", "480p", "360p", "240p", "variable"])
+        .optional(),
+      frameRate: z.enum(["30fps", "60fps", "variable"]).optional(),
+    }),
+    outputSchema: z.object({
+      streamId: z.string(),
+      title: z.string(),
+      streamStatus: z.string(),
+    }),
+    execute: async ({ context }) => {
+      const current = await dataApi<LiveStreamResponse>(env, "/liveStreams", {
+        params: {
+          part: "snippet,cdn,status",
+          id: context.streamId,
+        },
+      });
+      const existing = current.items?.[0];
+      if (!existing) {
+        throw new Error(`Live stream ${context.streamId} not found.`);
+      }
+
+      const snippet = {
+        ...existing.snippet,
+        title: context.title ?? existing.snippet?.title,
+      };
+      const cdn = {
+        ...existing.cdn,
+        resolution: context.resolution ?? existing.cdn?.resolution,
+        frameRate: context.frameRate ?? existing.cdn?.frameRate,
+      };
+
+      const updated = await dataApi<LiveStreamItem>(env, "/liveStreams", {
+        method: "PUT",
+        params: { part: "snippet,cdn" },
+        body: {
+          id: context.streamId,
+          snippet,
+          cdn,
+        },
+      });
+
+      return {
+        streamId: context.streamId,
+        title: updated.snippet?.title ?? "",
+        streamStatus: updated.status?.streamStatus ?? "",
+      };
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// 14. createListLiveChatBansTool
+// ---------------------------------------------------------------------------
+
+export const createListLiveChatBansTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_LIST_LIVE_CHAT_BANS",
+    description: "List users banned from a live chat.",
+    inputSchema: z.object({
+      liveChatId: z.string(),
+      maxResults: z.coerce.number().int().min(1).max(1000).default(500),
+      pageToken: z.string().optional(),
+    }),
+    outputSchema: z.object({
+      bans: z.array(
+        z.object({
+          banId: z.string(),
+          channelId: z.string(),
+          displayName: z.string(),
+          type: z.string(),
+          banDurationSeconds: z.number().optional(),
+          liveChatId: z.string(),
+        }),
+      ),
+      nextPageToken: z.string().optional(),
+    }),
+    execute: async ({ context }) => {
+      const data = await dataApi<LiveChatBanResponse>(env, "/liveChat/bans", {
+        params: {
+          part: "id,snippet",
+          liveChatId: context.liveChatId,
+          maxResults: context.maxResults,
+          pageToken: context.pageToken,
+        },
+      });
+      return {
+        bans: (data.items ?? []).map((item) => ({
+          banId: item.id,
+          channelId: item.snippet?.bannedUserDetails?.channelId ?? "",
+          displayName: item.snippet?.bannedUserDetails?.displayName ?? "",
+          type: item.snippet?.type ?? "",
+          banDurationSeconds: item.snippet?.banDurationSeconds,
+          liveChatId: item.snippet?.liveChatId ?? "",
+        })),
+        nextPageToken: data.nextPageToken,
+      };
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// 15. createBanLiveChatUserTool
+// ---------------------------------------------------------------------------
+
+export const createBanLiveChatUserTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_BAN_LIVE_CHAT_USER",
+    description:
+      "Ban a user from a live chat. Use type 'permanent' or 'temporary' (with banDurationSeconds).",
+    inputSchema: z.object({
+      liveChatId: z.string(),
+      channelId: z.string().describe("Channel ID of the user to ban"),
+      type: z.enum(["permanent", "temporary"]).default("permanent"),
+      banDurationSeconds: z
+        .number()
+        .int()
+        .min(300)
+        .max(86400)
+        .optional()
+        .describe("Required if type is temporary (300–86400 seconds)"),
+    }),
+    outputSchema: z.object({
+      banId: z.string(),
+      channelId: z.string(),
+      type: z.string(),
+      banDurationSeconds: z.number().optional(),
+    }),
+    execute: async ({ context }) => {
+      const item = await dataApi<LiveChatBanItem>(env, "/liveChat/bans", {
+        method: "POST",
+        params: { part: "snippet" },
+        body: {
+          snippet: {
+            liveChatId: context.liveChatId,
+            type: context.type,
+            banDurationSeconds: context.banDurationSeconds,
+            bannedUserDetails: { channelId: context.channelId },
+          },
+        },
+      });
+      return {
+        banId: item.id,
+        channelId:
+          item.snippet?.bannedUserDetails?.channelId ?? context.channelId,
+        type: item.snippet?.type ?? context.type,
+        banDurationSeconds: item.snippet?.banDurationSeconds,
+      };
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// 16. createUnbanLiveChatUserTool
+// ---------------------------------------------------------------------------
+
+export const createUnbanLiveChatUserTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_UNBAN_LIVE_CHAT_USER",
+    description: "Remove a ban from a live chat user.",
+    inputSchema: z.object({
+      banId: z.string(),
+    }),
+    outputSchema: z.object({
+      banId: z.string(),
+      deleted: z.boolean(),
+    }),
+    execute: async ({ context }) => {
+      await dataApi(env, "/liveChat/bans", {
+        method: "DELETE",
+        params: { id: context.banId },
+      });
+      return { banId: context.banId, deleted: true };
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// 17. createListLiveChatModeratorsTool
+// ---------------------------------------------------------------------------
+
+export const createListLiveChatModeratorsTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_LIST_LIVE_CHAT_MODERATORS",
+    description: "List moderators of a live chat.",
+    inputSchema: z.object({
+      liveChatId: z.string(),
+      maxResults: z.coerce.number().int().min(1).max(1000).default(250),
+      pageToken: z.string().optional(),
+    }),
+    outputSchema: z.object({
+      moderators: z.array(
+        z.object({
+          moderatorId: z.string(),
+          channelId: z.string(),
+          displayName: z.string(),
+          channelUrl: z.string().optional(),
+          liveChatId: z.string(),
+        }),
+      ),
+      nextPageToken: z.string().optional(),
+    }),
+    execute: async ({ context }) => {
+      const data = await dataApi<LiveChatModeratorResponse>(
+        env,
+        "/liveChat/moderators",
+        {
+          params: {
+            part: "id,snippet",
+            liveChatId: context.liveChatId,
+            maxResults: context.maxResults,
+            pageToken: context.pageToken,
+          },
+        },
+      );
+      return {
+        moderators: (data.items ?? []).map((item) => ({
+          moderatorId: item.id,
+          channelId: item.snippet?.moderatorDetails?.channelId ?? "",
+          displayName: item.snippet?.moderatorDetails?.displayName ?? "",
+          channelUrl: item.snippet?.moderatorDetails?.channelUrl,
+          liveChatId: item.snippet?.liveChatId ?? "",
+        })),
+        nextPageToken: data.nextPageToken,
+      };
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// 18. createAddLiveChatModeratorTool
+// ---------------------------------------------------------------------------
+
+export const createAddLiveChatModeratorTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_ADD_LIVE_CHAT_MODERATOR",
+    description: "Add a moderator to a live chat.",
+    inputSchema: z.object({
+      liveChatId: z.string(),
+      channelId: z
+        .string()
+        .describe("Channel ID of the user to make moderator"),
+    }),
+    outputSchema: z.object({
+      moderatorId: z.string(),
+      channelId: z.string(),
+      displayName: z.string(),
+      liveChatId: z.string(),
+    }),
+    execute: async ({ context }) => {
+      const item = await dataApi<LiveChatModeratorItem>(
+        env,
+        "/liveChat/moderators",
+        {
+          method: "POST",
+          params: { part: "snippet" },
+          body: {
+            snippet: {
+              liveChatId: context.liveChatId,
+              moderatorDetails: { channelId: context.channelId },
+            },
+          },
+        },
+      );
+      return {
+        moderatorId: item.id,
+        channelId:
+          item.snippet?.moderatorDetails?.channelId ?? context.channelId,
+        displayName: item.snippet?.moderatorDetails?.displayName ?? "",
+        liveChatId: item.snippet?.liveChatId ?? context.liveChatId,
+      };
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// 19. createRemoveLiveChatModeratorTool
+// ---------------------------------------------------------------------------
+
+export const createRemoveLiveChatModeratorTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_REMOVE_LIVE_CHAT_MODERATOR",
+    description: "Remove a moderator from a live chat.",
+    inputSchema: z.object({
+      moderatorId: z.string(),
+    }),
+    outputSchema: z.object({
+      moderatorId: z.string(),
+      deleted: z.boolean(),
+    }),
+    execute: async ({ context }) => {
+      await dataApi(env, "/liveChat/moderators", {
+        method: "DELETE",
+        params: { id: context.moderatorId },
+      });
+      return { moderatorId: context.moderatorId, deleted: true };
+    },
+  });

--- a/youtube-channel-admin/server/tools/live.ts
+++ b/youtube-channel-admin/server/tools/live.ts
@@ -1,0 +1,680 @@
+import { createPrivateTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { dataApi } from "../lib/yt-client.ts";
+import type { Env } from "../types/env.ts";
+
+// ---------------------------------------------------------------------------
+// Shared response interfaces
+// ---------------------------------------------------------------------------
+
+interface BroadcastResponse {
+  items?: BroadcastItem[];
+  nextPageToken?: string;
+}
+
+interface BroadcastItem {
+  id: string;
+  snippet?: {
+    title?: string;
+    description?: string;
+    scheduledStartTime?: string;
+    scheduledEndTime?: string;
+    actualStartTime?: string;
+    actualEndTime?: string;
+    liveChatId?: string;
+    thumbnails?: {
+      high?: { url?: string };
+      medium?: { url?: string };
+      default?: { url?: string };
+    };
+  };
+  status?: {
+    lifeCycleStatus?: string;
+    privacyStatus?: string;
+  };
+  contentDetails?: {
+    boundStreamId?: string;
+    enableAutoStart?: boolean;
+    enableAutoStop?: boolean;
+    enableDvr?: boolean;
+    enableEmbed?: boolean;
+    latencyPreference?: string;
+    monitorStream?: { enableMonitorStream?: boolean };
+    videoId?: string;
+  };
+}
+
+interface LiveStreamResponse {
+  items?: LiveStreamItem[];
+  nextPageToken?: string;
+}
+
+interface LiveStreamItem {
+  id: string;
+  snippet?: {
+    title?: string;
+    description?: string;
+  };
+  cdn?: {
+    ingestionType?: string;
+    resolution?: string;
+    frameRate?: string;
+    ingestionInfo?: {
+      streamName?: string;
+      ingestionAddress?: string;
+      backupIngestionAddress?: string;
+    };
+  };
+  status?: {
+    streamStatus?: string;
+  };
+}
+
+interface LiveChatMessagesResponse {
+  items?: LiveChatMessageItem[];
+  nextPageToken?: string;
+  pollingIntervalMillis?: number;
+}
+
+interface LiveChatMessageItem {
+  id: string;
+  snippet?: {
+    type?: string;
+    displayMessage?: string;
+    textMessageDetails?: { messageText?: string };
+    publishedAt?: string;
+  };
+  authorDetails?: {
+    channelId?: string;
+    displayName?: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: map a BroadcastItem to the standard output shape
+// ---------------------------------------------------------------------------
+
+function mapBroadcast(item: BroadcastItem) {
+  const thumb =
+    item.snippet?.thumbnails?.high?.url ??
+    item.snippet?.thumbnails?.medium?.url ??
+    item.snippet?.thumbnails?.default?.url;
+  return {
+    broadcastId: item.id,
+    title: item.snippet?.title ?? "",
+    scheduledStartTime: item.snippet?.scheduledStartTime,
+    scheduledEndTime: item.snippet?.scheduledEndTime,
+    actualStartTime: item.snippet?.actualStartTime,
+    actualEndTime: item.snippet?.actualEndTime,
+    lifeCycleStatus: item.status?.lifeCycleStatus ?? "",
+    privacyStatus: item.status?.privacyStatus ?? "",
+    liveChatId: item.snippet?.liveChatId,
+    thumbnailUrl: thumb,
+    watchUrl: `https://www.youtube.com/watch?v=${item.id}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. createListBroadcastsTool
+// ---------------------------------------------------------------------------
+
+export const createListBroadcastsTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_LIST_BROADCASTS",
+    description:
+      "List live broadcasts (scheduled, live, or completed). Use broadcastStatus to filter.",
+    inputSchema: z.object({
+      broadcastStatus: z
+        .enum(["all", "active", "completed", "upcoming"])
+        .default("upcoming"),
+      maxResults: z.coerce.number().int().min(1).max(50).default(25),
+      pageToken: z.string().optional(),
+    }),
+    outputSchema: z.object({
+      broadcasts: z.array(
+        z.object({
+          broadcastId: z.string(),
+          title: z.string(),
+          scheduledStartTime: z.string().optional(),
+          scheduledEndTime: z.string().optional(),
+          actualStartTime: z.string().optional(),
+          actualEndTime: z.string().optional(),
+          lifeCycleStatus: z.string(),
+          privacyStatus: z.string(),
+          liveChatId: z.string().optional(),
+          thumbnailUrl: z.string().optional(),
+          watchUrl: z.string(),
+        }),
+      ),
+      nextPageToken: z.string().optional(),
+    }),
+    execute: async ({ context }) => {
+      const data = await dataApi<BroadcastResponse>(env, "/liveBroadcasts", {
+        params: {
+          part: "snippet,status,contentDetails",
+          broadcastStatus: context.broadcastStatus,
+          maxResults: context.maxResults,
+          pageToken: context.pageToken,
+        },
+      });
+      return {
+        broadcasts: (data.items ?? []).map(mapBroadcast),
+        nextPageToken: data.nextPageToken,
+      };
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// 2. createCreateBroadcastTool
+// ---------------------------------------------------------------------------
+
+export const createCreateBroadcastTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_CREATE_BROADCAST",
+    description:
+      "Create a live broadcast or schedule a Premiere. For a Premiere: upload the video first, then bind with YOUTUBE_ADMIN_BIND_BROADCAST using videoId. For a live stream: create a liveStream too, then bind with streamId.",
+    inputSchema: z.object({
+      title: z.string().max(100),
+      description: z.string().max(5000).optional(),
+      scheduledStartTime: z
+        .string()
+        .describe("ISO 8601 datetime (UTC) for when the broadcast goes live"),
+      scheduledEndTime: z.string().optional(),
+      privacyStatus: z
+        .enum(["public", "unlisted", "private"])
+        .default("public"),
+      enableAutoStart: z.boolean().default(false),
+      enableAutoStop: z.boolean().default(false),
+      enableDvr: z.boolean().default(true),
+      enableEmbed: z.boolean().default(true),
+      latencyPreference: z
+        .enum(["normal", "low", "ultraLow"])
+        .default("normal"),
+    }),
+    outputSchema: z.object({
+      broadcastId: z.string(),
+      title: z.string(),
+      scheduledStartTime: z.string(),
+      lifeCycleStatus: z.string(),
+      privacyStatus: z.string(),
+      liveChatId: z.string().optional(),
+      watchUrl: z.string(),
+    }),
+    execute: async ({ context }) => {
+      const item = await dataApi<BroadcastItem>(env, "/liveBroadcasts", {
+        method: "POST",
+        params: { part: "snippet,status,contentDetails" },
+        body: {
+          snippet: {
+            title: context.title,
+            description: context.description,
+            scheduledStartTime: context.scheduledStartTime,
+            scheduledEndTime: context.scheduledEndTime,
+          },
+          status: {
+            privacyStatus: context.privacyStatus,
+          },
+          contentDetails: {
+            enableAutoStart: context.enableAutoStart,
+            enableAutoStop: context.enableAutoStop,
+            enableDvr: context.enableDvr,
+            enableEmbed: context.enableEmbed,
+            latencyPreference: context.latencyPreference,
+            monitorStream: { enableMonitorStream: false },
+          },
+        },
+      });
+      return {
+        broadcastId: item.id,
+        title: item.snippet?.title ?? context.title,
+        scheduledStartTime:
+          item.snippet?.scheduledStartTime ?? context.scheduledStartTime,
+        lifeCycleStatus: item.status?.lifeCycleStatus ?? "",
+        privacyStatus: item.status?.privacyStatus ?? context.privacyStatus,
+        liveChatId: item.snippet?.liveChatId,
+        watchUrl: `https://www.youtube.com/watch?v=${item.id}`,
+      };
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// 3. createUpdateBroadcastTool
+// ---------------------------------------------------------------------------
+
+export const createUpdateBroadcastTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_UPDATE_BROADCAST",
+    description:
+      "Update a broadcast's title, description, scheduled time or privacy.",
+    inputSchema: z.object({
+      broadcastId: z.string(),
+      title: z.string().max(100).optional(),
+      description: z.string().max(5000).optional(),
+      scheduledStartTime: z.string().optional(),
+      scheduledEndTime: z.string().optional(),
+      privacyStatus: z.enum(["public", "unlisted", "private"]).optional(),
+    }),
+    outputSchema: z.object({
+      broadcastId: z.string(),
+      title: z.string(),
+      scheduledStartTime: z.string(),
+      lifeCycleStatus: z.string(),
+      privacyStatus: z.string(),
+      liveChatId: z.string().optional(),
+      watchUrl: z.string(),
+    }),
+    execute: async ({ context }) => {
+      const current = await dataApi<BroadcastResponse>(env, "/liveBroadcasts", {
+        params: {
+          part: "snippet,status,contentDetails",
+          id: context.broadcastId,
+        },
+      });
+      const existing = current.items?.[0];
+      if (!existing) {
+        throw new Error(`Broadcast ${context.broadcastId} not found.`);
+      }
+
+      const snippet = {
+        ...existing.snippet,
+        title: context.title ?? existing.snippet?.title,
+        description: context.description ?? existing.snippet?.description,
+        scheduledStartTime:
+          context.scheduledStartTime ?? existing.snippet?.scheduledStartTime,
+        scheduledEndTime:
+          context.scheduledEndTime ?? existing.snippet?.scheduledEndTime,
+      };
+      const status = {
+        ...existing.status,
+        privacyStatus: context.privacyStatus ?? existing.status?.privacyStatus,
+      };
+
+      const updated = await dataApi<BroadcastItem>(env, "/liveBroadcasts", {
+        method: "PUT",
+        params: { part: "snippet,status,contentDetails" },
+        body: {
+          id: context.broadcastId,
+          snippet,
+          status,
+          contentDetails: existing.contentDetails,
+        },
+      });
+
+      return {
+        broadcastId: context.broadcastId,
+        title: updated.snippet?.title ?? "",
+        scheduledStartTime: updated.snippet?.scheduledStartTime ?? "",
+        lifeCycleStatus: updated.status?.lifeCycleStatus ?? "",
+        privacyStatus: updated.status?.privacyStatus ?? "",
+        liveChatId: updated.snippet?.liveChatId,
+        watchUrl: `https://www.youtube.com/watch?v=${context.broadcastId}`,
+      };
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// 4. createDeleteBroadcastTool
+// ---------------------------------------------------------------------------
+
+export const createDeleteBroadcastTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_DELETE_BROADCAST",
+    description:
+      "Delete a broadcast. Only broadcasts in 'complete' or 'created' status can be deleted.",
+    inputSchema: z.object({
+      broadcastId: z.string(),
+    }),
+    outputSchema: z.object({
+      broadcastId: z.string(),
+      deleted: z.boolean(),
+    }),
+    execute: async ({ context }) => {
+      await dataApi(env, "/liveBroadcasts", {
+        method: "DELETE",
+        params: { id: context.broadcastId },
+      });
+      return { broadcastId: context.broadcastId, deleted: true };
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// 5. createBindBroadcastTool
+// ---------------------------------------------------------------------------
+
+export const createBindBroadcastTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_BIND_BROADCAST",
+    description:
+      "Bind a broadcast to a live stream (for live streaming) OR to an existing video (for Premieres). Pass streamId for live, videoId for Premiere.",
+    inputSchema: z.object({
+      broadcastId: z.string(),
+      streamId: z
+        .string()
+        .optional()
+        .describe("liveStream id — for live broadcasts"),
+      videoId: z
+        .string()
+        .optional()
+        .describe("existing video id — for Premieres"),
+    }),
+    outputSchema: z.object({
+      broadcastId: z.string(),
+      boundStreamId: z.string().optional(),
+      boundVideoId: z.string().optional(),
+    }),
+    execute: async ({ context }) => {
+      const result = await dataApi<BroadcastItem>(env, "/liveBroadcasts/bind", {
+        method: "POST",
+        params: {
+          id: context.broadcastId,
+          part: "id,contentDetails",
+          ...(context.streamId && { streamId: context.streamId }),
+          ...(context.videoId && { videoId: context.videoId }),
+        },
+      });
+      return {
+        broadcastId: context.broadcastId,
+        boundStreamId: result.contentDetails?.boundStreamId,
+        boundVideoId: result.contentDetails?.videoId,
+      };
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// 6. createTransitionBroadcastTool
+// ---------------------------------------------------------------------------
+
+export const createTransitionBroadcastTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_TRANSITION_BROADCAST",
+    description:
+      "Transition a broadcast: 'testing' → test mode, 'live' → go live, 'complete' → end broadcast.",
+    inputSchema: z.object({
+      broadcastId: z.string(),
+      broadcastStatus: z.enum(["testing", "live", "complete"]),
+    }),
+    outputSchema: z.object({
+      broadcastId: z.string(),
+      lifeCycleStatus: z.string(),
+    }),
+    execute: async ({ context }) => {
+      const result = await dataApi<BroadcastItem>(
+        env,
+        "/liveBroadcasts/transition",
+        {
+          method: "POST",
+          params: {
+            id: context.broadcastId,
+            broadcastStatus: context.broadcastStatus,
+            part: "id,status",
+          },
+        },
+      );
+      return {
+        broadcastId: context.broadcastId,
+        lifeCycleStatus: result.status?.lifeCycleStatus ?? "",
+      };
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// 7. createListLiveStreamsTool
+// ---------------------------------------------------------------------------
+
+export const createListLiveStreamsTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_LIST_LIVE_STREAMS",
+    description:
+      "List the channel's live stream ingestion points (RTMP endpoints).",
+    inputSchema: z.object({
+      maxResults: z.coerce.number().int().min(1).max(50).default(25),
+      pageToken: z.string().optional(),
+    }),
+    outputSchema: z.object({
+      streams: z.array(
+        z.object({
+          streamId: z.string(),
+          title: z.string(),
+          streamStatus: z.string(),
+          ingestionType: z.string().optional(),
+          ingestionAddress: z.string().optional(),
+          streamKey: z.string().optional(),
+          backupIngestionAddress: z.string().optional(),
+          resolution: z.string().optional(),
+          frameRate: z.string().optional(),
+        }),
+      ),
+      nextPageToken: z.string().optional(),
+    }),
+    execute: async ({ context }) => {
+      const data = await dataApi<LiveStreamResponse>(env, "/liveStreams", {
+        params: {
+          part: "snippet,cdn,status",
+          mine: true,
+          maxResults: context.maxResults,
+          pageToken: context.pageToken,
+        },
+      });
+      return {
+        streams: (data.items ?? []).map((item) => ({
+          streamId: item.id,
+          title: item.snippet?.title ?? "",
+          streamStatus: item.status?.streamStatus ?? "",
+          ingestionType: item.cdn?.ingestionType,
+          ingestionAddress: item.cdn?.ingestionInfo?.ingestionAddress,
+          streamKey: item.cdn?.ingestionInfo?.streamName,
+          backupIngestionAddress:
+            item.cdn?.ingestionInfo?.backupIngestionAddress,
+          resolution: item.cdn?.resolution,
+          frameRate: item.cdn?.frameRate,
+        })),
+        nextPageToken: data.nextPageToken,
+      };
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// 8. createCreateLiveStreamTool
+// ---------------------------------------------------------------------------
+
+export const createCreateLiveStreamTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_CREATE_LIVE_STREAM",
+    description:
+      "Create a live stream ingestion point. Returns the RTMP URL and stream key for your encoder (OBS, etc.). Bind it to a broadcast with YOUTUBE_ADMIN_BIND_BROADCAST.",
+    inputSchema: z.object({
+      title: z.string().max(128),
+      description: z.string().optional(),
+      resolution: z
+        .enum(["1080p", "720p", "480p", "360p", "240p", "variable"])
+        .default("variable"),
+      frameRate: z.enum(["30fps", "60fps", "variable"]).default("variable"),
+      ingestionType: z.enum(["rtmp", "dash", "webrtc", "hls"]).default("rtmp"),
+    }),
+    outputSchema: z.object({
+      streamId: z.string(),
+      title: z.string(),
+      ingestionAddress: z.string(),
+      streamKey: z.string(),
+      backupIngestionAddress: z.string().optional(),
+      resolution: z.string(),
+      frameRate: z.string(),
+    }),
+    execute: async ({ context }) => {
+      const item = await dataApi<LiveStreamItem>(env, "/liveStreams", {
+        method: "POST",
+        params: { part: "snippet,cdn" },
+        body: {
+          snippet: {
+            title: context.title,
+            description: context.description,
+          },
+          cdn: {
+            ingestionType: context.ingestionType,
+            resolution: context.resolution,
+            frameRate: context.frameRate,
+          },
+        },
+      });
+      return {
+        streamId: item.id,
+        title: item.snippet?.title ?? context.title,
+        ingestionAddress: item.cdn?.ingestionInfo?.ingestionAddress ?? "",
+        streamKey: item.cdn?.ingestionInfo?.streamName ?? "",
+        backupIngestionAddress: item.cdn?.ingestionInfo?.backupIngestionAddress,
+        resolution: item.cdn?.resolution ?? context.resolution,
+        frameRate: item.cdn?.frameRate ?? context.frameRate,
+      };
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// 9. createDeleteLiveStreamTool
+// ---------------------------------------------------------------------------
+
+export const createDeleteLiveStreamTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_DELETE_LIVE_STREAM",
+    description: "Delete a live stream ingestion point.",
+    inputSchema: z.object({
+      streamId: z.string(),
+    }),
+    outputSchema: z.object({
+      streamId: z.string(),
+      deleted: z.boolean(),
+    }),
+    execute: async ({ context }) => {
+      await dataApi(env, "/liveStreams", {
+        method: "DELETE",
+        params: { id: context.streamId },
+      });
+      return { streamId: context.streamId, deleted: true };
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// 10. createListLiveChatMessagesTool
+// ---------------------------------------------------------------------------
+
+export const createListLiveChatMessagesTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_LIST_LIVE_CHAT",
+    description:
+      "Read messages from a live broadcast's chat. Use liveChatId from LIST_BROADCASTS or CREATE_BROADCAST output.",
+    inputSchema: z.object({
+      liveChatId: z.string(),
+      maxResults: z.coerce.number().int().min(1).max(2000).default(200),
+      pageToken: z.string().optional(),
+    }),
+    outputSchema: z.object({
+      messages: z.array(
+        z.object({
+          messageId: z.string(),
+          authorChannelId: z.string(),
+          authorDisplayName: z.string(),
+          text: z.string(),
+          publishedAt: z.string(),
+          type: z.string(),
+        }),
+      ),
+      nextPageToken: z.string().optional(),
+      pollingIntervalMillis: z.number().optional(),
+    }),
+    execute: async ({ context }) => {
+      const data = await dataApi<LiveChatMessagesResponse>(
+        env,
+        "/liveChat/messages",
+        {
+          params: {
+            part: "id,snippet,authorDetails",
+            liveChatId: context.liveChatId,
+            maxResults: context.maxResults,
+            pageToken: context.pageToken,
+          },
+        },
+      );
+      return {
+        messages: (data.items ?? []).map((item) => ({
+          messageId: item.id,
+          authorChannelId: item.authorDetails?.channelId ?? "",
+          authorDisplayName: item.authorDetails?.displayName ?? "",
+          text:
+            item.snippet?.displayMessage ??
+            item.snippet?.textMessageDetails?.messageText ??
+            "",
+          publishedAt: item.snippet?.publishedAt ?? "",
+          type: item.snippet?.type ?? "",
+        })),
+        nextPageToken: data.nextPageToken,
+        pollingIntervalMillis: data.pollingIntervalMillis,
+      };
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// 11. createSendLiveChatMessageTool
+// ---------------------------------------------------------------------------
+
+export const createSendLiveChatMessageTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_SEND_LIVE_CHAT_MESSAGE",
+    description: "Send a text message to a live broadcast's chat.",
+    inputSchema: z.object({
+      liveChatId: z.string(),
+      text: z.string().min(1).max(200),
+    }),
+    outputSchema: z.object({
+      messageId: z.string(),
+      text: z.string(),
+      publishedAt: z.string().optional(),
+    }),
+    execute: async ({ context }) => {
+      const result = await dataApi<LiveChatMessageItem>(
+        env,
+        "/liveChat/messages",
+        {
+          method: "POST",
+          params: { part: "snippet" },
+          body: {
+            snippet: {
+              liveChatId: context.liveChatId,
+              type: "textMessageEvent",
+              textMessageDetails: { messageText: context.text },
+            },
+          },
+        },
+      );
+      return {
+        messageId: result.id,
+        text:
+          result.snippet?.textMessageDetails?.messageText ??
+          result.snippet?.displayMessage ??
+          context.text,
+        publishedAt: result.snippet?.publishedAt,
+      };
+    },
+  });
+
+// ---------------------------------------------------------------------------
+// 12. createDeleteLiveChatMessageTool
+// ---------------------------------------------------------------------------
+
+export const createDeleteLiveChatMessageTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_DELETE_LIVE_CHAT_MESSAGE",
+    description: "Delete a message from a live broadcast's chat.",
+    inputSchema: z.object({
+      messageId: z.string(),
+    }),
+    outputSchema: z.object({
+      messageId: z.string(),
+      deleted: z.boolean(),
+    }),
+    execute: async ({ context }) => {
+      await dataApi(env, "/liveChat/messages", {
+        method: "DELETE",
+        params: { id: context.messageId },
+      });
+      return { messageId: context.messageId, deleted: true };
+    },
+  });

--- a/youtube-channel-admin/server/tools/playlists.ts
+++ b/youtube-channel-admin/server/tools/playlists.ts
@@ -102,3 +102,230 @@ export const createAddToPlaylistTool = (env: Env) =>
       };
     },
   });
+
+export const createListPlaylistsTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_LIST_PLAYLISTS",
+    description: "List the channel's playlists.",
+    inputSchema: z.object({
+      maxResults: z.coerce.number().int().min(1).max(50).default(25),
+      pageToken: z.string().optional(),
+    }),
+    outputSchema: z.object({
+      playlists: z.array(
+        z.object({
+          playlistId: z.string(),
+          title: z.string(),
+          description: z.string().optional(),
+          privacyStatus: z.string(),
+          videoCount: z.number(),
+          watchUrl: z.string(),
+        }),
+      ),
+      nextPageToken: z.string().optional(),
+    }),
+    execute: async ({ context }) => {
+      const result = await dataApi<{
+        items?: Array<{
+          id: string;
+          snippet?: { title?: string; description?: string };
+          status?: { privacyStatus?: string };
+          contentDetails?: { itemCount?: number };
+        }>;
+        nextPageToken?: string;
+      }>(env, "/playlists", {
+        params: {
+          part: "snippet,status,contentDetails",
+          mine: true,
+          maxResults: context.maxResults,
+          pageToken: context.pageToken,
+        },
+      });
+
+      return {
+        playlists: (result.items ?? []).map((item) => ({
+          playlistId: item.id,
+          title: item.snippet?.title ?? "",
+          description: item.snippet?.description,
+          privacyStatus: item.status?.privacyStatus ?? "public",
+          videoCount: item.contentDetails?.itemCount ?? 0,
+          watchUrl: `https://www.youtube.com/playlist?list=${item.id}`,
+        })),
+        nextPageToken: result.nextPageToken,
+      };
+    },
+  });
+
+export const createUpdatePlaylistTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_UPDATE_PLAYLIST",
+    description: "Update a playlist's title, description or privacy.",
+    inputSchema: z.object({
+      playlistId: z.string(),
+      title: z.string().max(150).optional(),
+      description: z.string().max(5000).optional(),
+      privacyStatus: z.enum(["public", "unlisted", "private"]).optional(),
+    }),
+    outputSchema: z.object({
+      playlistId: z.string(),
+      title: z.string(),
+      description: z.string().optional(),
+      privacyStatus: z.string(),
+      watchUrl: z.string(),
+    }),
+    execute: async ({ context }) => {
+      // Fetch current playlist to merge fields
+      const current = await dataApi<{
+        items?: Array<{
+          id: string;
+          snippet?: { title?: string; description?: string };
+          status?: { privacyStatus?: string };
+        }>;
+      }>(env, "/playlists", {
+        params: {
+          part: "snippet,status",
+          id: context.playlistId,
+        },
+      });
+
+      const existing = current.items?.[0];
+      if (!existing) {
+        throw new Error(`Playlist not found: ${context.playlistId}`);
+      }
+
+      const updatedTitle = context.title ?? existing.snippet?.title ?? "";
+      const updatedDescription =
+        context.description ?? existing.snippet?.description;
+      const updatedPrivacyStatus =
+        context.privacyStatus ?? existing.status?.privacyStatus ?? "public";
+
+      const result = await dataApi<{
+        id: string;
+        snippet?: { title?: string; description?: string };
+        status?: { privacyStatus?: string };
+      }>(env, "/playlists", {
+        method: "PUT",
+        params: { part: "snippet,status" },
+        body: {
+          id: context.playlistId,
+          snippet: {
+            title: updatedTitle,
+            description: updatedDescription,
+          },
+          status: { privacyStatus: updatedPrivacyStatus },
+        },
+      });
+
+      return {
+        playlistId: result.id,
+        title: result.snippet?.title ?? updatedTitle,
+        description: result.snippet?.description,
+        privacyStatus: result.status?.privacyStatus ?? updatedPrivacyStatus,
+        watchUrl: `https://www.youtube.com/playlist?list=${result.id}`,
+      };
+    },
+  });
+
+export const createDeletePlaylistTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_DELETE_PLAYLIST",
+    description: "Delete a playlist (does not delete the videos in it).",
+    inputSchema: z.object({
+      playlistId: z.string(),
+    }),
+    outputSchema: z.object({
+      playlistId: z.string(),
+      deleted: z.boolean(),
+    }),
+    execute: async ({ context }) => {
+      await dataApi<undefined>(env, "/playlists", {
+        method: "DELETE",
+        params: { id: context.playlistId },
+      });
+
+      return {
+        playlistId: context.playlistId,
+        deleted: true,
+      };
+    },
+  });
+
+export const createListPlaylistItemsTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_LIST_PLAYLIST_ITEMS",
+    description: "List videos in a playlist.",
+    inputSchema: z.object({
+      playlistId: z.string(),
+      maxResults: z.coerce.number().int().min(1).max(50).default(25),
+      pageToken: z.string().optional(),
+    }),
+    outputSchema: z.object({
+      items: z.array(
+        z.object({
+          playlistItemId: z.string(),
+          videoId: z.string(),
+          title: z.string(),
+          position: z.number(),
+          privacyStatus: z.string(),
+        }),
+      ),
+      nextPageToken: z.string().optional(),
+    }),
+    execute: async ({ context }) => {
+      const result = await dataApi<{
+        items?: Array<{
+          id: string;
+          snippet?: {
+            title?: string;
+            position?: number;
+            resourceId?: { videoId?: string };
+          };
+          status?: { privacyStatus?: string };
+        }>;
+        nextPageToken?: string;
+      }>(env, "/playlistItems", {
+        params: {
+          part: "snippet,status",
+          playlistId: context.playlistId,
+          maxResults: context.maxResults,
+          pageToken: context.pageToken,
+        },
+      });
+
+      return {
+        items: (result.items ?? []).map((item) => ({
+          playlistItemId: item.id,
+          videoId: item.snippet?.resourceId?.videoId ?? "",
+          title: item.snippet?.title ?? "",
+          position: item.snippet?.position ?? 0,
+          privacyStatus: item.status?.privacyStatus ?? "public",
+        })),
+        nextPageToken: result.nextPageToken,
+      };
+    },
+  });
+
+export const createRemoveFromPlaylistTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_REMOVE_FROM_PLAYLIST",
+    description:
+      "Remove a video from a playlist using its playlistItemId (from LIST_PLAYLIST_ITEMS).",
+    inputSchema: z.object({
+      playlistItemId: z.string(),
+    }),
+    outputSchema: z.object({
+      playlistItemId: z.string(),
+      removed: z.boolean(),
+    }),
+    execute: async ({ context }) => {
+      await dataApi<undefined>(env, "/playlistItems", {
+        method: "DELETE",
+        params: { id: context.playlistItemId },
+      });
+
+      return {
+        playlistItemId: context.playlistItemId,
+        removed: true,
+      };
+    },
+  });

--- a/youtube-channel-admin/server/tools/search.ts
+++ b/youtube-channel-admin/server/tools/search.ts
@@ -1,0 +1,80 @@
+import { createPrivateTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { dataApi } from "../lib/yt-client.ts";
+import type { Env } from "../types/env.ts";
+
+export const createSearchMyVideosTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_SEARCH_MY_VIDEOS",
+    description:
+      "Search within the channel's own videos. More flexible than listing the uploads playlist — supports text search, date range, order, and type filters. Quota: 100 units.",
+    inputSchema: z.object({
+      query: z.string().optional().describe("Search text"),
+      type: z.enum(["video", "live", "completed", "upcoming"]).default("video"),
+      order: z
+        .enum(["date", "rating", "relevance", "title", "viewCount"])
+        .default("date"),
+      publishedAfter: z
+        .string()
+        .optional()
+        .describe("ISO 8601 datetime e.g. 2026-01-01T00:00:00Z"),
+      publishedBefore: z.string().optional().describe("ISO 8601 datetime"),
+      maxResults: z.coerce.number().int().min(1).max(50).default(25),
+      pageToken: z.string().optional(),
+    }),
+    outputSchema: z.object({
+      results: z.array(
+        z.object({
+          videoId: z.string(),
+          title: z.string(),
+          publishedAt: z.string().optional(),
+          thumbnailUrl: z.string().optional(),
+          liveBroadcastContent: z.string().optional(),
+        }),
+      ),
+      nextPageToken: z.string().optional(),
+      totalResults: z.number().optional(),
+    }),
+    execute: async ({ context }) => {
+      const data = await dataApi<{
+        items?: Array<{
+          id?: { videoId?: string };
+          snippet?: {
+            title?: string;
+            publishedAt?: string;
+            thumbnails?: { medium?: { url?: string } };
+            liveBroadcastContent?: string;
+          };
+        }>;
+        nextPageToken?: string;
+        pageInfo?: { totalResults?: number };
+      }>(env, "/search", {
+        params: {
+          part: "snippet",
+          forMine: true,
+          type: "video",
+          eventType: context.type !== "video" ? context.type : undefined,
+          q: context.query,
+          order: context.order,
+          publishedAfter: context.publishedAfter,
+          publishedBefore: context.publishedBefore,
+          maxResults: context.maxResults,
+          pageToken: context.pageToken,
+        },
+      });
+
+      const results = (data.items ?? []).map((item) => ({
+        videoId: item.id?.videoId ?? "",
+        title: item.snippet?.title ?? "",
+        publishedAt: item.snippet?.publishedAt,
+        thumbnailUrl: item.snippet?.thumbnails?.medium?.url,
+        liveBroadcastContent: item.snippet?.liveBroadcastContent,
+      }));
+
+      return {
+        results,
+        nextPageToken: data.nextPageToken,
+        totalResults: data.pageInfo?.totalResults,
+      };
+    },
+  });

--- a/youtube-channel-admin/server/tools/videos.ts
+++ b/youtube-channel-admin/server/tools/videos.ts
@@ -191,3 +191,46 @@ export const createGetVideosTool = (env: Env) =>
       videos: await getVideosByIds(env, context.videoIds),
     }),
   });
+
+export const createDeleteVideoTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_DELETE_VIDEO",
+    description:
+      "Permanently delete one of the channel's videos. This cannot be undone. Quota: 50 units.",
+    inputSchema: z.object({
+      videoId: z.string(),
+    }),
+    outputSchema: z.object({
+      videoId: z.string(),
+      deleted: z.boolean(),
+    }),
+    execute: async ({ context }) => {
+      await dataApi(env, "/videos", {
+        method: "DELETE",
+        params: { id: context.videoId },
+      });
+      return { videoId: context.videoId, deleted: true };
+    },
+  });
+
+export const createRateVideoTool = (env: Env) =>
+  createPrivateTool({
+    id: "YOUTUBE_ADMIN_RATE_VIDEO",
+    description:
+      "Like, dislike or remove your rating from any YouTube video. rating: 'like' | 'dislike' | 'none'.",
+    inputSchema: z.object({
+      videoId: z.string(),
+      rating: z.enum(["like", "dislike", "none"]),
+    }),
+    outputSchema: z.object({
+      videoId: z.string(),
+      rating: z.string(),
+    }),
+    execute: async ({ context }) => {
+      await dataApi(env, "/videos/rate", {
+        method: "POST",
+        params: { id: context.videoId, rating: context.rating },
+      });
+      return { videoId: context.videoId, rating: context.rating };
+    },
+  });

--- a/youtube-channel-admin/server/tools/widgets.ts
+++ b/youtube-channel-admin/server/tools/widgets.ts
@@ -7,6 +7,7 @@ import { createTool } from "@decocms/runtime/tools";
 import { z } from "zod";
 import {
   WIDGET_ALERTS_RESOURCE_URI,
+  WIDGET_LIVES_RESOURCE_URI,
   WIDGET_PERFORMANCE_RESOURCE_URI,
   WIDGET_TOP_VIDEOS_RESOURCE_URI,
 } from "../constants.ts";
@@ -16,6 +17,7 @@ import {
   getPerformance,
   getTopVideos,
 } from "../lib/yt-data.ts";
+import { dataApi } from "../lib/yt-client.ts";
 import type { Env } from "../types/env.ts";
 import {
   AlertCountsSchema,
@@ -95,4 +97,96 @@ export const createAlertsWidgetTool = (env: Env) =>
       ...(await getAlerts(env)),
       updatedAt: new Date().toISOString(),
     }),
+  });
+
+// ---------- Lives widget ----------
+
+interface BroadcastItem {
+  id: string;
+  snippet?: {
+    title?: string;
+    scheduledStartTime?: string;
+    actualStartTime?: string;
+    liveChatId?: string;
+    thumbnails?: {
+      high?: { url?: string };
+      medium?: { url?: string };
+      default?: { url?: string };
+    };
+  };
+  status?: {
+    lifeCycleStatus?: string;
+  };
+}
+
+export const createLivesWidgetTool = (env: Env) =>
+  createTool({
+    id: "YOUTUBE_ADMIN_WIDGET_LIVES",
+    description:
+      "Home widget: upcoming and active live broadcasts (includes Premieres). Shows the next 5 scheduled/active streams with status, thumbnail and countdown.",
+    inputSchema: z.object({}),
+    outputSchema: z.object({
+      broadcasts: z.array(
+        z.object({
+          broadcastId: z.string(),
+          title: z.string(),
+          lifeCycleStatus: z.string(),
+          scheduledStartTime: z.string().optional(),
+          actualStartTime: z.string().optional(),
+          thumbnailUrl: z.string().optional(),
+          liveChatId: z.string().optional(),
+          watchUrl: z.string(),
+        }),
+      ),
+      hasActiveBroadcast: z.boolean(),
+      updatedAt: z.string(),
+    }),
+    _meta: { ui: { resourceUri: WIDGET_LIVES_RESOURCE_URI } },
+    annotations: { readOnlyHint: true },
+    execute: async () => {
+      const [activeData, upcomingData] = await Promise.all([
+        dataApi<{ items?: BroadcastItem[] }>(env, "/liveBroadcasts", {
+          params: {
+            part: "snippet,status",
+            broadcastStatus: "active",
+            maxResults: 5,
+          },
+        }),
+        dataApi<{ items?: BroadcastItem[] }>(env, "/liveBroadcasts", {
+          params: {
+            part: "snippet,status",
+            broadcastStatus: "upcoming",
+            maxResults: 5,
+          },
+        }),
+      ]);
+
+      const mapBc = (item: BroadcastItem) => ({
+        broadcastId: item.id,
+        title: item.snippet?.title ?? "",
+        lifeCycleStatus: item.status?.lifeCycleStatus ?? "",
+        scheduledStartTime: item.snippet?.scheduledStartTime,
+        actualStartTime: item.snippet?.actualStartTime,
+        thumbnailUrl:
+          item.snippet?.thumbnails?.high?.url ??
+          item.snippet?.thumbnails?.medium?.url ??
+          item.snippet?.thumbnails?.default?.url,
+        liveChatId: item.snippet?.liveChatId,
+        watchUrl: `https://www.youtube.com/watch?v=${item.id}`,
+      });
+
+      const active = (activeData.items ?? []).map(mapBc);
+      const upcoming = (upcomingData.items ?? []).map(mapBc);
+      const seen = new Set(active.map((b) => b.broadcastId));
+      const merged = [
+        ...active,
+        ...upcoming.filter((b) => !seen.has(b.broadcastId)),
+      ].slice(0, 8);
+
+      return {
+        broadcasts: merged,
+        hasActiveBroadcast: active.length > 0,
+        updatedAt: new Date().toISOString(),
+      };
+    },
   });

--- a/youtube-channel-admin/vite.config.ts
+++ b/youtube-channel-admin/vite.config.ts
@@ -9,6 +9,7 @@ const MCP_APP_ENTRIES = {
   "widget-top-videos": path.resolve(__dirname, "widget-top-videos.html"),
   "widget-performance": path.resolve(__dirname, "widget-performance.html"),
   "widget-alerts": path.resolve(__dirname, "widget-alerts.html"),
+  "widget-lives": path.resolve(__dirname, "widget-lives.html"),
 } as const;
 
 type McpAppEntry = keyof typeof MCP_APP_ENTRIES;

--- a/youtube-channel-admin/web/tools/widget-lives/index.tsx
+++ b/youtube-channel-admin/web/tools/widget-lives/index.tsx
@@ -1,0 +1,119 @@
+import { Loader2, Radio } from "lucide-react";
+import { usePollingTool } from "@/hooks/use-tool.ts";
+
+const POLL_MS = 60_000; // 1min — live status changes quickly
+
+interface BroadcastEntry {
+  broadcastId: string;
+  title: string;
+  lifeCycleStatus: string;
+  scheduledStartTime?: string;
+  actualStartTime?: string;
+  thumbnailUrl?: string;
+  watchUrl: string;
+}
+
+interface LivesWidgetData {
+  broadcasts: BroadcastEntry[];
+  hasActiveBroadcast: boolean;
+  updatedAt: string;
+}
+
+function formatScheduled(iso?: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  return d.toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function StatusBadge({ status }: { status: string }) {
+  if (status === "live") {
+    return (
+      <span className="rounded bg-red-600 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white">
+        Ao vivo
+      </span>
+    );
+  }
+  if (status === "testing") {
+    return (
+      <span className="rounded bg-orange-500 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white">
+        Teste
+      </span>
+    );
+  }
+  return null;
+}
+
+export default function WidgetLivesPage() {
+  const { data, loading, error } = usePollingTool<LivesWidgetData>(
+    "YOUTUBE_ADMIN_WIDGET_LIVES",
+    {},
+    POLL_MS,
+  );
+
+  if (loading && !data) {
+    return (
+      <div className="flex h-full min-h-[8rem] items-center justify-center">
+        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+  if (error && !data) {
+    return (
+      <div className="p-4 text-xs text-red-600 dark:text-red-400">{error}</div>
+    );
+  }
+
+  const broadcasts = data?.broadcasts ?? [];
+
+  if (broadcasts.length === 0) {
+    return (
+      <div className="flex h-full min-h-[8rem] flex-col items-center justify-center gap-1 p-4 text-center">
+        <Radio className="h-5 w-5 text-muted-foreground/50" />
+        <p className="text-xs text-muted-foreground">
+          Nenhuma live ou estreia agendada.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5 p-2">
+      <p className="px-1.5 text-[11px] text-muted-foreground">
+        Lives & Estreias
+      </p>
+      {broadcasts.map((bc) => (
+        <a
+          key={bc.broadcastId}
+          href={bc.watchUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted/60 transition-colors"
+        >
+          {bc.thumbnailUrl && (
+            <img
+              src={bc.thumbnailUrl}
+              alt=""
+              className="h-8 w-14 flex-shrink-0 rounded object-cover"
+            />
+          )}
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-xs font-medium leading-tight">
+              {bc.title}
+            </p>
+            <p className="text-[11px] text-muted-foreground">
+              {bc.lifeCycleStatus === "live" || bc.lifeCycleStatus === "testing"
+                ? null
+                : formatScheduled(bc.scheduledStartTime ?? bc.actualStartTime)}
+            </p>
+          </div>
+          <StatusBadge status={bc.lifeCycleStatus} />
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/youtube-channel-admin/web/tools/widget-lives/main.tsx
+++ b/youtube-channel-admin/web/tools/widget-lives/main.tsx
@@ -1,0 +1,4 @@
+import { mountMcpApp } from "@/bootstrap.tsx";
+import WidgetLivesPage from "./index.tsx";
+
+mountMcpApp(WidgetLivesPage);

--- a/youtube-channel-admin/widget-lives.html
+++ b/youtube-channel-admin/widget-lives.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Lives & Estreias</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./web/tools/widget-lives/main.tsx"></script>
+	</body>
+</html>


### PR DESCRIPTION
## Summary

Cobre 100% dos endpoints relevantes da YouTube Data API v3 no `youtube-channel-admin`. Adicionados 19 tools novos (total: 38 tools).

## Novos tools por categoria

**Videos (+2)**
| Tool | API |
|---|---|
| `YOUTUBE_ADMIN_DELETE_VIDEO` | `videos.delete` |
| `YOUTUBE_ADMIN_RATE_VIDEO` | `videos.rate` (like/dislike/none) |

**Captions (+2)**
| Tool | API |
|---|---|
| `YOUTUBE_ADMIN_UPDATE_CAPTION` | `captions.update` — substitui o conteúdo de um track existente |
| `YOUTUBE_ADMIN_DELETE_CAPTION` | `captions.delete` |

**Playlists (+5)**
| Tool | API |
|---|---|
| `YOUTUBE_ADMIN_LIST_PLAYLISTS` | `playlists.list` |
| `YOUTUBE_ADMIN_UPDATE_PLAYLIST` | `playlists.update` (fetch-merge-put) |
| `YOUTUBE_ADMIN_DELETE_PLAYLIST` | `playlists.delete` |
| `YOUTUBE_ADMIN_LIST_PLAYLIST_ITEMS` | `playlistItems.list` |
| `YOUTUBE_ADMIN_REMOVE_FROM_PLAYLIST` | `playlistItems.delete` |

**Comments (+2)**
| Tool | API |
|---|---|
| `YOUTUBE_ADMIN_UPDATE_COMMENT` | `comments.update` |
| `YOUTUBE_ADMIN_DELETE_COMMENT` | `comments.delete` |

**Channel (+3)**
| Tool | API |
|---|---|
| `YOUTUBE_ADMIN_LIST_VIDEO_CATEGORIES` | `videoCategories.list` |
| `YOUTUBE_ADMIN_LIST_SUBSCRIBERS` | `subscriptions.list?mySubscribers=true` |
| `YOUTUBE_ADMIN_SEARCH_MY_VIDEOS` | `search.list?forMine=true` |

**Live Streaming (+12)**
| Tool | API |
|---|---|
| `YOUTUBE_ADMIN_LIST_BROADCASTS` | `liveBroadcasts.list` |
| `YOUTUBE_ADMIN_CREATE_BROADCAST` | `liveBroadcasts.insert` |
| `YOUTUBE_ADMIN_UPDATE_BROADCAST` | `liveBroadcasts.update` |
| `YOUTUBE_ADMIN_DELETE_BROADCAST` | `liveBroadcasts.delete` |
| `YOUTUBE_ADMIN_BIND_BROADCAST` | `liveBroadcasts.bind` (live com streamId **ou** Premiere com videoId) |
| `YOUTUBE_ADMIN_TRANSITION_BROADCAST` | `liveBroadcasts.transition` (ready→live→complete) |
| `YOUTUBE_ADMIN_LIST_LIVE_STREAMS` | `liveStreams.list` — RTMP URL + stream key |
| `YOUTUBE_ADMIN_CREATE_LIVE_STREAM` | `liveStreams.insert` |
| `YOUTUBE_ADMIN_DELETE_LIVE_STREAM` | `liveStreams.delete` |
| `YOUTUBE_ADMIN_LIST_LIVE_CHAT` | `liveChatMessages.list` |
| `YOUTUBE_ADMIN_SEND_LIVE_CHAT_MESSAGE` | `liveChatMessages.insert` |
| `YOUTUBE_ADMIN_DELETE_LIVE_CHAT_MESSAGE` | `liveChatMessages.delete` |

## Fluxo Premiere (vídeo de estreia)
1. `UPLOAD_VIDEO` → obtém `videoId`
2. `CREATE_BROADCAST` com `scheduledStartTime` no futuro
3. `BIND_BROADCAST` com `videoId` → YouTube exibe countdown + live chat

## O que intencionalmente não foi incluído
- `watermarks.set/unset` — muito nichado
- `members/membershipsLevels` — requer YouTube Partner Program com memberships ativo
- `superChatEvents.list` — requer monetização habilitada
- `i18nLanguages/Regions.list` — dados estáticos de referência, sem valor operacional

## Test plan
- [ ] Criar broadcast + live stream + bind + transition no canal de testes
- [ ] Criar Premiere: upload vídeo → create broadcast → bind com videoId
- [ ] Delete vídeo, rate vídeo
- [ ] List/update/delete playlist, list/remove playlist items
- [ ] Update/delete caption, update/delete comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full YouTube Data API v3 coverage to `youtube-channel-admin`, including lives, premieres, playlists, video delete/rate, and search, plus a new Lives & Premieres widget. Also includes `youtube-search` for keyless search, transcripts, and downloads.

- **New Features**
  - `youtube-channel-admin` (OAuth: youtube.force-ssl, youtube.upload, yt-analytics.readonly)
    - Channel ops: videos (list/update/upload/delete/rate, thumbnails), captions (list/upload/update/delete), playlists (CRUD + items), comments (list/reply/update/delete/moderate), channel (get/update, categories, subscribers, sections CRUD, watermarks set/unset), search my videos, analytics.
    - Live: broadcasts (list/create/update/delete/bind/transition), streams (list/create/update/delete/update with RTMP URL + key), live chat (list/send/delete), bans (list/ban/unban), moderators (list/add/remove).
    - UI: dashboard + 4 widgets (top videos, performance, alerts, lives & premieres). Resumable uploads accept `videoUrl` or `storageKey` via `@deco/object-storage`.
  - `youtube-search` (keyless via `youtubei.js`)
    - Search videos/channels/playlists; get full video metadata and caption tracks; fetch transcripts (incl. auto-generated); download video/audio to object storage with a presigned URL.

- **Migration**
  - Connect `@deco/object-storage` if you want uploads (`YOUTUBE_ADMIN_UPLOAD_VIDEO`) and downloads (`YOUTUBE_DOWNLOAD_VIDEO`).
  - For `youtube-channel-admin`, sign in with Google on first use; app requests youtube.force-ssl, youtube.upload, yt-analytics.readonly.
  - Premieres: upload video → create broadcast with future `scheduledStartTime` → bind broadcast with `videoId`.

<sup>Written for commit 3c7ccc0663f9c10c2ceb4e4f21ebe2feb5a733e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

