### PR TITLE
feat(tanstack-migrator): per-round merge loop, .deco sync-mirror, deep triage

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -2399,6 +2399,55 @@
     }
   },
   {
+    "id": "deco/grafana",
+    "title": "Grafana",
+    "description": "Query self-hosted Grafana: list datasources, search/read dashboards, and run raw datasource or PromQL queries via /api/ds/query.",
+    "is_public": true,
+    "_meta": {
+      "mcp.mesh": {
+        "verified": false,
+        "friendly_name": "Grafana",
+        "short_description": "Query self-hosted Grafana datasources, dashboards, and PromQL — connect with your Grafana URL + a service-account token.",
+        "owner": "deco",
+        "has_remote": true,
+        "has_oauth": false,
+        "tags": [
+          "grafana",
+          "self-hosted",
+          "observability",
+          "monitoring",
+          "prometheus",
+          "dashboards",
+          "promql",
+          "metrics"
+        ],
+        "categories": [
+          "Observability"
+        ],
+        "readme": "The Grafana MCP connects AI agents to any self-hosted (or Cloud) Grafana instance over its HTTP API. **Key Features** — **GRAFANA_LIST_DATASOURCES** lists configured datasources (uid/name/type); **GRAFANA_SEARCH_DASHBOARDS** and **GRAFANA_GET_DASHBOARD** discover dashboards and read their full JSON (panels, targets, variables) so agents can learn the exact query a panel uses; **GRAFANA_QUERY** runs any native datasource query through POST /api/ds/query; **GRAFANA_QUERY_PROMETHEUS** is a convenience wrapper for instant or range PromQL. **Use Cases** — pull metrics into agent workflows, reproduce a dashboard panel's query, inspect cost/observability dashboards, and build automations on top of existing Grafana data. **Authentication** — provide your Grafana base URL and a service-account token (Administration → Service accounts → Add token); Viewer role is enough for querying. Ideal for teams running self-hosted Grafana who want programmatic, read-only access to metrics and dashboards without exposing Grafana broadly."
+      }
+    },
+    "server": {
+      "name": "grafana",
+      "title": "Grafana",
+      "description": "Query self-hosted Grafana: list datasources, search/read dashboards, and run raw datasource or PromQL queries via /api/ds/query.",
+      "icons": [
+        {
+          "src": "https://grafana.com/static/assets/img/fav32.png"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "HTTP",
+          "url": "https://sites-grafana.deco.site/mcp",
+          "name": "grafana",
+          "title": "Grafana",
+          "description": "Query self-hosted Grafana: list datasources, search/read dashboards, and run raw datasource or PromQL queries via /api/ds/query."
+        }
+      ]
+    }
+  },
+  {
     "id": "deco/grain",
     "title": "Grain",
     "description": "Integrate with Grain to access and manage your meeting recordings, transcripts and AI summaries.",

--- a/tanstack-migrator/server/constants.ts
+++ b/tanstack-migrator/server/constants.ts
@@ -17,7 +17,10 @@ export const LIVENESS_STALL_MS = 4 * 60_000;
 /** Session timeouts per task kind (the reader gives up past these). */
 export const SESSION_TIMEOUT_MS: Record<string, number> = {
   migrate: 30 * 60_000,
-  triage: 20 * 60_000,
+  // triage is intentionally exhaustive (build + SSR + headless-browser console
+  // capture + skill grep sweep) — give it room.
+  triage: 40 * 60_000,
+  review: 20 * 60_000,
   fix: 25 * 60_000,
   parity: 20 * 60_000,
 };
@@ -34,7 +37,11 @@ export const DEFAULT_NO_IMPROVE_LIMIT = 3;
 export const DEFAULT_MAX_CONCURRENT = 1;
 export const DEFAULT_MAX_FIX_SESSIONS = 20;
 export const DEFAULT_FIX_BATCH_SIZE = 3;
-export const DEFAULT_MAX_ISSUES_PER_TRIAGE = 15;
+/**
+ * Effectively uncapped: triage should report EVERY real problem it finds. The
+ * high bound is only a runaway safety rail (dedupe + labeling stay bounded).
+ */
+export const DEFAULT_MAX_ISSUES_PER_TRIAGE = 100;
 export const DEFAULT_WORK_BRANCH = "migration/tanstack";
 
 /** Object-storage key prefix for parity artifacts. */

--- a/tanstack-migrator/server/db/types.ts
+++ b/tanstack-migrator/server/db/types.ts
@@ -9,6 +9,8 @@ export type SiteStatus =
   | "baselining"
   | "migrating_script"
   | "opening_pr"
+  | "reviewing"
+  | "merging"
   | "triaging"
   | "fixing"
   | "paritying"
@@ -47,6 +49,8 @@ export const ACTIVE_STATUSES: SiteStatus[] = [
   "baselining",
   "migrating_script",
   "opening_pr",
+  "reviewing",
+  "merging",
   "triaging",
   "fixing",
   "paritying",
@@ -109,6 +113,7 @@ export function isSessionStatus(status: string): boolean {
     status === "baselining" ||
     status === "migrating_script" ||
     status === "triaging" ||
+    status === "reviewing" ||
     status === "fixing" ||
     status === "paritying" ||
     isLegacyStatus(status)
@@ -131,6 +136,7 @@ export function isActiveStatus(status: string): boolean {
 export type RunKind =
   | "migrate"
   | "triage"
+  | "review"
   | "fix"
   | "parity"
   | "fix_iteration" // legacy (≤ v0.4.x)

--- a/tanstack-migrator/server/engine/machine.ts
+++ b/tanstack-migrator/server/engine/machine.ts
@@ -8,10 +8,12 @@ import { baselining } from "./phases/baselining.ts";
 import { creatingRepo } from "./phases/creating-repo.ts";
 import { deployingCf } from "./phases/deploying-cf.ts";
 import { fixing } from "./phases/fixing.ts";
+import { merging } from "./phases/merging.ts";
 import { migratingScript } from "./phases/migrating-script.ts";
 import { openingPr } from "./phases/opening-pr.ts";
 import { paritying } from "./phases/paritying.ts";
 import { provisioningSandbox } from "./phases/provisioning-sandbox.ts";
+import { reviewing } from "./phases/reviewing.ts";
 import { triaging } from "./phases/triaging.ts";
 
 export interface EngineDeps {
@@ -35,6 +37,8 @@ export const PHASE_HANDLERS: Partial<Record<SiteStatus, PhaseHandler>> = {
   baselining,
   migrating_script: migratingScript,
   opening_pr: openingPr,
+  reviewing,
+  merging,
   triaging,
   fixing,
   paritying,

--- a/tanstack-migrator/server/engine/phases/deploying-cf.ts
+++ b/tanstack-migrator/server/engine/phases/deploying-cf.ts
@@ -22,21 +22,29 @@ import { previewRendersRealHtml } from "../../lib/preview.ts";
 import { getDriver, isSimulation } from "../../sandbox/client.ts";
 import { deployPrompt } from "../../sandbox/templates/prompts.ts";
 
-/** After a successful deploy, advance to parity (measured against the CF URL). */
-async function advanceToParity(
+/**
+ * After a successful deploy, route on whether this was the FIRST deploy:
+ *   - initial migration (no cf_deploy_url yet) → triaging (build the backlog)
+ *   - every fix round (cf_deploy_url already set) → paritying (measure vs URL)
+ * Robust even when triage found zero issues (doesn't depend on issues_total).
+ */
+async function advanceAfterDeploy(
   site: SiteRow,
   patch: Partial<SiteRow>,
 ): Promise<void> {
+  const firstDeploy = !site.cf_deploy_url;
+  const next = firstDeploy ? "triaging" : "paritying";
   await updateSite(site.id, {
     ...patch,
-    status: "paritying",
-    phase_detail:
-      "deploy ok — starting parity measurement against the real URL",
+    status: next,
+    phase_detail: firstDeploy
+      ? "deploy ok — triaging the migrated site"
+      : "deploy ok — measuring parity against the real URL",
     last_progress_at: new Date().toISOString(),
   });
   await addEvent(
     site.id,
-    `CF deploy ok at ${patch.cf_deploy_url ?? "?"} — advancing to parity`,
+    `CF deploy ok at ${patch.cf_deploy_url ?? site.cf_deploy_url ?? "?"} — ${firstDeploy ? "triaging" : "advancing to parity"}`,
   );
 }
 
@@ -48,7 +56,7 @@ export async function deployingCf(
   const workerName = parseRepo(site.target_repo).repo;
 
   if (isSimulation(ctx)) {
-    await advanceToParity(site, {
+    await advanceAfterDeploy(site, {
       cf_project_name: workerName,
       cf_deploy_url: `https://${workerName}.deco-cx.workers.dev`,
     });
@@ -142,7 +150,7 @@ export async function deployingCf(
         );
       }
 
-      await advanceToParity(current, {
+      await advanceAfterDeploy(current, {
         cf_project_name: workerName,
         cf_deploy_url: deployUrl,
       });

--- a/tanstack-migrator/server/engine/phases/fixing.ts
+++ b/tanstack-migrator/server/engine/phases/fixing.ts
@@ -11,7 +11,7 @@ import { addEvent } from "../../db/events.ts";
 import { createRun, finishRun } from "../../db/runs.ts";
 import { getSite, incrementCost, updateSite } from "../../db/sites.ts";
 import type { SiteRow } from "../../db/types.ts";
-import { ghsTokenForSite } from "../../lib/github.ts";
+import { ensureBranch, ghsTokenForSite, parseRepo } from "../../lib/github.ts";
 import {
   closeResolvedIssues,
   markBlockedIssues,
@@ -40,14 +40,24 @@ export async function fixing(
   ctx: WorkerCtx,
   deps: EngineDeps,
 ): Promise<void> {
-  // Terminal checks first (idempotent re-entry)
-  if (site.parity_score !== null && site.parity_score >= site.parity_target) {
+  // Terminal check (idempotent re-entry): parity target met AND backlog empty
+  // means we're done — no more rounds. (Parity is measured post-merge in
+  // paritying; deploy happens per-round via opening_pr → … → deploying.)
+  if (
+    site.parity_score !== null &&
+    site.parity_score >= site.parity_target &&
+    site.issues_open === 0
+  ) {
     await updateSite(site.id, {
-      status: "deploying",
-      phase_detail: `parity ${site.parity_score} >= ${site.parity_target}, going to deploy`,
+      status: "done",
+      phase_detail: `parity ${site.parity_score}% with empty backlog — done`,
+      finished_at: new Date().toISOString(),
       last_progress_at: new Date().toISOString(),
     });
-    await addEvent(site.id, `Parity reached ${site.parity_score}% — CF deploy`);
+    await addEvent(
+      site.id,
+      `Parity ${site.parity_score}% and backlog empty — done`,
+    );
     return;
   }
   if (deps.inflight.has(site.id)) return;
@@ -109,6 +119,36 @@ export async function fixing(
       title: i.title,
       body: i.body,
     }));
+  }
+
+  // New round: cut a fresh branch off main so this batch gets its own PR that
+  // is reviewed + merged independently. Only when starting a fresh round
+  // (pr_number null); a review-reject keeps pr_number set → same branch.
+  if (!isSimulation(ctx) && !site.pr_number) {
+    if (!site.target_repo) throw new Error("target_repo not set");
+    const ref = parseRepo(site.target_repo);
+    const round = site.fix_sessions_done + 1;
+    const roundBranch = `migration/fix-${round}`;
+    if (site.work_branch !== roundBranch) {
+      await ensureBranch(ctx, ref, roundBranch, "main");
+      await updateSite(site.id, {
+        work_branch: roundBranch,
+        pr_number: null,
+        pr_url: null,
+        preview_ready: false,
+      });
+      site = {
+        ...site,
+        work_branch: roundBranch,
+        pr_number: null,
+        pr_url: null,
+        preview_ready: false,
+      };
+      await addEvent(
+        site.id,
+        `New fix round on branch ${roundBranch} (off main)`,
+      );
+    }
   }
 
   const sessionNumber = site.fix_sessions_done + 1;
@@ -186,6 +226,7 @@ export async function fixing(
           meta: { issues: { resolved: [] } },
         });
         await updateSite(site.id, {
+          status: "opening_pr",
           fix_sessions_done: sessionNumber,
           issues_open: current.issues_open - resolvedCount,
           issues_closed: current.issues_closed + resolvedCount,
@@ -226,18 +267,19 @@ export async function fixing(
         },
       });
       await updateSite(site.id, {
+        status: "opening_pr",
         fix_sessions_done: sessionNumber,
         sandbox_session_id: null,
         phase_thread_id: null, // each batch is a fresh, narrow conversation
         transient_retries: 0,
-        phase_detail: `fix ${sessionNumber}: ${resolved.length}/${batch.length} resolved, backlog ${openIssues.open}`,
+        phase_detail: `fix ${sessionNumber}: ${resolved.length}/${batch.length} resolved, backlog ${openIssues.open} — opening PR`,
         last_progress_at: new Date().toISOString(),
       });
       await addEvent(
         site.id,
-        `Fix session ${sessionNumber}: resolved ${resolved.length > 0 ? resolved.map((n) => `#${n}`).join(", ") : "none"}${blocked.length > 0 ? ` · blocked ${blocked.map((b) => `#${b.number}`).join(", ")}` : ""} — backlog ${openIssues.open}`,
+        `Fix session ${sessionNumber}: resolved ${resolved.length > 0 ? resolved.map((n) => `#${n}`).join(", ") : "none"}${blocked.length > 0 ? ` · blocked ${blocked.map((b) => `#${b.number}`).join(", ")}` : ""} — backlog ${openIssues.open}, opening PR`,
       );
-      // next tick re-enters: backlog empty → paritying; budget out → needs_human
+      // advance: opening_pr → reviewing → merging → deploying → paritying
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       await finishRun(run.id, { status: "failed", logsTail: message });

--- a/tanstack-migrator/server/engine/phases/merging.ts
+++ b/tanstack-migrator/server/engine/phases/merging.ts
@@ -1,0 +1,142 @@
+/**
+ * Phase: merging — MCP-side (no session). Auto-merges the reviewed PR:
+ *   1. squash-merge the PR into main (idempotent: an already-merged PR passes)
+ *   2. delete the round branch (best-effort)
+ *   3. advance to deploying (which deploys main and routes to triaging on the
+ *      first deploy, else paritying)
+ * A merge conflict (main advanced under us) routes to needs_human(resume=fixing).
+ */
+
+import { addEvent } from "../../db/events.ts";
+import { getSite, updateSite } from "../../db/sites.ts";
+import type { SiteRow } from "../../db/types.ts";
+import {
+  deleteBranch,
+  getPullRequest,
+  mergePullRequest,
+  MergeConflictError,
+  parseRepo,
+} from "../../lib/github.ts";
+import type { WorkerCtx } from "../../lib/mesh.ts";
+import { isSimulation } from "../../sandbox/client.ts";
+
+async function advanceToDeploy(site: SiteRow, note: string): Promise<void> {
+  await updateSite(site.id, {
+    status: "deploying",
+    pr_number: null,
+    pr_url: null,
+    phase_detail: note,
+    last_progress_at: new Date().toISOString(),
+  });
+}
+
+export async function merging(site: SiteRow, ctx: WorkerCtx): Promise<void> {
+  if (isSimulation(ctx)) {
+    await advanceToDeploy(site, "[simulation] PR merged — deploying");
+    await addEvent(site.id, "[simulation] PR merged (squash) — deploying");
+    return;
+  }
+
+  if (!site.target_repo) throw new Error("target_repo not set");
+  const ref = parseRepo(site.target_repo);
+
+  if (!site.pr_number) {
+    // nothing to merge — treat as already done, deploy main
+    await advanceToDeploy(site, "no open PR — deploying main");
+    return;
+  }
+
+  // Read the PR first — idempotent re-entry (a prior tick may have merged it).
+  let pr;
+  try {
+    pr = await getPullRequest(ctx, ref, site.pr_number);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await addEvent(
+      site.id,
+      `Could not read PR #${site.pr_number} (${message.slice(0, 140)}) — retrying next tick`,
+      "warn",
+    );
+    return; // stay in merging, retry
+  }
+
+  if (!pr) {
+    await updateSite(site.id, {
+      status: "needs_human",
+      resume_status: "merging",
+      needs_human_reason: `PR #${site.pr_number} not found on ${site.target_repo} — merge it manually or retry.`,
+      last_progress_at: new Date().toISOString(),
+    });
+    await addEvent(
+      site.id,
+      `PR #${site.pr_number} not found — needs human`,
+      "error",
+    );
+    return;
+  }
+
+  try {
+    if (!pr.merged) {
+      if (pr.mergeableState === "dirty") {
+        await updateSite(site.id, {
+          status: "needs_human",
+          resume_status: "fixing",
+          needs_human_reason: `PR #${site.pr_number} has merge conflicts with main — rebase the branch (${site.work_branch}) and retry.`,
+          last_progress_at: new Date().toISOString(),
+        });
+        await addEvent(
+          site.id,
+          `PR #${site.pr_number} has conflicts — needs human (then resume fixing)`,
+          "warn",
+        );
+        return;
+      }
+      const merged = await mergePullRequest(ctx, ref, site.pr_number, {
+        method: "squash",
+      });
+      await addEvent(
+        site.id,
+        `PR #${site.pr_number} ${merged.alreadyMerged ? "was already merged" : "merged (squash)"}`,
+      );
+    } else {
+      await addEvent(
+        site.id,
+        `PR #${site.pr_number} already merged — continuing`,
+      );
+    }
+  } catch (err) {
+    if (err instanceof MergeConflictError) {
+      await updateSite(site.id, {
+        status: "needs_human",
+        resume_status: "fixing",
+        needs_human_reason: `PR #${site.pr_number} is not mergeable (${err.message}) — resolve conflicts and resume.`,
+        last_progress_at: new Date().toISOString(),
+      });
+      await addEvent(
+        site.id,
+        `PR #${site.pr_number} not mergeable — needs human`,
+        "warn",
+      );
+      return;
+    }
+    throw err; // transient — advanceSite will retry/fail with resume_status=merging
+  }
+
+  // best-effort branch cleanup — never block the pipeline
+  try {
+    await deleteBranch(ctx, ref, site.work_branch);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await addEvent(
+      site.id,
+      `branch ${site.work_branch} not deleted (${message.slice(0, 120)})`,
+      "warn",
+    );
+  }
+
+  const current = (await getSite(site.id)) ?? site;
+  await advanceToDeploy(
+    current,
+    `PR #${site.pr_number} merged — deploying main`,
+  );
+}

--- a/tanstack-migrator/server/engine/phases/opening-pr.ts
+++ b/tanstack-migrator/server/engine/phases/opening-pr.ts
@@ -1,12 +1,14 @@
 /**
- * Phase: opening_pr — MCP-side (no session):
- *   1. add the .deco sync workflow files to the WORK BRANCH (part of the PR
- *      diff; GitHub cron only runs on the default branch, so it activates
- *      after the merge — during migration the agent runs sync:decofile
- *      in-session when it needs fresh content)
- *   2. open the PR work_branch → main (the human merge is the go-live)
- *   3. re-SANDBOX_START so the daemon takes over install + dev server now
- *      that the branch has a package.json
+ * Phase: opening_pr — MCP-side (no session). REUSED by the initial migration
+ * and by every fix round:
+ *   1. open the PR for the current branch (site.work_branch) → main
+ *   2. INITIAL migration only: open the .deco sync-mirror PR on the CLIENT repo
+ *      (surfaced for the human to add the token + merge), and destroy+recreate
+ *      the sandbox so the daemon clones the branch with package.json present
+ *   3. advance to reviewing (code-review agent gate before the auto-merge)
+ *
+ * "Initial vs fix round" is derived from cf_deploy_url (unset until the first
+ * deploy), matching deploying-cf's advanceAfterDeploy.
  */
 
 import { addEvent } from "../../db/events.ts";
@@ -15,107 +17,86 @@ import type { SiteRow } from "../../db/types.ts";
 import {
   createPullRequest,
   findOpenPullRequest,
-  getFile,
   parseRepo,
-  putFile,
 } from "../../lib/github.ts";
 import type { WorkerCtx } from "../../lib/mesh.ts";
+import { installSyncWorkflow } from "../../lib/sync-install.ts";
 import { getDriver, isSimulation } from "../../sandbox/client.ts";
-import {
-  SYNC_PACKAGE_SCRIPT_NAME,
-  SYNC_SCRIPT_PATH,
-  SYNC_WORKFLOW_PATH,
-  syncPackageScriptCommand,
-  syncScriptSource,
-  syncWorkflowYaml,
-} from "../../sandbox/templates/sync-files.ts";
+
+function isInitialMigration(site: SiteRow): boolean {
+  return !site.cf_deploy_url;
+}
+
+function prTitle(site: SiteRow): string {
+  return isInitialMigration(site)
+    ? `TanStack Start migration — ${site.name}`
+    : `fix round ${site.fix_sessions_done} — ${site.name}`;
+}
 
 function prBody(site: SiteRow): string {
+  if (isInitialMigration(site)) {
+    return [
+      `Automatic migration of \`${site.source_repo}\` (Fresh/Deno) to TanStack Start, orchestrated by **tanstack-migrator**.`,
+      "",
+      `- Work branch: \`${site.work_branch}\``,
+      `- Parity target: **${site.parity_target}%** vs ${site.prod_url}`,
+      `- Reviewed by the code-review agent, then auto-merged; Cloudflare deploys \`main\` to \`*.workers.dev\`.`,
+    ].join("\n");
+  }
   return [
-    `Automatic migration of \`${site.source_repo}\` (Fresh/Deno) to TanStack Start, orchestrated by **tanstack-migrator**.`,
+    `Fix round ${site.fix_sessions_done} for the TanStack migration of \`${site.name}\` (branch \`${site.work_branch}\`).`,
     "",
-    `- Work branch: \`${site.work_branch}\` — short sessions commit here`,
-    `- Backlog: issues with the \`tanstack-migrator\` label (closed as fixes are pushed)`,
-    `- Parity target: **${site.parity_target}%** vs ${site.prod_url}`,
-    `- The \`.deco\` sync workflow is in this diff and activates after the merge (cron only runs on the default branch)`,
-    "",
-    "**Merge = go-live**: the Cloudflare project watches main and deploys on merge.",
+    "Drains a batch of `tanstack-migrator` issues. Reviewed by the code-review agent, then auto-merged.",
   ].join("\n");
+}
+
+/** Open the sync-mirror PR on the client repo (once). Never blocks the migration. */
+async function installClientSyncWorkflow(
+  site: SiteRow,
+  ctx: WorkerCtx,
+): Promise<void> {
+  if (!site.target_repo) return;
+  const sync = await installSyncWorkflow(ctx, parseRepo(site.source_repo), {
+    sourceRepo: site.source_repo,
+    targetRepo: site.target_repo,
+    base: site.source_branch,
+  });
+  if (sync.installed && sync.reason !== "reused") {
+    await addEvent(
+      site.id,
+      `.deco sync PR opened on ${site.source_repo} (${sync.prUrl ?? "?"}) — add the ${sync.tokenSecret} secret + merge to activate`,
+    );
+  } else if (!sync.installed && sync.reason !== "up-to-date") {
+    await addEvent(
+      site.id,
+      `.deco sync PR not opened on ${site.source_repo} (${sync.reason.slice(0, 150)}) — install ${sync.path} manually`,
+      "warn",
+    );
+  }
 }
 
 export async function openingPr(site: SiteRow, ctx: WorkerCtx): Promise<void> {
   if (isSimulation(ctx)) {
     await updateSite(site.id, {
-      status: "triaging",
+      status: "reviewing",
       pr_number: site.pr_number ?? 1,
       pr_url:
         site.pr_url ??
         `https://github.com/${site.target_repo ?? "sim/sim"}/pull/1`,
-      phase_detail: "[simulation] PR opened, triaging issues",
+      phase_detail: "[simulation] PR opened, reviewing",
       phase_thread_id: null,
       last_progress_at: new Date().toISOString(),
     });
-    await addEvent(site.id, "[simulation] PR opened (work branch → main)");
+    await addEvent(site.id, "[simulation] PR opened (branch → main)");
     return;
   }
 
   if (!site.target_repo) throw new Error("target_repo not set");
   const ref = parseRepo(site.target_repo);
   const branch = site.work_branch;
+  const initial = isInitialMigration(site);
 
-  // 1. sync files on the work branch — nice-to-have: a permission failure
-  // (workflows:write) must not block the migration
-  try {
-    await putFile(ctx, ref, {
-      path: SYNC_SCRIPT_PATH,
-      content: syncScriptSource(),
-      message: "chore: add .deco sync script (tanstack-migrator)",
-      branch,
-    });
-    const pkgFile = await getFile(ctx, ref, "package.json", branch);
-    if (pkgFile) {
-      try {
-        const pkg = JSON.parse(pkgFile.text) as {
-          scripts?: Record<string, string>;
-        };
-        const command = syncPackageScriptCommand(site.prod_url);
-        if (pkg.scripts?.[SYNC_PACKAGE_SCRIPT_NAME] !== command) {
-          pkg.scripts = { ...pkg.scripts, [SYNC_PACKAGE_SCRIPT_NAME]: command };
-          await putFile(ctx, ref, {
-            path: "package.json",
-            content: `${JSON.stringify(pkg, null, 2)}\n`,
-            message: "chore: add sync:decofile script (tanstack-migrator)",
-            branch,
-          });
-        }
-      } catch {
-        await addEvent(
-          site.id,
-          "package.json not parseable — sync:decofile script not added",
-          "warn",
-        );
-      }
-    }
-    await putFile(ctx, ref, {
-      path: SYNC_WORKFLOW_PATH,
-      content: syncWorkflowYaml({ prodUrl: site.prod_url }),
-      message: "ci: sync .deco/blocks from production (tanstack-migrator)",
-      branch,
-    });
-    await addEvent(
-      site.id,
-      ".deco sync added to the branch (activates after the merge)",
-    );
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    await addEvent(
-      site.id,
-      `.deco sync not installed (${message.slice(0, 160)}) — install ${SYNC_WORKFLOW_PATH} manually after the merge`,
-      "warn",
-    );
-  }
-
-  // 2. the PR (idempotent: reuse the branch's open PR on re-runs)
+  // 1. the PR (idempotent: reuse the branch's open PR on re-runs)
   let prPatch: Partial<SiteRow> = {};
   if (!site.pr_number) {
     const existing = await findOpenPullRequest(ctx, ref, branch).catch(
@@ -135,7 +116,7 @@ export async function openingPr(site: SiteRow, ctx: WorkerCtx): Promise<void> {
     } else {
       try {
         const pr = await createPullRequest(ctx, ref, {
-          title: `TanStack Start migration — ${site.name}`,
+          title: prTitle(site),
           body: prBody(site),
           head: branch,
           base: "main",
@@ -154,7 +135,7 @@ export async function openingPr(site: SiteRow, ctx: WorkerCtx): Promise<void> {
         const message = err instanceof Error ? err.message : String(err);
         if (!/already exists|pull request already/i.test(message)) throw err;
         // a PR exists but findOpenPullRequest missed it — fail retryably
-        // instead of continuing without a number (that would skip the merge gate)
+        // instead of continuing without a number (that would skip the gate)
         throw new Error(
           `PR for ${branch} already exists but was not located (${message.slice(0, 120)}) — retry will find it again`,
         );
@@ -162,42 +143,56 @@ export async function openingPr(site: SiteRow, ctx: WorkerCtx): Promise<void> {
     }
   }
 
-  // 3. fresh sandbox — destroy + recreate so the daemon clones the branch
-  // WITH package.json already present (provisioning_sandbox ran when the repo
-  // was still empty; the daemon marks packageManager=null and never recovers).
-  try {
-    await getDriver(ctx).destroy({ ...site, ...prPatch } as SiteRow, ctx);
-  } catch {
-    // sandbox may have already expired — ignore
-  }
-  try {
-    const info = await getDriver(ctx).ensure(
-      { ...site, ...prPatch } as SiteRow,
-      ctx,
-    );
-    prPatch = {
-      ...prPatch,
-      sandbox_handle: info.handle,
-      sandbox_preview_url: info.previewUrl,
-      preview_ready: false,
-    };
-    await addEvent(
-      site.id,
-      "Sandbox recreated — daemon clones the branch with package.json, installs deps and starts the dev server",
-    );
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    await addEvent(
-      site.id,
-      `Sandbox recreation failed (${message.slice(0, 160)}) — keepalive retries on the next tick`,
-      "warn",
-    );
+  // 2. INITIAL migration only: client sync PR + sandbox recreate (fix rounds
+  // reuse the existing sandbox and the sync is already on the client repo).
+  if (initial) {
+    try {
+      await installClientSyncWorkflow(site, ctx);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await addEvent(
+        site.id,
+        `.deco sync PR step skipped (${message.slice(0, 150)})`,
+        "warn",
+      );
+    }
+
+    // fresh sandbox — destroy + recreate so the daemon clones the branch WITH
+    // package.json already present (provisioning_sandbox ran on an empty repo).
+    try {
+      await getDriver(ctx).destroy({ ...site, ...prPatch } as SiteRow, ctx);
+    } catch {
+      // sandbox may have already expired — ignore
+    }
+    try {
+      const info = await getDriver(ctx).ensure(
+        { ...site, ...prPatch } as SiteRow,
+        ctx,
+      );
+      prPatch = {
+        ...prPatch,
+        sandbox_handle: info.handle,
+        sandbox_preview_url: info.previewUrl,
+        preview_ready: false,
+      };
+      await addEvent(
+        site.id,
+        "Sandbox recreated — daemon clones the branch with package.json, installs deps and starts the dev server",
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await addEvent(
+        site.id,
+        `Sandbox recreation failed (${message.slice(0, 160)}) — keepalive retries on the next tick`,
+        "warn",
+      );
+    }
   }
 
   await updateSite(site.id, {
     ...prPatch,
-    status: "triaging",
-    phase_detail: "PR opened, triaging issues",
+    status: "reviewing",
+    phase_detail: `PR #${prPatch.pr_number ?? site.pr_number} opened — reviewing`,
     phase_thread_id: null,
     last_progress_at: new Date().toISOString(),
   });

--- a/tanstack-migrator/server/engine/phases/paritying.ts
+++ b/tanstack-migrator/server/engine/phases/paritying.ts
@@ -116,23 +116,27 @@ export async function paritying(
   ctx: WorkerCtx,
   deps: EngineDeps,
 ): Promise<void> {
-  // Terminal checks first (idempotent re-entry)
+  // Terminal checks first (idempotent re-entry). Parity is measured AFTER the
+  // per-round merge+deploy, so a PR is never open here. Target met:
+  //   - backlog empty → done
+  //   - backlog non-empty → keep draining in fixing (no wasted parity session,
+  //     which also avoids a false no_improve strike while the score holds)
   const target = site.parity_target;
   if (site.parity_score !== null && site.parity_score >= target) {
-    const hasPr = Boolean(site.pr_number);
+    const done = site.issues_open === 0;
     await updateSite(site.id, {
-      status: hasPr ? "awaiting_merge" : "done",
-      phase_detail: hasPr
-        ? `parity ${site.parity_score}% ✓ — awaiting merge of PR #${site.pr_number}`
-        : `parity ${site.parity_score}% ✓ — migration done`,
-      finished_at: hasPr ? undefined : new Date().toISOString(),
+      status: done ? "done" : "fixing",
+      phase_detail: done
+        ? `parity ${site.parity_score}% ✓ — migration done`
+        : `parity ${site.parity_score}% ✓ — draining ${site.issues_open} open issues`,
+      finished_at: done ? new Date().toISOString() : undefined,
       last_progress_at: new Date().toISOString(),
     });
     await addEvent(
       site.id,
-      hasPr
-        ? `Parity ${site.parity_score}% — only the merge of PR #${site.pr_number} is left`
-        : `Parity ${site.parity_score}% — migration done 🎉`,
+      done
+        ? `Parity ${site.parity_score}% — migration done 🎉`
+        : `Parity ${site.parity_score}% reached — draining ${site.issues_open} remaining issues`,
     );
     return;
   }
@@ -258,7 +262,6 @@ export async function paritying(
           ctx.config.maxIssuesPerTriage,
         );
         createdCount = sync.created.length;
-        await refreshIssueCounts(ctx, current);
       }
 
       await finishRun(run.id, {
@@ -271,7 +274,19 @@ export async function paritying(
       });
 
       const hitTarget = score !== null && score >= target;
-      const hasPr = Boolean(current.pr_number);
+      // latest backlog drives the loop-back decision
+      const openNow = isSimulation(ctx)
+        ? current.issues_open
+        : (await refreshIssueCounts(ctx, current)).open;
+
+      // done (target + empty backlog) | fixing (more issues to drain) |
+      // re-triage (target missed but backlog empty → find more work)
+      const nextStatus: SiteRow["status"] =
+        hitTarget && openNow === 0
+          ? "done"
+          : !hitTarget && openNow === 0
+            ? "triaging"
+            : "fixing";
       await updateSite(site.id, {
         parity_score: score,
         best_score: improved ? score : current.best_score,
@@ -280,14 +295,15 @@ export async function paritying(
         sandbox_session_id: null,
         phase_thread_id: null,
         transient_retries: 0,
-        status: hitTarget ? (hasPr ? "awaiting_merge" : "done") : "fixing",
-        phase_detail: `round ${iteration}: score ${score ?? "?"}${hitTarget ? " — target reached!" : ` (${createdCount} new issues)`}`,
-        finished_at: hitTarget && !hasPr ? new Date().toISOString() : undefined,
+        status: nextStatus,
+        phase_detail: `round ${iteration}: score ${score ?? "?"}${hitTarget && openNow === 0 ? " — target reached!" : ` (${createdCount} new issues, backlog ${openNow})`}`,
+        finished_at:
+          nextStatus === "done" ? new Date().toISOString() : undefined,
         last_progress_at: new Date().toISOString(),
       });
       await addEvent(
         site.id,
-        `Parity round ${iteration} — score ${score ?? "unknown"}%${createdCount > 0 ? ` · ${createdCount} new issues` : ""}`,
+        `Parity round ${iteration} — score ${score ?? "unknown"}%${createdCount > 0 ? ` · ${createdCount} new issues` : ""} → ${nextStatus}`,
       );
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/tanstack-migrator/server/engine/phases/reviewing.ts
+++ b/tanstack-migrator/server/engine/phases/reviewing.ts
@@ -1,0 +1,177 @@
+/**
+ * Phase: reviewing — a code-review agent gates the auto-merge. ONE analyze-only
+ * session reviews the diff of the current PR branch vs main and returns
+ * approved:true/false in its RESULT_JSON.
+ *   - approved       → merging (MCP squash-merges)
+ *   - not approved   → persist the blocking problems as issues and go back to
+ *                      fixing ON THE SAME branch/PR (no work lost); when the
+ *                      fix budget is spent → needs_human.
+ */
+
+import { SESSION_TIMEOUT_MS } from "../../constants.ts";
+import { addEvent } from "../../db/events.ts";
+import { createRun, finishRun } from "../../db/runs.ts";
+import { getSite, incrementCost, updateSite } from "../../db/sites.ts";
+import type { SiteRow } from "../../db/types.ts";
+import { refreshIssueCounts, syncIssuesFromDrafts } from "../../lib/issues.ts";
+import type { WorkerCtx } from "../../lib/mesh.ts";
+import { getDriver, isSimulation } from "../../sandbox/client.ts";
+import { reviewPrompt } from "../../sandbox/templates/prompts.ts";
+import type { EngineDeps } from "../machine.ts";
+import { clearStaleSession, markSessionStart } from "./session-guard.ts";
+import { failOrAutoRetry } from "./transient.ts";
+
+export async function reviewing(
+  site: SiteRow,
+  ctx: WorkerCtx,
+  deps: EngineDeps,
+): Promise<void> {
+  if (!site.pr_number) {
+    // opening_pr must have set it — nothing to review without a PR
+    await updateSite(site.id, {
+      status: "opening_pr",
+      phase_detail: "no PR to review — reopening",
+      last_progress_at: new Date().toISOString(),
+    });
+    return;
+  }
+
+  if (deps.inflight.has(site.id)) return;
+  const proceed = await clearStaleSession(site, deps);
+  if (!proceed) return;
+
+  const run = await createRun({ siteId: site.id, kind: "review" });
+  await markSessionStart(site.id, "review");
+  await addEvent(site.id, `Code review of PR #${site.pr_number} started`);
+
+  deps.inflight.start(site.id, "review", async () => {
+    try {
+      const result = await getDriver(ctx).runTask(site, ctx, {
+        kind: "review",
+        prompt: isSimulation(ctx)
+          ? ""
+          : reviewPrompt({ site, prNumber: site.pr_number! }),
+        runId: run.id,
+        threadId: site.phase_thread_id ?? undefined,
+        timeoutMs: SESSION_TIMEOUT_MS.review,
+      });
+      await incrementCost(site.id, result.meta?.usage?.costUsd);
+
+      const current = await getSite(site.id);
+      if (!current || current.status !== "reviewing") {
+        await finishRun(run.id, {
+          status: "failed",
+          logsTail: `[abandoned: site left reviewing during the session]`,
+          meta: result.meta,
+        });
+        return;
+      }
+
+      if (!result.ok) {
+        await finishRun(run.id, {
+          status: "failed",
+          logsTail: result.output,
+          meta: result.meta,
+        });
+        await failOrAutoRetry(
+          current,
+          result.error ?? "review failed",
+          "reviewing",
+          "Code review failed",
+        );
+        return;
+      }
+
+      // Simulation always approves so the e2e flow reaches merging.
+      const approved = isSimulation(ctx)
+        ? true
+        : result.parsed?.approved === true;
+
+      if (approved) {
+        await finishRun(run.id, {
+          status: "succeeded",
+          logsTail: result.output,
+          meta: result.meta,
+        });
+        await updateSite(site.id, {
+          status: "merging",
+          phase_detail: `review approved PR #${current.pr_number} — merging`,
+          sandbox_session_id: null,
+          phase_thread_id: null,
+          transient_retries: 0,
+          last_progress_at: new Date().toISOString(),
+        });
+        await addEvent(
+          site.id,
+          `Review approved PR #${current.pr_number} — merging`,
+        );
+        return;
+      }
+
+      // Rejected: fold the blocking problems into the backlog and keep fixing
+      // on the SAME branch/PR (do NOT reset pr_number — no work is lost).
+      const drafts = result.parsed?.issues ?? [];
+      if (drafts.length > 0) {
+        await syncIssuesFromDrafts(
+          ctx,
+          current,
+          drafts,
+          "triage",
+          ctx.config.maxIssuesPerTriage,
+        );
+      }
+      const counts = await refreshIssueCounts(ctx, current);
+      await finishRun(run.id, {
+        status: "succeeded",
+        logsTail: result.output,
+        meta: { ...result.meta, issues: { created: drafts.length } },
+      });
+
+      if (current.fix_sessions_done >= current.max_fix_sessions) {
+        await updateSite(site.id, {
+          status: "needs_human",
+          resume_status: "reviewing",
+          needs_human_reason:
+            `Code review keeps rejecting PR #${current.pr_number} and the fix budget (${current.max_fix_sessions}) is spent. ${result.parsed?.detail ?? ""}`.slice(
+              0,
+              500,
+            ),
+          sandbox_session_id: null,
+          phase_thread_id: null,
+          last_progress_at: new Date().toISOString(),
+        });
+        await addEvent(
+          site.id,
+          `Review rejected PR #${current.pr_number} and fix budget is spent — needs human`,
+          "warn",
+        );
+        return;
+      }
+
+      await updateSite(site.id, {
+        status: "fixing",
+        phase_detail: `review requested changes (${drafts.length} issues) — backlog ${counts.open}, back to fixing`,
+        sandbox_session_id: null,
+        phase_thread_id: null,
+        transient_retries: 0,
+        last_progress_at: new Date().toISOString(),
+      });
+      await addEvent(
+        site.id,
+        `Review requested changes on PR #${current.pr_number}: ${drafts.length} issues — back to fixing (same branch)`,
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await finishRun(run.id, { status: "failed", logsTail: message });
+      const current = await getSite(site.id);
+      if (current) {
+        await failOrAutoRetry(
+          current,
+          message,
+          "reviewing",
+          "Code review failed",
+        );
+      }
+    }
+  });
+}

--- a/tanstack-migrator/server/lib/github.ts
+++ b/tanstack-migrator/server/lib/github.ts
@@ -438,6 +438,9 @@ export interface PullRequestInfo {
   url?: string;
   state: string;
   merged: boolean;
+  /** From the single-PR get only (absent on list endpoints). */
+  mergeable?: boolean | null;
+  mergeableState?: string; // "clean" | "dirty" | "blocked" | "unknown"
 }
 
 function toPullRequest(raw: Record<string, unknown>): PullRequestInfo | null {
@@ -461,7 +464,15 @@ function toPullRequest(raw: Record<string, unknown>): PullRequestInfo | null {
     typeof raw.merged_at === "string" ||
     typeof raw.mergedAt === "string" ||
     state === "merged";
-  return { number, url, state, merged };
+  const mergeable =
+    typeof raw.mergeable === "boolean" ? raw.mergeable : undefined;
+  const mergeableState =
+    typeof raw.mergeable_state === "string"
+      ? raw.mergeable_state
+      : typeof raw.mergeableState === "string"
+        ? raw.mergeableState
+        : undefined;
+  return { number, url, state, merged, mergeable, mergeableState };
 }
 
 export async function createPullRequest(
@@ -601,6 +612,126 @@ export async function getPullRequest(
   throw lastError instanceof Error
     ? lastError
     : new Error(`getPullRequest failed: ${message}`);
+}
+
+/** Thrown when the PR cannot be merged because of conflicts (not a transient). */
+export class MergeConflictError extends Error {}
+
+/**
+ * Squash-merge a PR. Idempotent: an already-merged PR resolves as success.
+ * Tolerates the proxy's arg-shape variants (consolidated pull_request_write vs
+ * discrete merge_pull_request; pullNumber vs pull_number).
+ */
+export async function mergePullRequest(
+  ctx: WorkerCtx,
+  ref: RepoRef,
+  prNumber: number,
+  opts: { method?: "squash" | "merge" | "rebase"; title?: string } = {},
+): Promise<{ merged: boolean; alreadyMerged: boolean }> {
+  const method = opts.method ?? "squash";
+  const attempts: Array<{ tool: string; args: Record<string, unknown> }> = [
+    {
+      tool: "pull_request_write",
+      args: {
+        method: "merge",
+        owner: ref.owner,
+        repo: ref.repo,
+        pullNumber: prNumber,
+        merge_method: method,
+        ...(opts.title ? { commit_title: opts.title } : {}),
+      },
+    },
+    {
+      tool: "merge_pull_request",
+      args: {
+        owner: ref.owner,
+        repo: ref.repo,
+        pull_number: prNumber,
+        merge_method: method,
+        ...(opts.title ? { commit_title: opts.title } : {}),
+      },
+    },
+    {
+      tool: "merge_pull_request",
+      args: {
+        owner: ref.owner,
+        repo: ref.repo,
+        pullNumber: prNumber,
+        merge_method: method,
+      },
+    },
+  ];
+  let lastError: unknown = null;
+  for (const attempt of attempts) {
+    try {
+      await callBindingTool(ctx, "GITHUB", attempt.tool, attempt.args);
+      return { merged: true, alreadyMerged: false };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // already merged — the state we wanted
+      if (
+        /already merged|pull request is not mergeable.*merged|already been merged/i.test(
+          message,
+        )
+      ) {
+        return { merged: true, alreadyMerged: true };
+      }
+      // genuine conflict — not retryable with a different arg shape
+      if (
+        /not mergeable|merge conflict|conflict|405/i.test(message) &&
+        !isUnknownToolError(message)
+      ) {
+        throw new MergeConflictError(message.slice(0, 200));
+      }
+      lastError = err;
+      // otherwise try the next shape
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`mergePullRequest failed: ${String(lastError ?? "")}`);
+}
+
+/** Delete a branch. Best-effort: an already-gone branch resolves as success. */
+export async function deleteBranch(
+  ctx: WorkerCtx,
+  ref: RepoRef,
+  branch: string,
+): Promise<void> {
+  const attempts: Array<{ tool: string; args: Record<string, unknown> }> = [
+    {
+      tool: "delete_branch",
+      args: { owner: ref.owner, repo: ref.repo, branch },
+    },
+    {
+      tool: "git",
+      args: {
+        method: "delete_ref",
+        owner: ref.owner,
+        repo: ref.repo,
+        ref: `heads/${branch}`,
+      },
+    },
+    {
+      tool: "delete_ref",
+      args: { owner: ref.owner, repo: ref.repo, ref: `heads/${branch}` },
+    },
+  ];
+  let lastError: unknown = null;
+  for (const attempt of attempts) {
+    try {
+      await callBindingTool(ctx, "GITHUB", attempt.tool, attempt.args);
+      return;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (/not found|404|reference does not exist|no such/i.test(message))
+        return;
+      lastError = err;
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`deleteBranch failed: ${String(lastError ?? "")}`);
 }
 
 interface FileContents {

--- a/tanstack-migrator/server/lib/sync-install.ts
+++ b/tanstack-migrator/server/lib/sync-install.ts
@@ -1,0 +1,139 @@
+/**
+ * Install the .deco sync-mirror workflow into a CLIENT production repo — via a
+ * PR, with the strictest possible blast radius: it adds EXACTLY ONE file
+ * (`.github/workflows/sync-deco-content.yml`) on a dedicated branch and opens a
+ * PR into the client's default branch. It never pushes to the client's main
+ * directly and never touches any other file — a human reviews/merges it and
+ * adds the token secret.
+ *
+ * Idempotent: reuses an already-open sync PR and skips the write when the file
+ * already matches. Fail-safe: a missing `workflows:write` permission returns a
+ * reason instead of throwing, so it can never block a migration.
+ */
+
+import {
+  createPullRequest,
+  ensureBranch,
+  findOpenPullRequest,
+  getFile,
+  putFile,
+  type RepoRef,
+} from "./github.ts";
+import type { WorkerCtx } from "./mesh.ts";
+import {
+  DEFAULT_SYNC_TOKEN_SECRET,
+  SYNC_WORKFLOW_PATH,
+  syncWorkflowYaml,
+} from "../sandbox/templates/sync-files.ts";
+
+export const SYNC_PR_BRANCH = "chore/deco-sync";
+
+export interface InstallSyncResult {
+  installed: boolean;
+  path: string;
+  prNumber: number | null;
+  prUrl: string | null;
+  tokenSecret: string;
+  /** "opened" | "reused" | "up-to-date" | error message when installed=false */
+  reason: string;
+}
+
+/**
+ * Open (or reuse) a PR on `clientRef` that adds only the sync workflow.
+ * `targetRepo` is the -tanstack repo the workflow mirrors into.
+ */
+export async function installSyncWorkflow(
+  ctx: WorkerCtx,
+  clientRef: RepoRef,
+  input: {
+    sourceRepo: string;
+    targetRepo: string;
+    base?: string;
+    headBranch?: string;
+    tokenSecret?: string;
+  },
+): Promise<InstallSyncResult> {
+  const base = input.base ?? "main";
+  const head = input.headBranch ?? SYNC_PR_BRANCH;
+  const tokenSecret = input.tokenSecret ?? DEFAULT_SYNC_TOKEN_SECRET;
+  const content = syncWorkflowYaml({
+    sourceRepo: input.sourceRepo,
+    targetRepo: input.targetRepo,
+    tokenSecret,
+  });
+  const base_result = (
+    reason: string,
+    extra: Partial<InstallSyncResult> = {},
+  ) => ({
+    installed: false,
+    path: SYNC_WORKFLOW_PATH,
+    prNumber: null,
+    prUrl: null,
+    tokenSecret,
+    reason,
+    ...extra,
+  });
+
+  try {
+    // dedicated branch off the client default — never commit to main directly
+    await ensureBranch(ctx, clientRef, head, base);
+    const outcome = await putFile(ctx, clientRef, {
+      path: SYNC_WORKFLOW_PATH,
+      content,
+      message:
+        "ci: mirror .deco to the TanStack storefront (tanstack-migrator)",
+      branch: head,
+    });
+
+    // reuse an already-open PR for this branch
+    const existing = await findOpenPullRequest(ctx, clientRef, head).catch(
+      () => null,
+    );
+    if (existing) {
+      return {
+        installed: true,
+        path: SYNC_WORKFLOW_PATH,
+        prNumber: existing.number,
+        prUrl: existing.url ?? null,
+        tokenSecret,
+        reason: "reused",
+      };
+    }
+    // nothing changed and no open PR → already merged/installed, nothing to do
+    if (outcome === "unchanged") return base_result("up-to-date");
+
+    const pr = await createPullRequest(ctx, clientRef, {
+      title: "ci: mirror .deco to the TanStack storefront",
+      body: [
+        `Adds \`${SYNC_WORKFLOW_PATH}\` — mirrors \`.deco/blocks\` published here into \`${input.targetRepo}\` on every push, so the TanStack migration stays in sync with the live CMS.`,
+        "",
+        `**This is the only file this PR adds.** To activate it after merging, add a repo secret \`${tokenSecret}\` — a PAT (or fine-grained token) with **write** access to \`${input.targetRepo}\`.`,
+        "",
+        "Opened automatically by **tanstack-migrator**.",
+      ].join("\n"),
+      head,
+      base,
+    });
+    return {
+      installed: true,
+      path: SYNC_WORKFLOW_PATH,
+      prNumber: pr.number,
+      prUrl: pr.url ?? null,
+      tokenSecret,
+      reason: "opened",
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return base_result(message);
+  }
+}
+
+/** Read-only probe: does the client already have the workflow on its default branch? */
+export async function syncWorkflowInstalled(
+  ctx: WorkerCtx,
+  clientRef: RepoRef,
+  base = "main",
+): Promise<boolean> {
+  const file = await getFile(ctx, clientRef, SYNC_WORKFLOW_PATH, base);
+  return Boolean(file && file.text.includes("Sync .deco to TanStack"));
+}

--- a/tanstack-migrator/server/migrator.test.ts
+++ b/tanstack-migrator/server/migrator.test.ts
@@ -23,10 +23,7 @@ import {
   parseResultJson,
   triagePrompt,
 } from "./sandbox/templates/prompts.ts";
-import {
-  syncPackageScriptCommand,
-  syncWorkflowYaml,
-} from "./sandbox/templates/sync-files.ts";
+import { syncWorkflowYaml } from "./sandbox/templates/sync-files.ts";
 import { looksLikeRealSite } from "./lib/preview.ts";
 import type { SiteRow } from "./db/types.ts";
 
@@ -147,10 +144,17 @@ describe("prompts", () => {
     expect(prompt).toContain("credentials synced by the mesh");
   });
 
-  test("triagePrompt: analyze-only with capped issue list contract", () => {
+  test("triagePrompt: analyze-only, exhaustive (no cap), with browser + sweep checks", () => {
     const prompt = triagePrompt({ site, maxIssues: 15 });
     expect(prompt).toContain("ANALYSIS ONLY");
-    expect(prompt).toContain("At most 15 issues");
+    // uncapped: report every real problem, only the top N persist
+    expect(prompt).toContain("no cap");
+    expect(prompt).toContain("Only the top 15 are persisted");
+    // deep investigation: headless browser console + grep sweep
+    expect(prompt).toContain("playwright");
+    expect(prompt).toContain("pageerror");
+    expect(prompt).toContain("@preact/signals");
+    expect(prompt).toContain("dangerouslySetInnerHTML");
     expect(prompt).toContain("tsc --noEmit");
     expect(prompt).toContain('"issues": [');
     expect(prompt).toContain("git checkout migration/tanstack");
@@ -471,16 +475,32 @@ describe("looksLikeRealSite (preview readiness)", () => {
 });
 
 describe("sync templates", () => {
-  test("workflow yaml references the prod host and the package script", () => {
-    const yaml = syncWorkflowYaml({ prodUrl: "https://www.granado.com.br" });
-    expect(yaml).toContain('cron: "*/30 * * * *"');
-    expect(yaml).toContain("bun run sync:decofile");
-    expect(yaml).toContain("sync: .deco/blocks from www.granado.com.br");
+  test("workflow yaml is the push-mirror (client repo → target repo)", () => {
+    const yaml = syncWorkflowYaml({
+      sourceRepo: "deco-sites/miess-01",
+      targetRepo: "deco-sites/miess-01-tanstack",
+    });
+    // event-driven on CMS commits, not a cron/URL poll
+    expect(yaml).toContain("push:");
+    expect(yaml).toContain("paths: ['.deco/**']");
+    // mirrors blocks into the target repo using the token secret
+    expect(yaml).toContain("repository: deco-sites/miess-01-tanstack");
+    expect(yaml).toContain("${{ secrets.STOREFRONT_SYNC_TOKEN }}");
+    expect(yaml).toContain("rsync -av --delete");
+    expect(yaml).toContain("source/.deco/blocks/ target/.deco/blocks/");
+    expect(yaml).toContain("sync: .deco content from miess-01");
+    expect(yaml).toContain('user.name "deco-sync-bot"');
+    // it is ONLY a workflow — no cron, no URL fetch, no helper script
+    expect(yaml).not.toContain("cron:");
+    expect(yaml).not.toContain("/.decofile");
   });
 
-  test("package script points the shim at the prod url", () => {
-    expect(syncPackageScriptCommand("https://www.granado.com.br")).toBe(
-      "bun scripts/sync-decofile.ts --url https://www.granado.com.br",
-    );
+  test("token secret name is overridable", () => {
+    const yaml = syncWorkflowYaml({
+      sourceRepo: "deco-sites/acme",
+      targetRepo: "deco-sites/acme-tanstack",
+      tokenSecret: "CUSTOM_TOKEN",
+    });
+    expect(yaml).toContain("${{ secrets.CUSTOM_TOKEN }}");
   });
 });

--- a/tanstack-migrator/server/sandbox/client.ts
+++ b/tanstack-migrator/server/sandbox/client.ts
@@ -28,6 +28,7 @@ export interface SandboxInfo {
 export type SandboxTaskKind =
   | "migrate"
   | "triage"
+  | "review"
   | "fix"
   | "parity"
   | "deploy"

--- a/tanstack-migrator/server/sandbox/drivers/manual.ts
+++ b/tanstack-migrator/server/sandbox/drivers/manual.ts
@@ -75,6 +75,17 @@ export const manualDriver: SandboxDriver = {
         parsed: { ok: true, resolved: [], detail: "[simulation] fixes pushed" },
       };
     }
+    if (task.kind === "review") {
+      return {
+        ok: true,
+        output: "[simulation] code review approved",
+        parsed: {
+          ok: true,
+          approved: true,
+          detail: "[simulation] review approved",
+        },
+      };
+    }
     const iteration = task.iteration ?? site.iterations_done;
     const score = simulatedParityScore(iteration + 1);
     return {

--- a/tanstack-migrator/server/sandbox/templates/prompts.ts
+++ b/tanstack-migrator/server/sandbox/templates/prompts.ts
@@ -116,7 +116,9 @@ export interface SessionResult {
   ok: boolean;
   parityScore?: number;
   detail?: string;
-  /** triage: problems to persist as GitHub issues. */
+  /** review: whether the code-review agent approved the PR for merge. */
+  approved?: boolean;
+  /** triage/review: problems to persist as GitHub issues. */
   issues?: IssueDraft[];
   /** fix: GitHub issue numbers the session claims to have resolved (pushed). */
   resolved?: number[];
@@ -200,6 +202,8 @@ export function parseResultJson(output: string): SessionResult | null {
       parityScore:
         typeof parsed.parityScore === "number" ? parsed.parityScore : undefined,
       detail: typeof parsed.detail === "string" ? parsed.detail : undefined,
+      approved:
+        typeof parsed.approved === "boolean" ? parsed.approved : undefined,
       issues,
       resolved,
       blocked,
@@ -254,7 +258,8 @@ This block is idempotent and self-healing: run it in full before analyzing/fixin
 # /app/source = pristine clone of the original deco.cx site (to port components/compare). DISAPPEARS on
 # sandbox recreate — re-clones idempotently. NEVER modify it or run migrate on it.
 [ -d /app/source/.git ] || git clone --depth 1 -b ${site.source_branch} ${sourceUrl} /app/source 2>/dev/null || true
-cd /app/repo && git checkout ${branch} && git pull origin ${branch} 2>/dev/null || true
+# sync to the round branch (fresh fix branches are cut off main server-side; fall back to main)
+cd /app/repo && git fetch origin ${branch} main 2>/dev/null; git checkout -B ${branch} origin/${branch} 2>/dev/null || git checkout -B ${branch} origin/main 2>/dev/null || git checkout ${branch} 2>/dev/null || true
 rm -f org 2>/dev/null || true                          # sandbox mount symlink
 [ -d node_modules ] || bun install || npm install       # clean deps (node_modules is gitignored — never comes from the branch)
 # gitignored generates: without routeTree.gen.ts the router has no routes → "No web page" placeholder
@@ -350,20 +355,51 @@ The success criterion for this migration is: **\`npm run build\` passes** (exit 
 
 ${ensureReadyPreamble(site)}
 
-# Survey (in this order of priority)
+# Survey (be EXHAUSTIVE — there is no cap on issues; run every check below before writing RESULT_JSON)
 1. **Build (critical gate)**: \`npm run build 2>&1 | tail -60\`. If it FAILS (exit≠0), the error(s) breaking the build are the critical/high issues — focus on them.
 2. **Runtime — the site MUST render HTML (prerequisite for parity)**: with dev already up from Setup, \`curl -sL http://localhost:$DEV_PORT/ 2>&1 | head -120\`:
    a. If it returns **"No web page at this URL"** (sandbox placeholder) OR a nearly empty shell (just \`<div id="root"></div>\` with no content) → the **SSR is broken**: dev comes up but \`/\` does not return rendered HTML (severity **high**, category **runtime**). Common cause #1: **node_modules with the wrong version** (if it was committed to the branch, e.g. vite ≠ package.json) — the fix is \`rm -rf node_modules && npm install\` and never committing node_modules. Also investigate \`tail -80 /tmp/dev.log\` for the SSR stack (\`is not a function\`, missing module) and open the file:line.
    a2. If \`/\` RETURNS HTML (200, thousands of bytes) but contains \`Switched to client rendering because the server rendering errored\` → the SSR **degraded to client-render**: the page renders, but with a real SSR bug (severity **medium**, runtime). Grep the stack: \`curl -sL http://localhost:$DEV_PORT/ | grep -o "server rendering errored[^<]*"\` and \`tail -80 /tmp/dev.log\`. MOST common cause: **client-only globals used in the server render** (\`globalThis.location\`, \`window\`, \`document\`) → yields \`Cannot read properties of undefined (reading 'href')\`. Fix: guard with \`typeof window !== "undefined"\` (or move to useEffect). Report with the file:line.
    b. If \`/\` renders but the blocks are empty: \`ls .deco/blocks/ 2>/dev/null | head -20\` — check that the \`__resolveType\` values match the exports of \`src/sections/\` and \`src/apps/\`.
    c. Test routes: home, category, product (URLs in /app/source/routes/).
-3. SECONDARY typecheck: \`npx tsc --noEmit 2>&1 | head -60\` — ONLY if the build passed. Group by root cause; these go in as severity "low" (type debt), since they block neither deploy nor parity.
-4. Compare with /app/source: sections/components that exist there and were not ported (those ARE relevant — visual/content).
+3. **Terminal/dev.log errors**: \`tail -120 /tmp/dev.log\` and grep it for real problems — \`grep -iE "error|warn|fail|is not a function|cannot read|hydrat|unhandled|ECONN|EADDR|Module not found" /tmp/dev.log | tail -60\`. Every recurring stack in the dev log is a runtime issue (open the file:line it points to).
+4. **Browser console errors (headless, REAL browser)**: curl cannot see client-side \`console.error\`/hydration warnings — a real browser can. Install Playwright's chromium in a scratch dir (the same engine \`@decocms/parity\` uses) and visit the key routes, collecting console errors + uncaught page errors:
+\`\`\`bash
+cd /tmp && npm init -y >/dev/null 2>&1 && npm i playwright >/dev/null 2>&1 && npx playwright install --with-deps chromium >/dev/null 2>&1 || npx playwright install chromium >/dev/null 2>&1
+cat > /tmp/console-check.mjs <<'PW_EOF'
+import { chromium } from "playwright";
+const PORT = process.env.DEV_PORT || "5173";
+const base = "http://localhost:" + PORT;
+const routes = (process.env.ROUTES || "/").split(",");
+const browser = await chromium.launch();
+const found = [];
+for (const route of routes) {
+  const page = await browser.newPage();
+  page.on("console", (m) => { if (m.type() === "error") found.push(route + " [console.error] " + m.text()); });
+  page.on("pageerror", (e) => { found.push(route + " [pageerror] " + (e && e.message ? e.message : String(e))); });
+  try { await page.goto(base + route, { waitUntil: "networkidle", timeout: 30000 }); }
+  catch (e) { found.push(route + " [navigation] " + (e && e.message ? e.message : String(e))); }
+  await page.waitForTimeout(1500);
+  await page.close();
+}
+await browser.close();
+console.log(found.length ? found.join("\\n") : "no console/page errors");
+PW_EOF
+DEV_PORT=$DEV_PORT ROUTES="/,$(cat /tmp/routes.txt 2>/dev/null || echo /)" node /tmp/console-check.mjs
+\`\`\`
+   Pick real routes for ROUTES (home + a category + a product from /app/source/routes/, comma-separated). A \`Hydration failed\`, \`Text content does not match\`, \`Prop \\\`...\\\` did not match\`, or any \`console.error\` → a **medium** runtime/visual issue (hydration mismatch). If chromium cannot be installed, say so in the detail and fall back to the curl checks — do NOT block.
+5. **Deep migration sweep (grep — leftovers from Fresh/Preact that survived the codemod)**: run these in /app/repo/src and report each real hit (medium unless it breaks the build):
+   - Fresh/Preact leftovers: \`grep -rnE 'from "preact|@preact/signals|useSignal|@deco/deco|\\$fresh/|from "apps/|~/islands/' src/ | head -40\` — these should be zero after migration; each is a port/rewrite issue.
+   - Hydration risk (client-only globals in modules that render on the server): \`grep -rnE '\\b(window|document|globalThis)\\.' src/ | grep -viE 'useEffect|typeof window|typeof document' | head -40\`.
+   - Edge-cache contamination (per-user data baked into SSR HTML): \`grep -rnE 'dangerouslySetInnerHTML|inlineScript' src/ | head -40\` cross-referenced with loaders reading cookies \`grep -rnE 'getCookies|parseCookie|headers.*cookie' src/ | head -40\` — an inlineScript/dangerouslySetInnerHTML that embeds cookie-derived data (CEP, cart, user) is a **high** cache-contamination bug.
+   - Image optimization: \`grep -rnE 'height=\\{undefined\\}|width=\\{undefined\\}' src/ | head -20\` and raw S3 URLs in blocks \`grep -rn 's3\\..*amazonaws\\.com' .deco/blocks/ 2>/dev/null | head -20\`.
+6. SECONDARY typecheck: \`npx tsc --noEmit 2>&1 | head -80\` — ONLY informative if the build passed. Group by root cause; these go in as severity "low" (type debt), since they block neither deploy nor parity.
+7. Compare with /app/source: sections/components that exist there and were not ported (those ARE relevant — visual/content).
 
 # IMPORTANT RULES
 - **NEVER report an issue to edit \`*.gen.ts\` files** (manifest.gen, invoke.gen, meta.gen, etc.) — they are REGENERATED by \`npm run build\`. If a \`*.gen\` import is broken, the issue is "run npm run build/generate", not "edit the file".
 - **Suspected framework bug**: if an error seems to come from \`@decocms/start\` or \`@decocms/apps\` (the stack points inside node_modules of those packages, or it is a pattern that cannot be fixed in the site code), prefix the title with \`[framework?]\` and use category **infra** — the MCP catalogs these to detect recurring framework bugs across sites.
-- If \`npm run build\` already passes AND the site renders real HTML at \`/\`, most of the work is done — report few issues (only what affects parity/visual).
+- Even if \`npm run build\` passes AND \`/\` renders real HTML, STILL run the full sweep (steps 3–7): console errors, hydration mismatches, leftover Fresh/Preact imports and cache-contamination all count as real issues. Do not invent problems, but do not stop early either — report every real one you find.
 
 ${memorySection(site, [
   FRAMEWORK_NOTES_SPEC,
@@ -373,8 +409,8 @@ ${memorySection(site, [
 ])}
 
 # Issue format
-- At most ${maxIssues} issues, ordered from most to least severe.
-- severity: "critical" (npm run build fails) | "high" (route 500/page does not render) | "medium" (missing section, hydration, broken visual) | "low" (tsc type debt, warning, style).
+- Report EVERY real problem you found — no cap. Order from most to least severe. (Only the top ${maxIssues} are persisted, so severity order matters; never drop a real critical/high to stay under a number.)
+- severity: "critical" (npm run build fails) | "high" (route 500/page does not render, cache contamination) | "medium" (missing section, hydration mismatch, console error, broken visual) | "low" (tsc type debt, warning, style).
 - category: "build" | "runtime" | "visual" | "content" | "infra".
 - body ≤ 1200 characters, following the template:
 ${ISSUE_BODY_TEMPLATE}
@@ -385,6 +421,47 @@ ${progressInstruction(site)}
 End your LAST message with a single line in exactly this format (valid JSON, one line):
 RESULT_JSON: {"ok": true, "detail": "<summary: N issues, overall state>", "issues": [{"title": "...", "body": "...", "severity": "critical", "category": "build", "page": "/"}]}
 (ok=false only if you could not even analyze the repo)`;
+}
+
+/**
+ * Phase reviewing: a code-review agent gates the auto-merge. It reviews the
+ * diff of the current PR branch vs main and returns approved:true/false. This
+ * is the safety check before the MCP squash-merges into main (which the CF
+ * project deploys). Analysis only — it never edits or merges.
+ */
+export function reviewPrompt(input: {
+  site: SiteRow;
+  prNumber: number;
+  ghToken?: string;
+}): string {
+  const { site, prNumber } = input;
+  return `You are the code-review agent for the migration ${site.source_repo} → ${site.target_repo} (branch ${site.work_branch}, PR #${prNumber}). Work inside the sandbox using the vm tools (bash, read, write). Do not ask for confirmation. REVIEW ONLY — never edit files, never merge.
+
+# Goal
+Decide whether the diff of this branch vs main is SAFE to squash-merge into main (Cloudflare deploys main to *.workers.dev). Approve unless there is a real, blocking problem introduced by THIS diff.
+
+${ensureReadyPreamble(site)}
+
+# Review steps
+1. Get the diff: \`cd /app/repo && git fetch origin main 2>/dev/null && git diff origin/main...HEAD --stat && git diff origin/main...HEAD | head -800\`.
+2. **Build gate (the hard bar)**: \`npm run build 2>&1 | tail -40\`. If the build FAILS, this is a blocking problem — NOT approved.
+3. **Runtime**: with dev up from Setup, \`curl -sL http://localhost:$DEV_PORT/ 2>&1 | head -40\` — if \`/\` no longer renders real HTML (empty shell / "No web page" / a new SSR error in \`tail -60 /tmp/dev.log\`) that this diff introduced, NOT approved.
+4. Scan the diff for real regressions introduced HERE: broken imports, a section removed by mistake, a client-only global (\`window\`/\`document\`) newly used in server render, an edited \`*.gen.ts\` (must be regenerated, not hand-edited), secrets/tokens committed.
+
+# What to IGNORE (do NOT block on these)
+- Pre-existing problems not caused by this diff.
+- tsc/type-only errors that don't break \`npm run build\` (type debt), lint/format nits, style.
+- Missing-but-unrelated features, TODOs.
+
+${progressInstruction(site)}
+
+# Result
+End your LAST message with a single line, valid JSON:
+- If safe to merge:
+RESULT_JSON: {"ok": true, "approved": true, "detail": "<one-line summary of what the diff does + why it's safe>"}
+- If a blocking problem exists (list each as a self-contained issue so it can be fixed without more context):
+RESULT_JSON: {"ok": true, "approved": false, "detail": "<why blocked>", "issues": [{"title": "...", "body": "...", "severity": "critical", "category": "build", "page": "/"}]}
+(ok=false only if you could not review at all. When unsure but nothing is clearly broken, approve.)`;
 }
 
 /**
@@ -605,7 +682,8 @@ Build the TanStack Start site and deploy it to Cloudflare Workers via \`wrangler
 # Steps
 \`\`\`bash
 cd /app/repo
-git checkout ${site.work_branch} && git pull origin ${site.work_branch} 2>/dev/null || true
+# deploy runs on main post-merge (the round branch was merged + deleted)
+git fetch origin main 2>/dev/null; git checkout -B main origin/main 2>/dev/null || git checkout main
 [ -d node_modules ] || bun install || npm install
 # build: generate all gens + vite build
 npm run build

--- a/tanstack-migrator/server/sandbox/templates/prompts.ts
+++ b/tanstack-migrator/server/sandbox/templates/prompts.ts
@@ -453,6 +453,17 @@ ${ensureReadyPreamble(site)}
 - tsc/type-only errors that don't break \`npm run build\` (type debt), lint/format nits, style.
 - Missing-but-unrelated features, TODOs.
 
+${memorySection(site, [
+  {
+    ...FRAMEWORK_NOTES_SPEC,
+    read: "if the diff reproduces a signature listed here, it is a KNOWN framework bug — do not block the merge on it (it is not fixable in the site code); note it in the detail instead",
+  },
+  {
+    ...FIXES_SPEC,
+    read: "if the diff applies one of these proven recipes, that is a GOOD sign — approve; if it works AROUND a recipe in a fragile way, call it out",
+  },
+])}
+
 ${progressInstruction(site)}
 
 # Result

--- a/tanstack-migrator/server/sandbox/templates/sync-files.ts
+++ b/tanstack-migrator/server/sandbox/templates/sync-files.ts
@@ -1,223 +1,82 @@
 /**
- * Files installed into the -tanstack repo so CMS content edited on the
- * production (Fresh) site keeps flowing in: a scheduled GitHub workflow that
- * fetches /.decofile from production and rewrites .deco/blocks/.
+ * A single GitHub Actions workflow that mirrors the CMS content (`.deco/blocks`)
+ * from a client's production (Fresh/Deno) repo into our migrated `-tanstack`
+ * repo, event-driven.
  *
- * Mirrors deco-sites/granadobr-tanstack (.github/workflows/sync-decofile.yml
- * + scripts/sync-decofile.ts). The script is a local shim of
- * @decocms/start/scripts/sync-decofile.ts — replace with the node_modules
- * path once every migrated site is on a release that bundles it.
+ * The client repo is git-backed: publishing in the deco admin UI commits
+ * `.deco/blocks/*.json` to its `main` (e.g. "Publish N from <site>"). This
+ * workflow triggers on those pushes and rsyncs the blocks into the target repo,
+ * so the migration always sees fresh CMS state.
+ *
+ * Modeled 1:1 on the proven `deco-sites/miess-01` workflow
+ * (.github/workflows/sync-deco-content.yml). It is the ONLY file we ever add
+ * to a client production repo — it edits nothing else. Pushing to the target
+ * needs a PAT with write access, stored as a repo secret (default
+ * STOREFRONT_SYNC_TOKEN) — a one-time human setup.
  */
 
-export const SYNC_WORKFLOW_PATH = ".github/workflows/sync-decofile.yml";
-export const SYNC_SCRIPT_PATH = "scripts/sync-decofile.ts";
-export const SYNC_PACKAGE_SCRIPT_NAME = "sync:decofile";
+export const SYNC_WORKFLOW_PATH = ".github/workflows/sync-deco-content.yml";
+export const DEFAULT_SYNC_TOKEN_SECRET = "STOREFRONT_SYNC_TOKEN";
 
-export function syncPackageScriptCommand(prodUrl: string): string {
-  return `bun ${SYNC_SCRIPT_PATH} --url ${prodUrl}`;
+function repoName(full: string): string {
+  return full.includes("/") ? full.split("/")[1] : full;
 }
 
-export function syncWorkflowYaml(input: { prodUrl: string }): string {
-  const host = input.prodUrl.replace(/^https?:\/\//, "").replace(/\/$/, "");
-  return `name: Sync .deco/blocks from production
+/**
+ * The mirror workflow YAML. `targetRepo` is the "owner/name" of the -tanstack
+ * repo that receives the blocks; `tokenSecret` is the repo-secret name holding
+ * a PAT with write access to it.
+ */
+export function syncWorkflowYaml(input: {
+  sourceRepo: string;
+  targetRepo: string;
+  tokenSecret?: string;
+}): string {
+  const target = input.targetRepo;
+  const source = repoName(input.sourceRepo);
+  const secret = input.tokenSecret ?? DEFAULT_SYNC_TOKEN_SECRET;
+  return `name: Sync .deco to TanStack Storefront
 
-# Mirrors blocks edited via the deco admin UI on ${input.prodUrl}
-# into this repo's .deco/blocks/ so the TanStack migration sees fresh CMS
-# state. Runs every 30 min on schedule and on-demand via workflow_dispatch.
-# Installed automatically by the tanstack-migrator MCP.
+# Mirrors CMS content committed by the deco admin (.deco/blocks) from this
+# production repo into ${target} so the TanStack migration stays in sync.
+# Installed by the tanstack-migrator MCP — this is the ONLY file it adds.
+# Requires a repo secret \`${secret}\` (PAT with write access to ${target}).
 
 on:
-  schedule:
-    - cron: "*/30 * * * *"
+  push:
+    branches: [main]
+    paths: ['.deco/**']
   workflow_dispatch:
-
-permissions:
-  contents: write
 
 jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: oven-sh/setup-bun@v2
+      - name: Checkout source (${source})
+        uses: actions/checkout@v4
         with:
-          bun-version: latest
+          path: source
 
-      - name: Fetch /.decofile and write blocks
-        run: bun run ${SYNC_PACKAGE_SCRIPT_NAME}
+      - name: Checkout target (${repoName(target)})
+        uses: actions/checkout@v4
+        with:
+          repository: ${target}
+          token: \${{ secrets.${secret} }}
+          path: target
 
-      - name: Commit & push if changed
+      - name: Sync .deco/blocks
+        run: |
+          rsync -av --delete \\
+            source/.deco/blocks/ target/.deco/blocks/
+
+      - name: Commit and push if changed
+        working-directory: target
         run: |
           git config user.name "deco-sync-bot"
           git config user.email "sync@deco.cx"
-          git add .deco/blocks/
-          if git diff --staged --quiet; then
-            echo "No changes to sync"
-            exit 0
-          fi
-          git commit -m "sync: .deco/blocks from ${host}"
+          git add .deco/
+          git diff --staged --quiet && echo "No changes to sync" && exit 0
+          git commit -m "sync: .deco content from ${source}"
           git push
-`;
-}
-
-export function syncScriptSource(): string {
-  return `#!/usr/bin/env bun
-/**
- * Local shim for \`@decocms/start/scripts/sync-decofile.ts\`.
- * Installed by the tanstack-migrator MCP. Behaviour mirrors the upstream
- * script: fetch /.decofile from production and rewrite .deco/blocks/.
- */
-import fs from "node:fs";
-import path from "node:path";
-
-interface ParsedArgs {
-  site?: string;
-  url?: string;
-  out: string;
-  dryRun: boolean;
-  clean: boolean;
-}
-
-function parseArgs(): ParsedArgs {
-  const argv = process.argv.slice(2);
-  const get = (name: string): string | undefined => {
-    const i = argv.indexOf(\`--\${name}\`);
-    if (i === -1 || !argv[i + 1] || argv[i + 1].startsWith("--")) return undefined;
-    return argv[i + 1];
-  };
-  const has = (name: string): boolean => argv.includes(\`--\${name}\`);
-  return {
-    site: get("site"),
-    url: get("url"),
-    out: get("out") ?? ".deco/blocks",
-    dryRun: has("dry-run"),
-    clean: !has("no-clean"),
-  };
-}
-
-function normalizeKey(rawKey: string): string {
-  let k = rawKey;
-  while (k.includes("%")) {
-    try {
-      const next = decodeURIComponent(k);
-      if (next === k) break;
-      k = next;
-    } catch {
-      break;
-    }
-  }
-  return k;
-}
-
-function encodeBlockKeyToFilename(key: string): string {
-  return encodeURIComponent(key) + ".json";
-}
-
-function normalizeBlocks(raw: Record<string, unknown>): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(raw)) {
-    out[normalizeKey(k)] = v;
-  }
-  return out;
-}
-
-async function fetchDecofile(baseUrl: string): Promise<Record<string, unknown>> {
-  const url = baseUrl.replace(/\\/$/, "") + "/.decofile";
-  console.log(\`Fetching \${url} ...\`);
-  const res = await fetch(url, { headers: { "user-agent": "decocms-sync-decofile/1.0" } });
-  if (!res.ok) throw new Error(\`GET \${url} returned \${res.status} \${res.statusText}\`);
-  const json = (await res.json()) as Record<string, unknown>;
-  if (!json || typeof json !== "object") throw new Error(\`Unexpected response shape from \${url}\`);
-  return json;
-}
-
-function readExistingSnapshot(dir: string): Record<string, unknown> {
-  if (!fs.existsSync(dir)) return {};
-  const out: Record<string, unknown> = {};
-  for (const f of fs.readdirSync(dir).filter((x) => x.endsWith(".json"))) {
-    const key = normalizeKey(f.replace(/\\.json$/, ""));
-    try {
-      out[key] = JSON.parse(fs.readFileSync(path.join(dir, f), "utf-8"));
-    } catch {
-      // ignore unparseable
-    }
-  }
-  return out;
-}
-
-function diffSnapshots(
-  next: Record<string, unknown>,
-  prev: Record<string, unknown>,
-): { added: string[]; removed: string[]; changed: string[] } {
-  const nextKeys = new Set(Object.keys(next));
-  const prevKeys = new Set(Object.keys(prev));
-  const added: string[] = [];
-  const removed: string[] = [];
-  const changed: string[] = [];
-  for (const k of nextKeys) {
-    if (!prevKeys.has(k)) added.push(k);
-    else if (JSON.stringify(next[k]) !== JSON.stringify(prev[k])) changed.push(k);
-  }
-  for (const k of prevKeys) if (!nextKeys.has(k)) removed.push(k);
-  return { added, removed, changed };
-}
-
-function writeAtomically(dir: string, blocks: Record<string, unknown>, clean: boolean): void {
-  const stagingDir = \`\${dir}.tmp-\${process.pid}\`;
-  if (fs.existsSync(stagingDir)) fs.rmSync(stagingDir, { recursive: true, force: true });
-  fs.mkdirSync(stagingDir, { recursive: true });
-  for (const [key, value] of Object.entries(blocks)) {
-    fs.writeFileSync(
-      path.join(stagingDir, encodeBlockKeyToFilename(key)),
-      JSON.stringify(value, null, 2),
-    );
-  }
-  if (clean) {
-    if (fs.existsSync(dir)) fs.rmSync(dir, { recursive: true, force: true });
-    fs.renameSync(stagingDir, dir);
-  } else {
-    fs.mkdirSync(dir, { recursive: true });
-    for (const f of fs.readdirSync(stagingDir)) {
-      fs.copyFileSync(path.join(stagingDir, f), path.join(dir, f));
-    }
-    fs.rmSync(stagingDir, { recursive: true, force: true });
-  }
-}
-
-async function main(): Promise<void> {
-  const args = parseArgs();
-  if (!args.site && !args.url) {
-    console.error("Usage: bun scripts/sync-decofile.ts --site <name>  OR  --url <base-url>");
-    process.exit(2);
-  }
-  const baseUrl = args.url ?? \`https://www.\${args.site}.com.br\`;
-  const outDir = path.resolve(process.cwd(), args.out);
-
-  const next = normalizeBlocks(await fetchDecofile(baseUrl));
-  const prev = readExistingSnapshot(outDir);
-  const diff = diffSnapshots(next, prev);
-
-  console.log("");
-  console.log(\`  fetched  \${Object.keys(next).length} blocks\`);
-  console.log(\`  on disk  \${Object.keys(prev).length} blocks\`);
-  console.log(\`  added    \${diff.added.length}\`);
-  console.log(\`  removed  \${diff.removed.length}\`);
-  console.log(\`  changed  \${diff.changed.length}\`);
-  console.log("");
-
-  if (args.dryRun) {
-    console.log("--dry-run set, not writing.");
-    return;
-  }
-
-  writeAtomically(outDir, next, args.clean);
-  console.log(\`Wrote \${Object.keys(next).length} blocks to \${path.relative(process.cwd(), outDir)}\`);
-}
-
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
 `;
 }

--- a/tanstack-migrator/server/tools/index.ts
+++ b/tanstack-migrator/server/tools/index.ts
@@ -26,6 +26,7 @@ import {
   createSiteRetryTool,
   createSiteTerminalTool,
 } from "./sites.ts";
+import { createSyncDecofileInstallTool } from "./sync.ts";
 
 export const tools = [
   createDashboardTool,
@@ -47,6 +48,7 @@ export const tools = [
   createSiteCatalogSearchTool,
   createSiteSuggestionsTool,
   createSiteDeleteTool,
+  createSyncDecofileInstallTool,
   createParityReportUrlsTool,
   createReportProgressTool,
   createAdvanceQueueTool,

--- a/tanstack-migrator/server/tools/sandbox-test.ts
+++ b/tanstack-migrator/server/tools/sandbox-test.ts
@@ -30,6 +30,8 @@ const SITE_STATUSES = [
   "provisioning_sandbox",
   "migrating_script",
   "opening_pr",
+  "reviewing",
+  "merging",
   "triaging",
   "fixing",
   "paritying",

--- a/tanstack-migrator/server/tools/sync.ts
+++ b/tanstack-migrator/server/tools/sync.ts
@@ -1,0 +1,111 @@
+/** Standalone, deterministic installer for the .deco sync-mirror workflow. */
+
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { loadConnection } from "../db/connections.ts";
+import { getSite } from "../db/sites.ts";
+import { parseRepo } from "../lib/github.ts";
+import { buildWorkerCtx } from "../lib/mesh.ts";
+import { installSyncWorkflow } from "../lib/sync-install.ts";
+import { SYNC_WORKFLOW_PATH } from "../sandbox/templates/sync-files.ts";
+import type { Env } from "../types/env.ts";
+
+function normalizeRepo(input: string): string {
+  return input
+    .trim()
+    .replace(/^https?:\/\/github\.com\//, "")
+    .replace(/\.git$/, "");
+}
+
+export const createSyncDecofileInstallTool = (env: Env) =>
+  createTool({
+    id: "SYNC_DECOFILE_INSTALL",
+    description:
+      "Open a PR on a CLIENT production repo that adds the .deco sync-mirror workflow (.github/workflows/sync-deco-content.yml). On every push of CMS content to the client's main, it mirrors .deco/blocks into the -tanstack repo. Adds EXACTLY this one file — never touches anything else (safe for production repos). Idempotent (reuses an open PR). Pass a siteId to default repo=client source repo + target=-tanstack, or pass repo + targetRepo explicitly. NOTE: after merging, a human must add the token secret (default STOREFRONT_SYNC_TOKEN) with write access to the target repo.",
+    inputSchema: z.object({
+      siteId: z
+        .string()
+        .optional()
+        .describe(
+          "Migration site id — defaults repo to its source (client) repo and targetRepo to its -tanstack repo.",
+        ),
+      repo: z
+        .string()
+        .optional()
+        .describe(
+          'Client production repo "owner/name" (where the workflow is installed).',
+        ),
+      targetRepo: z
+        .string()
+        .optional()
+        .describe(
+          'The -tanstack repo "owner/name" the workflow mirrors .deco/blocks into.',
+        ),
+      base: z
+        .string()
+        .optional()
+        .describe("Client repo base branch for the PR (default main)."),
+      tokenSecret: z
+        .string()
+        .optional()
+        .describe(
+          "Repo-secret name holding the target-repo write token (default STOREFRONT_SYNC_TOKEN).",
+        ),
+    }),
+    outputSchema: z.object({
+      installed: z.boolean(),
+      repo: z.string(),
+      targetRepo: z.string(),
+      path: z.string(),
+      prNumber: z.number().nullable(),
+      prUrl: z.string().nullable(),
+      tokenSecret: z.string(),
+      reason: z.string(),
+    }),
+    execute: async ({ context }) => {
+      const site = context.siteId ? await getSite(context.siteId) : null;
+      if (context.siteId && !site) throw new Error("Site not found");
+
+      const clientRepo = normalizeRepo(context.repo ?? site?.source_repo ?? "");
+      const targetRepo = normalizeRepo(
+        context.targetRepo ?? site?.target_repo ?? "",
+      );
+      if (!clientRepo)
+        throw new Error("repo is required (pass repo or a siteId)");
+      if (!targetRepo) {
+        throw new Error(
+          "targetRepo is required (pass targetRepo or a siteId with a -tanstack repo)",
+        );
+      }
+
+      // GitHub mutations must run under the right tenant — prefer the site's
+      // connection, fall back to the current request's connection.
+      const connectionId =
+        site?.connection_id ?? env.MESH_REQUEST_CONTEXT?.connectionId;
+      if (!connectionId) {
+        throw new Error(
+          "No connection context — call through a studio connection or pass a siteId.",
+        );
+      }
+      const row = await loadConnection(connectionId);
+      if (!row) throw new Error(`Connection ${connectionId} not found`);
+      const ctx = buildWorkerCtx(row);
+
+      const result = await installSyncWorkflow(ctx, parseRepo(clientRepo), {
+        sourceRepo: clientRepo,
+        targetRepo,
+        base: context.base,
+        tokenSecret: context.tokenSecret,
+      });
+      return {
+        installed: result.installed,
+        repo: clientRepo,
+        targetRepo,
+        path: SYNC_WORKFLOW_PATH,
+        prNumber: result.prNumber,
+        prUrl: result.prUrl,
+        tokenSecret: result.tokenSecret,
+        reason: result.reason,
+      };
+    },
+  });

--- a/tanstack-migrator/web/components/pipeline-stepper.tsx
+++ b/tanstack-migrator/web/components/pipeline-stepper.tsx
@@ -2,6 +2,7 @@ import {
   Activity,
   Box,
   Check,
+  ClipboardCheck,
   GitBranch,
   GitMerge,
   GitPullRequest,
@@ -25,11 +26,12 @@ export const PIPELINE_PHASES = [
   { key: "baseline", label: "Baseline", icon: Activity },
   { key: "script", label: "Script", icon: Play },
   { key: "pr", label: "PR", icon: GitPullRequest },
+  { key: "review", label: "Review", icon: ClipboardCheck },
+  { key: "merge", label: "Merge", icon: GitMerge },
+  { key: "deploy", label: "Deploy", icon: Rocket },
   { key: "triage", label: "Triage", icon: ListChecks },
   { key: "fix", label: "Fixes", icon: Wrench },
-  { key: "deploy", label: "Deploy", icon: Rocket },
   { key: "parity", label: "Parity", icon: Gauge },
-  { key: "merge", label: "Merge", icon: GitMerge },
 ] as const;
 
 type PhaseKey = (typeof PIPELINE_PHASES)[number]["key"];
@@ -46,6 +48,8 @@ const STATUS_TO_PHASE: Record<string, PhaseKey> = {
   migrating3: "script",
   opening_pr: "pr",
   installing_sync: "pr", // legacy
+  reviewing: "review",
+  merging: "merge",
   triaging: "triage",
   fixing: "fix",
   paritying: "parity",

--- a/tanstack-migrator/web/components/status-badge.tsx
+++ b/tanstack-migrator/web/components/status-badge.tsx
@@ -25,6 +25,16 @@ export const STATUS_META: Record<
     className: "bg-blue-500/15 text-blue-600 dark:text-blue-400",
     active: true,
   },
+  reviewing: {
+    label: "Reviewing PR",
+    className: "bg-blue-500/15 text-blue-600 dark:text-blue-400",
+    active: true,
+  },
+  merging: {
+    label: "Merging PR",
+    className: "bg-sky-500/15 text-sky-600 dark:text-sky-400",
+    active: true,
+  },
   triaging: {
     label: "Triaging issues",
     className: "bg-cyan-500/15 text-cyan-600 dark:text-cyan-400",

--- a/tanstack-migrator/web/lib/status.ts
+++ b/tanstack-migrator/web/lib/status.ts
@@ -4,6 +4,8 @@ export const ACTIVE_STATUSES_SET = new Set([
   "baselining",
   "migrating_script",
   "opening_pr",
+  "reviewing",
+  "merging",
   "triaging",
   "fixing",
   "paritying",


### PR DESCRIPTION
Replaces the single-PR + human-merge model with an **incremental per-round loop**: `opening_pr → reviewing` (a code-review agent gates the merge) `→ merging` (the MCP squash-merges + deletes the branch) `→ deploying`, then `triaging` on the first deploy or `paritying` on fix rounds — each fix round cuts a fresh `migration/fix-N` branch off `main` and loops until parity target is hit with an empty backlog (adds `mergePullRequest`/`deleteBranch` github wrappers and `reviewing`/`merging` statuses, no DB migration since `status` is free-text). Reworks the `.deco` sync into the proven **push-mirror installed on the client production repo** (`on: push .deco/** → rsync blocks → -tanstack repo via STOREFRONT_SYNC_TOKEN`), with `SYNC_DECOFILE_INSTALL` opening a PR that adds only that one workflow file. Makes triage **uncapped and investigative** (headless Playwright console capture + a skill-derived grep sweep) and surfaces the new phases across the widgets, dashboard, and pipeline stepper. Deploy stays in-sandbox `wrangler deploy` (CF Workers Builds needs a human dashboard link — a known gap). Verified: project typecheck clean and 39/39 tests green; the live simulation e2e was traced statically (SANDBOX_TEST needs the runtime + Supabase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shifts the migration to an incremental per‑round loop with a code‑review gate, auto‑merge, and deploy; moves `.deco` content sync to a client‑repo push‑mirror. The review agent now uses cross‑migration memory to avoid blocking on known framework bugs and to recognize proven fix recipes.

- New Features
  - Per‑round flow: `opening_pr → reviewing → merging → deploying`, then `triaging` on first deploy or `paritying` on fix rounds; each fix round uses a fresh `migration/fix-N` branch off `main`.
  - Code‑review gate: analyze‑only agent reviews the PR diff, reads `framework-notes.md` and `fixes.md`, won’t block on known framework bugs, and recognizes proven recipes; approve → `merging`; reject → issues filed and return to `fixing` on the same PR.
  - Auto‑merge: squash‑merge + branch delete via new GitHub helpers (`mergePullRequest`, `deleteBranch`); conflicts route to `needs_human`.
  - `.deco` sync: open a client‑repo PR that adds only `.github/workflows/sync-deco-content.yml` (push `.deco/**` → rsync to the `-tanstack` repo using `${{ secrets.STOREFRONT_SYNC_TOKEN }}`); also available via `SYNC_DECOFILE_INSTALL`.
  - Deep triage: uncapped reporting (persist up to 100), longer timeouts, adds headless Playwright console capture and a focused grep sweep; UI shows `reviewing`/`merging` with updated stepper/badges.
  - Regenerated `registry.json` to include `deco/grafana` and fix `check:registry` CI.

- Migration
  - When the sync workflow PR opens on the client repo, add a repo secret `STOREFRONT_SYNC_TOKEN` (or custom) with write access to the `-tanstack` repo, then merge to activate. Expect new statuses `reviewing` and `merging`. No DB migration required.

<sup>Written for commit 07f680cd8053cb281ec91d3df6e6da351710de3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

