### PR TITLE
Revert "fix(google-analytics): fix input validation and align output schemas with other Google MCPs (#475)"

### DIFF
--- a/google-analytics/server/lib/schemas.ts
+++ b/google-analytics/server/lib/schemas.ts
@@ -30,7 +30,6 @@ export const PropertySummarySchema = z.object({
   propertyType: z.string().optional(),
   /** Parent resource name, e.g. "accounts/123456". */
   parent: z.string().optional(),
-  canEdit: z.boolean().optional(),
 });
 
 export const AccountSummarySchema = z.object({
@@ -42,8 +41,10 @@ export const AccountSummarySchema = z.object({
   propertySummaries: z.array(PropertySummarySchema).optional(),
 });
 
-export const AccountSummariesOutputSchema = z.object({
-  accountSummaries: z.array(AccountSummarySchema).optional(),
+export const AccountSummariesResponseSchema = z.object({
+  response: z.object({
+    accountSummaries: z.array(AccountSummarySchema).optional(),
+  }),
 });
 
 // ── Admin API — Property ─────────────────────────────────────────────────────
@@ -66,6 +67,10 @@ export const PropertySchema = z.object({
   account: z.string().optional(),
   deleteTime: Timestamp.optional(),
   expireTime: Timestamp.optional(),
+});
+
+export const PropertyResponseSchema = z.object({
+  response: PropertySchema,
 });
 
 // ── Admin API — Custom Dimensions & Metrics ──────────────────────────────────
@@ -96,9 +101,19 @@ export const CustomMetricSchema = z.object({
   restrictedMetricType: z.array(z.string()).optional(),
 });
 
-export const CustomDimensionsAndMetricsOutputSchema = z.object({
+export const CustomDimensionsListSchema = z.object({
   customDimensions: z.array(CustomDimensionSchema).optional(),
+});
+
+export const CustomMetricsListSchema = z.object({
   customMetrics: z.array(CustomMetricSchema).optional(),
+});
+
+export const CustomDimensionsAndMetricsResponseSchema = z.object({
+  /** Result of listCustomDimensions — `{ customDimensions: [...] }` */
+  dimensions: CustomDimensionsListSchema,
+  /** Result of listCustomMetrics — `{ customMetrics: [...] }` */
+  metrics: CustomMetricsListSchema,
 });
 
 // ── Admin API — Google Ads Links ─────────────────────────────────────────────
@@ -115,8 +130,10 @@ export const GoogleAdsLinkSchema = z.object({
   updateTime: Timestamp.optional(),
 });
 
-export const GoogleAdsLinksOutputSchema = z.object({
-  googleAdsLinks: z.array(GoogleAdsLinkSchema).optional(),
+export const GoogleAdsLinksResponseSchema = z.object({
+  response: z.object({
+    googleAdsLinks: z.array(GoogleAdsLinkSchema).optional(),
+  }),
 });
 
 // ── Admin API — Property Annotations ─────────────────────────────────────────
@@ -125,12 +142,6 @@ export const ReportingDataAnnotationSchema = z.object({
   /** Resource name. */
   name: z.string().optional(),
   annotationDate: DateSchema.optional(),
-  annotationDateRange: z
-    .object({
-      startDate: DateSchema.optional(),
-      endDate: DateSchema.optional(),
-    })
-    .optional(),
   title: z.string().optional(),
   description: z.string().optional(),
   systemGenerated: z.boolean().optional(),
@@ -138,8 +149,10 @@ export const ReportingDataAnnotationSchema = z.object({
   color: z.string().optional(),
 });
 
-export const PropertyAnnotationsOutputSchema = z.object({
-  reportingDataAnnotations: z.array(ReportingDataAnnotationSchema).optional(),
+export const PropertyAnnotationsResponseSchema = z.object({
+  response: z.object({
+    reportingDataAnnotations: z.array(ReportingDataAnnotationSchema).optional(),
+  }),
 });
 
 // ── Data API — shared building blocks ────────────────────────────────────────
@@ -168,11 +181,9 @@ export const RowSchema = z.object({
 });
 
 export const ResponseMetaDataSchema = z.object({
-  dataLossFromOtherRow: z.boolean().optional(),
-  schemaRestrictionResponse: z.unknown().optional(),
   currencyCode: z.string().optional(),
   timeZone: z.string().optional(),
-  emptyReason: z.string().optional(),
+  schemaRestrictionResponse: z.unknown().optional(),
   subjectToThresholding: z.boolean().optional(),
   samplingMetadatas: z.array(z.unknown()).optional(),
 });
@@ -195,7 +206,7 @@ export const PropertyQuotaSchema = z
     potentiallyThresholdedRequestsPerHour: z
       .object({ consumed: z.number(), remaining: z.number() })
       .optional(),
-    tokensPerProjectPerHour: z
+    tokensPerProjectPerDay: z
       .object({ consumed: z.number(), remaining: z.number() })
       .optional(),
   })
@@ -203,7 +214,7 @@ export const PropertyQuotaSchema = z
 
 // ── Data API — runReport ──────────────────────────────────────────────────────
 
-export const RunReportOutputSchema = z.object({
+export const RunReportResponseSchema = z.object({
   dimensionHeaders: z.array(DimensionHeaderSchema).optional(),
   metricHeaders: z.array(MetricHeaderSchema).optional(),
   rows: z.array(RowSchema).optional(),
@@ -217,9 +228,13 @@ export const RunReportOutputSchema = z.object({
   kind: z.string().optional(),
 });
 
+export const RunReportOutputSchema = z.object({
+  response: RunReportResponseSchema,
+});
+
 // ── Data API — runRealtimeReport ─────────────────────────────────────────────
 
-export const RunRealtimeReportOutputSchema = z.object({
+export const RunRealtimeReportResponseSchema = z.object({
   dimensionHeaders: z.array(DimensionHeaderSchema).optional(),
   metricHeaders: z.array(MetricHeaderSchema).optional(),
   rows: z.array(RowSchema).optional(),
@@ -232,9 +247,13 @@ export const RunRealtimeReportOutputSchema = z.object({
   kind: z.string().optional(),
 });
 
+export const RunRealtimeReportOutputSchema = z.object({
+  response: RunRealtimeReportResponseSchema,
+});
+
 // ── Data API — runFunnelReport ────────────────────────────────────────────────
 
-const FunnelResponseMetaDataSchema = z.object({
+export const FunnelResponseMetaDataSchema = z.object({
   samplingMetadatas: z.array(z.unknown()).optional(),
   schemaRestrictionResponse: z.unknown().optional(),
 });
@@ -243,7 +262,7 @@ const FunnelResponseMetaDataSchema = z.object({
  * Funnel response rows share the same Row structure (dimensionValues +
  * metricValues), grouped in funnelTable and funnelVisualization sub-objects.
  */
-const FunnelSubReportSchema = z.object({
+export const FunnelSubReportSchema = z.object({
   dimensionHeaders: z.array(DimensionHeaderSchema).optional(),
   metricHeaders: z.array(MetricHeaderSchema).optional(),
   rows: z.array(RowSchema).optional(),
@@ -254,10 +273,14 @@ const FunnelSubReportSchema = z.object({
   metadata: FunnelResponseMetaDataSchema.optional(),
 });
 
-export const RunFunnelReportOutputSchema = z.object({
+export const RunFunnelReportResponseSchema = z.object({
   funnelTable: FunnelSubReportSchema.optional(),
   funnelVisualization: FunnelSubReportSchema.optional(),
   propertyQuota: PropertyQuotaSchema.optional(),
   /** Always "analyticsData#runFunnelReport". */
   kind: z.string().optional(),
+});
+
+export const RunFunnelReportOutputSchema = z.object({
+  response: RunFunnelReportResponseSchema,
 });

--- a/google-analytics/server/tools/accounts.ts
+++ b/google-analytics/server/tools/accounts.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { createPrivateTool } from "@decocms/runtime/tools";
 import type { Env } from "../../shared/deco.gen.ts";
 import { GaClient } from "../lib/ga-client.ts";
-import { AccountSummariesOutputSchema } from "../lib/schemas.ts";
+import { AccountSummariesResponseSchema } from "../lib/schemas.ts";
 
 export const getAccountSummariesTool = (env: Env) =>
   createPrivateTool({
@@ -10,12 +10,13 @@ export const getAccountSummariesTool = (env: Env) =>
     description:
       "Retrieves information about the user's Google Analytics accounts and properties.",
     inputSchema: z.object({}),
-    outputSchema: AccountSummariesOutputSchema,
+    outputSchema: AccountSummariesResponseSchema,
     execute: async () => {
       const client = GaClient.fromEnv(env);
+
       try {
         const result = await client.listAccountSummaries();
-        return AccountSummariesOutputSchema.parse(result);
+        return AccountSummariesResponseSchema.parse({ response: result });
       } catch (error) {
         throw new Error(
           `Failed to retrieve account summaries: ${error instanceof Error ? error.message : String(error)}`,

--- a/google-analytics/server/tools/ads.ts
+++ b/google-analytics/server/tools/ads.ts
@@ -3,11 +3,14 @@ import { createPrivateTool } from "@decocms/runtime/tools";
 import type { Env } from "../../shared/deco.gen.ts";
 import { GaClient } from "../lib/ga-client.ts";
 import { resolveProperty } from "../lib/env.ts";
-import { GoogleAdsLinksOutputSchema } from "../lib/schemas.ts";
+import { GoogleAdsLinksResponseSchema } from "../lib/schemas.ts";
 
 const propertySchema = z
+
   .string()
+
   .optional()
+
   .describe(
     "GA4 Property identifier — 'properties/1234567' or just '1234567'. Falls back to the default propertyId configured for this integration when omitted.",
   );
@@ -18,14 +21,14 @@ export const listGoogleAdsLinksTool = (env: Env) =>
     description:
       "Returns a list of links to Google Ads accounts for a GA4 property.",
     inputSchema: z.object({ property: propertySchema }),
-    outputSchema: GoogleAdsLinksOutputSchema,
+    outputSchema: GoogleAdsLinksResponseSchema,
     execute: async ({ context: args }) => {
       const client = GaClient.fromEnv(env);
       try {
         const result = await client.listGoogleAdsLinks(
           resolveProperty(env, args.property),
         );
-        return GoogleAdsLinksOutputSchema.parse(result);
+        return GoogleAdsLinksResponseSchema.parse({ response: result });
       } catch (error) {
         throw new Error(
           `Failed to retrieve Google Ads links: ${error instanceof Error ? error.message : String(error)}`,

--- a/google-analytics/server/tools/annotations.ts
+++ b/google-analytics/server/tools/annotations.ts
@@ -3,11 +3,14 @@ import { createPrivateTool } from "@decocms/runtime/tools";
 import type { Env } from "../../shared/deco.gen.ts";
 import { GaClient } from "../lib/ga-client.ts";
 import { resolveProperty } from "../lib/env.ts";
-import { PropertyAnnotationsOutputSchema } from "../lib/schemas.ts";
+import { PropertyAnnotationsResponseSchema } from "../lib/schemas.ts";
 
 const propertySchema = z
+
   .string()
+
   .optional()
+
   .describe(
     "GA4 Property identifier — 'properties/1234567' or just '1234567'. Falls back to the default propertyId configured for this integration when omitted.",
   );
@@ -18,14 +21,14 @@ export const listPropertyAnnotationsTool = (env: Env) =>
     description:
       "Returns timestamped annotations for a GA4 property — useful for correlating traffic changes with events like campaign launches, site releases, or data collection changes.",
     inputSchema: z.object({ property: propertySchema }),
-    outputSchema: PropertyAnnotationsOutputSchema,
+    outputSchema: PropertyAnnotationsResponseSchema,
     execute: async ({ context: args }) => {
       const client = GaClient.fromEnv(env);
       try {
         const result = await client.listPropertyAnnotations(
           resolveProperty(env, args.property),
         );
-        return PropertyAnnotationsOutputSchema.parse(result);
+        return PropertyAnnotationsResponseSchema.parse({ response: result });
       } catch (error) {
         throw new Error(
           `Failed to retrieve property annotations: ${error instanceof Error ? error.message : String(error)}`,

--- a/google-analytics/server/tools/properties.ts
+++ b/google-analytics/server/tools/properties.ts
@@ -4,13 +4,16 @@ import type { Env } from "../../shared/deco.gen.ts";
 import { GaClient } from "../lib/ga-client.ts";
 import { resolveProperty } from "../lib/env.ts";
 import {
-  PropertySchema,
-  CustomDimensionsAndMetricsOutputSchema,
+  PropertyResponseSchema,
+  CustomDimensionsAndMetricsResponseSchema,
 } from "../lib/schemas.ts";
 
 const propertySchema = z
+
   .string()
+
   .optional()
+
   .describe(
     "GA4 Property identifier — 'properties/1234567' or just '1234567'. Falls back to the default propertyId configured for this integration when omitted.",
   );
@@ -21,14 +24,14 @@ export const getPropertyDetailsTool = (env: Env) =>
     description:
       "Returns metadata and configuration details about a GA4 property.",
     inputSchema: z.object({ property: propertySchema }),
-    outputSchema: PropertySchema,
+    outputSchema: PropertyResponseSchema,
     execute: async ({ context: args }) => {
       const client = GaClient.fromEnv(env);
       try {
         const result = await client.getProperty(
           resolveProperty(env, args.property),
         );
-        return PropertySchema.parse(result);
+        return PropertyResponseSchema.parse({ response: result });
       } catch (error) {
         throw new Error(
           `Failed to retrieve property details: ${error instanceof Error ? error.message : String(error)}`,
@@ -43,19 +46,20 @@ export const getCustomDimensionsAndMetricsTool = (env: Env) =>
     description:
       "Retrieves the custom dimensions and custom metrics configured for a GA4 property.",
     inputSchema: z.object({ property: propertySchema }),
-    outputSchema: CustomDimensionsAndMetricsOutputSchema,
+    outputSchema: CustomDimensionsAndMetricsResponseSchema,
     execute: async ({ context: args }) => {
       const client = GaClient.fromEnv(env);
       try {
         const property = resolveProperty(env, args.property);
         // Both calls are independent — run in parallel to halve latency.
-        const [dimensionsResult, metricsResult] = await Promise.all([
+        const [dimensions, metrics] = await Promise.all([
           client.listCustomDimensions(property),
           client.listCustomMetrics(property),
         ]);
-        return CustomDimensionsAndMetricsOutputSchema.parse({
-          ...(dimensionsResult as object),
-          ...(metricsResult as object),
+
+        return CustomDimensionsAndMetricsResponseSchema.parse({
+          dimensions,
+          metrics,
         });
       } catch (error) {
         throw new Error(

--- a/google-analytics/server/tools/reports.ts
+++ b/google-analytics/server/tools/reports.ts
@@ -9,31 +9,18 @@ import {
   RunRealtimeReportOutputSchema,
 } from "../lib/schemas.ts";
 
-// Some MCP clients serialize arrays/objects as JSON strings instead of native
-// types. This preprocessor parses the string before Zod validates it.
-// `.optional()` must be applied to the schema passed in here (not chained
-// after fromJson(...)) so that a `null` value — which the preprocessor
-// coerces to `undefined` — is actually accepted by the resulting schema.
-const fromJson = <T extends z.ZodTypeAny>(schema: T) =>
-  z.preprocess((val) => {
-    if (val === null) return undefined;
-    if (typeof val !== "string") return val;
-    try {
-      const parsed = JSON.parse(val);
-      return parsed === null ? undefined : parsed;
-    } catch {
-      return val;
-    }
-  }, schema);
-
 const DateRangeSchema = z.object({
   startDate: z
+
     .string()
+
     .describe(
       "Inclusive start date in YYYY-MM-DD format, or relative values: 'today', 'yesterday', 'NdaysAgo'.",
     ),
   endDate: z
+
     .string()
+
     .describe(
       "Inclusive end date in YYYY-MM-DD format, or relative values: 'today', 'yesterday'.",
     ),
@@ -44,13 +31,17 @@ const MetricSchema = z.object({ name: z.string() });
 
 // FilterExpression and OrderBy are passed as raw JSON objects matching the GA4 REST API schema.
 const FilterExpressionSchema = z
+
   .record(z.string(), z.unknown())
+
   .describe(
     "GA4 FilterExpression object. See https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/FilterExpression",
   );
 
 const OrderBySchema = z
+
   .record(z.string(), z.unknown())
+
   .describe(
     "GA4 OrderBy object. See https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/OrderBy",
   );
@@ -62,44 +53,94 @@ export const runReportTool = (env: Env) =>
       "Runs a Google Analytics 4 report using the Data API. Returns dimensions, metrics, and row data for the specified property and date range.",
     inputSchema: z.object({
       property: z
+
         .string()
+
         .optional()
+
         .describe(
           "GA4 Property identifier — 'properties/1234567' or just '1234567'. Falls back to the default propertyId configured for this integration when omitted.",
         ),
-      dateRanges: fromJson(z.array(DateRangeSchema).min(1)).describe(
-        "One or more date ranges to include in the report.",
-      ),
-      dimensions: fromJson(z.array(DimensionSchema).optional()).describe(
-        "Dimensions to group results by, e.g. [{ name: 'sessionSource' }].",
-      ),
-      metrics: fromJson(z.array(MetricSchema).min(1)).describe(
-        "Metrics to aggregate, e.g. [{ name: 'activeUsers' }].",
-      ),
-      dimensionFilter: fromJson(FilterExpressionSchema.optional()).describe(
+      dateRanges: z
+
+        .array(DateRangeSchema)
+
+        .min(1)
+
+        .describe("One or more date ranges to include in the report."),
+      dimensions: z
+
+        .array(DimensionSchema)
+
+        .optional()
+
+        .describe(
+          "Dimensions to group results by, e.g. [{ name: 'sessionSource' }].",
+        ),
+      metrics: z
+
+        .array(MetricSchema)
+
+        .min(1)
+
+        .describe("Metrics to aggregate, e.g. [{ name: 'activeUsers' }]."),
+      dimensionFilter: FilterExpressionSchema.optional().describe(
         "Optional filter to restrict dimension values.",
       ),
-      metricFilter: fromJson(FilterExpressionSchema.optional()).describe(
+      metricFilter: FilterExpressionSchema.optional().describe(
         "Optional filter to restrict metric values.",
       ),
-      orderBys: fromJson(z.array(OrderBySchema).optional()).describe(
-        "Optional ordering for returned rows.",
-      ),
-      limit: fromJson(z.number().int().positive().optional()).describe(
-        "Maximum number of rows to return. Defaults to 10,000; max 250,000.",
-      ),
-      offset: fromJson(z.number().int().nonnegative().optional()).describe(
-        "Row offset for pagination (0-based). Use with limit to page through results.",
-      ),
-      currencyCode: z
-        .string()
+      orderBys: z
+
+        .array(OrderBySchema)
+
         .optional()
+
+        .describe("Optional ordering for returned rows."),
+      limit: z
+
+        .number()
+
+        .int()
+
+        .positive()
+
+        .optional()
+
+        .describe(
+          "Maximum number of rows to return. Defaults to 10,000; max 250,000.",
+        ),
+      offset: z
+
+        .number()
+
+        .int()
+
+        .nonnegative()
+
+        .optional()
+
+        .describe(
+          "Row offset for pagination (0-based). Use with limit to page through results.",
+        ),
+      currencyCode: z
+
+        .string()
+
+        .optional()
+
         .describe(
           "Optional ISO 4217 currency code for revenue metrics, e.g. 'USD'.",
         ),
-      returnPropertyQuota: fromJson(z.boolean().optional()).describe(
-        "If true, includes the current GA4 property quota state in the response.",
-      ),
+      returnPropertyQuota: z
+
+        .boolean()
+
+        .optional()
+
+        .describe(
+          "If true, includes the current GA4 property quota state in the response.",
+        ),
     }),
     outputSchema: RunReportOutputSchema,
     execute: async ({ context: args }) => {
@@ -119,13 +160,15 @@ export const runReportTool = (env: Env) =>
         if (args.offset !== undefined) body.offset = args.offset;
         if (args.currencyCode !== undefined)
           body.currencyCode = args.currencyCode;
-        if (args.returnPropertyQuota !== undefined)
+        if (args.returnPropertyQuota !== undefined) {
           body.returnPropertyQuota = args.returnPropertyQuota;
+        }
         const response = await client.runReport(
           resolveProperty(env, args.property),
           body,
         );
-        return RunReportOutputSchema.parse(response);
+
+        return RunReportOutputSchema.parse({ response });
       } catch (error) {
         throw new Error(
           `Failed to run report: ${error instanceof Error ? error.message : String(error)}`,
@@ -136,17 +179,32 @@ export const runReportTool = (env: Env) =>
 
 const FunnelStepSchema = z.object({
   name: z
+
     .string()
+
     .describe("Display name for this funnel step (shown in reports)."),
-  filterExpression: fromJson(z.record(z.string(), z.unknown())).describe(
-    "Required. Condition that qualifies users for this step. See https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/FunnelStep#FunnelFilterExpression",
-  ),
-  isDirectlyFollowedBy: fromJson(z.boolean().optional()).describe(
-    "If true, this step must immediately follow the previous step (no intervening events). Defaults to false.",
-  ),
-  withinDurationFromPriorStep: z
-    .string()
+  filterExpression: z
+
+    .record(z.string(), z.unknown())
+
+    .describe(
+      "Required. Condition that qualifies users for this step. See https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/FunnelStep#FunnelFilterExpression",
+    ),
+  isDirectlyFollowedBy: z
+
+    .boolean()
+
     .optional()
+
+    .describe(
+      "If true, this step must immediately follow the previous step (no intervening events). Defaults to false.",
+    ),
+  withinDurationFromPriorStep: z
+
+    .string()
+
+    .optional()
+
     .describe(
       "Time window within which this step must occur after the prior step, e.g. '3600s' for 1 hour.",
     ),
@@ -159,36 +217,77 @@ export const runFunnelReportTool = (env: Env) =>
       "Runs a Google Analytics 4 funnel report. Analyzes how users progress through a sequence of steps (e.g. landing page → product page → checkout → purchase). Returns per-step completion counts and drop-off rates.",
     inputSchema: z.object({
       property: z
+
         .string()
+
         .optional()
+
         .describe(
           "GA4 Property identifier — 'properties/1234567' or just '1234567'. Falls back to the default propertyId configured for this integration when omitted.",
         ),
-      funnelSteps: fromJson(z.array(FunnelStepSchema).min(2)).describe(
-        "Ordered list of funnel steps. Each step is a GA4 FunnelStep object with a name and filterExpression.",
-      ),
-      dateRanges: fromJson(z.array(DateRangeSchema).min(1)).describe(
-        "One or more date ranges to include in the report.",
-      ),
-      funnelBreakdown: fromJson(
-        z.record(z.string(), z.unknown()).optional(),
-      ).describe(
-        "Optional FunnelBreakdown — adds a sub-dimension to the funnel table rows.",
-      ),
-      funnelNextAction: fromJson(
-        z.record(z.string(), z.unknown()).optional(),
-      ).describe(
-        "Optional FunnelNextAction — adds a next-action dimension showing what users do after abandoning a step.",
-      ),
-      limit: fromJson(z.number().int().positive().optional()).describe(
-        "Maximum number of rows to return.",
-      ),
-      offset: fromJson(z.number().int().nonnegative().optional()).describe(
-        "Row offset for pagination.",
-      ),
-      returnPropertyQuota: fromJson(z.boolean().optional()).describe(
-        "If true, includes current GA4 property quota in response.",
-      ),
+      funnelSteps: z
+
+        .array(FunnelStepSchema)
+
+        .min(2)
+
+        .describe(
+          "Ordered list of funnel steps. Each step is a GA4 FunnelStep object with a name and filterExpression.",
+        ),
+      dateRanges: z
+
+        .array(DateRangeSchema)
+
+        .min(1)
+
+        .describe("One or more date ranges to include in the report."),
+      funnelBreakdown: z
+
+        .record(z.string(), z.unknown())
+
+        .optional()
+
+        .describe(
+          "Optional FunnelBreakdown — adds a sub-dimension to the funnel table rows.",
+        ),
+      funnelNextAction: z
+
+        .record(z.string(), z.unknown())
+
+        .optional()
+
+        .describe(
+          "Optional FunnelNextAction — adds a next-action dimension showing what users do after abandoning a step.",
+        ),
+      limit: z
+
+        .number()
+
+        .int()
+
+        .positive()
+
+        .optional()
+
+        .describe("Maximum number of rows to return."),
+      offset: z
+
+        .number()
+
+        .int()
+
+        .nonnegative()
+
+        .optional()
+
+        .describe("Row offset for pagination."),
+      returnPropertyQuota: z
+
+        .boolean()
+
+        .optional()
+
+        .describe("If true, includes current GA4 property quota in response."),
     }),
     outputSchema: RunFunnelReportOutputSchema,
     execute: async ({ context: args }) => {
@@ -210,7 +309,8 @@ export const runFunnelReportTool = (env: Env) =>
           resolveProperty(env, args.property),
           body,
         );
-        return RunFunnelReportOutputSchema.parse(response);
+
+        return RunFunnelReportOutputSchema.parse({ response });
       } catch (error) {
         throw new Error(
           `Failed to run funnel report: ${error instanceof Error ? error.message : String(error)}`,
@@ -226,35 +326,64 @@ export const runRealtimeReportTool = (env: Env) =>
       "Runs a Google Analytics 4 realtime report. Returns live data from the last 30 minutes.",
     inputSchema: z.object({
       property: z
+
         .string()
+
         .optional()
+
         .describe(
           "GA4 Property identifier — 'properties/1234567' or just '1234567'. Falls back to the default propertyId configured for this integration when omitted.",
         ),
-      dimensions: fromJson(z.array(DimensionSchema).optional()).describe(
-        "Dimensions to group results by.",
-      ),
-      metrics: fromJson(z.array(MetricSchema).min(1)).describe(
-        "Metrics to aggregate.",
-      ),
-      dimensionFilter: fromJson(FilterExpressionSchema.optional()).describe(
+      dimensions: z
+
+        .array(DimensionSchema)
+
+        .optional()
+
+        .describe("Dimensions to group results by."),
+      metrics: z.array(MetricSchema).min(1).describe("Metrics to aggregate."),
+      dimensionFilter: FilterExpressionSchema.optional().describe(
         "Optional filter to restrict dimension values.",
       ),
-      metricFilter: fromJson(FilterExpressionSchema.optional()).describe(
+      metricFilter: FilterExpressionSchema.optional().describe(
         "Optional filter to restrict metric values.",
       ),
-      orderBys: fromJson(z.array(OrderBySchema).optional()).describe(
-        "Optional ordering for returned rows.",
-      ),
-      limit: fromJson(z.number().int().positive().optional()).describe(
-        "Maximum number of rows to return.",
-      ),
-      offset: fromJson(z.number().int().nonnegative().optional()).describe(
-        "Row offset for pagination.",
-      ),
-      returnPropertyQuota: fromJson(z.boolean().optional()).describe(
-        "If true, includes quota state in the response.",
-      ),
+      orderBys: z
+
+        .array(OrderBySchema)
+
+        .optional()
+
+        .describe("Optional ordering for returned rows."),
+      limit: z
+
+        .number()
+
+        .int()
+
+        .positive()
+
+        .optional()
+
+        .describe("Maximum number of rows to return."),
+      offset: z
+
+        .number()
+
+        .int()
+
+        .nonnegative()
+
+        .optional()
+
+        .describe("Row offset for pagination."),
+      returnPropertyQuota: z
+
+        .boolean()
+
+        .optional()
+
+        .describe("If true, includes quota state in the response."),
     }),
     outputSchema: RunRealtimeReportOutputSchema,
     execute: async ({ context: args }) => {
@@ -271,13 +400,15 @@ export const runRealtimeReportTool = (env: Env) =>
         if (args.orderBys !== undefined) body.orderBys = args.orderBys;
         if (args.limit !== undefined) body.limit = args.limit;
         if (args.offset !== undefined) body.offset = args.offset;
-        if (args.returnPropertyQuota !== undefined)
+        if (args.returnPropertyQuota !== undefined) {
           body.returnPropertyQuota = args.returnPropertyQuota;
+        }
         const response = await client.runRealtimeReport(
           resolveProperty(env, args.property),
           body,
         );
-        return RunRealtimeReportOutputSchema.parse(response);
+
+        return RunRealtimeReportOutputSchema.parse({ response });
       } catch (error) {
         throw new Error(
           `Failed to run realtime report: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Summary
- Reverts #475 (commit 6f3612cb) — currently the tip of `main`.
- Restores `google-analytics` schemas/tools to their pre-#475 state (verified byte-identical diff against the parent commit).

## Test plan
- [ ] CI checks pass
- [ ] Manual smoke test of google-analytics tools if needed before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts #475 for `google-analytics`. Restores the pre-#475 schemas and tool behavior, including response-wrapped outputs and stricter native input types.

- **Refactors**
  - Bring back response wrapper: outputs now return `{ response: ... }` for accounts, property, ads links, annotations, `runReport`, `runRealtimeReport`, and `runFunnelReport`.
  - Remove JSON-string preprocessing in tool inputs; arrays/objects/booleans must be passed as native values.
  - Restore custom dimensions/metrics shape: `{ dimensions: { customDimensions: [...] }, metrics: { customMetrics: [...] } }`.
  - Revert schema fields to prior state (e.g., remove `canEdit` on property summaries, remove `annotationDateRange`, rename quota field to `tokensPerProjectPerDay`, drop `dataLossFromOtherRow` and `emptyReason` from response metadata).

- **Migration**
  - Read results from the `response` key.
  - Stop sending JSON-encoded strings in inputs; send native JSON values.
  - Access custom dimensions and metrics under `dimensions.customDimensions` and `metrics.customMetrics`.

<sup>Written for commit b40c70378a47c37c9e982d1dd3aa9a96d0ee819f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

