### PR TITLE
feat(shopify): add read-only Shopify Admin GraphQL API MCP

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -966,6 +966,19 @@
         "zod": "^4.0.0",
       },
     },
+    "shopify": {
+      "name": "shopify",
+      "version": "1.0.0",
+      "dependencies": {
+        "@decocms/runtime": "^1.6.2",
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@decocms/mcps-shared": "1.0.0",
+        "@types/bun": "^1.2.14",
+        "typescript": "^5.7.2",
+      },
+    },
     "slack-mcp": {
       "name": "slack-mcp",
       "version": "1.0.0",
@@ -3537,6 +3550,8 @@
 
     "shimmer": ["shimmer@1.2.1", "", {}, "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="],
 
+    "shopify": ["shopify@workspace:shopify"],
+
     "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
 
     "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
@@ -4501,6 +4516,10 @@
 
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
+    "shopify/@decocms/runtime": ["@decocms/runtime@1.6.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.10", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.29.0", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-r6O4z+ISJpBnhDw4x1K8IYNqfQ+xdwSjNcg6vDqU42I6x82H8snfAg/E6u9WfcMClap7sXxMAdKuDcEMxPq55A=="],
+
+    "shopify/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
     "slack-mcp/@decocms/bindings": ["@decocms/bindings@1.4.9", "", { "dependencies": { "@decocms/mcp-utils": "^1.0.5", "@modelcontextprotocol/sdk": "1.29.0", "@tanstack/react-router": "1.169.2", "react": "^19.2.6", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-NvhuHsKL0YpSUaAZqEe0PAzF41/JJSi+H0X7HpMBScOVpALcGqAC+DaJvcKeo3aRXXW7z6du0oCdkhLf2A6Vjw=="],
 
     "slack-mcp/@decocms/runtime": ["@decocms/runtime@1.3.0", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.27.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-xRFTV9gqrdsUCAkJ3xoBOeDGXps6moZeZB/NNL+XZ7LNa4qzfmL3BGWG42n8xbFyEpprfEfOtOD+tVgWhkPDxQ=="],
@@ -5114,6 +5133,10 @@
     "replicate/@decocms/runtime/zod-from-json-schema": ["zod-from-json-schema@0.0.5", "", { "dependencies": { "zod": "^3.24.2" } }, "sha512-zYEoo86M1qpA1Pq6329oSyHLS785z/mTwfr9V1Xf/ZLhuuBGaMlDGu/pDVGVUe4H4oa1EFgWZT53DP0U3oT9CQ=="],
 
     "replicate/@modelcontextprotocol/sdk/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "shopify/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.4.9", "", { "dependencies": { "@decocms/mcp-utils": "^1.0.5", "@modelcontextprotocol/sdk": "1.29.0", "@tanstack/react-router": "1.169.2", "react": "^19.2.6", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-NvhuHsKL0YpSUaAZqEe0PAzF41/JJSi+H0X7HpMBScOVpALcGqAC+DaJvcKeo3aRXXW7z6du0oCdkhLf2A6Vjw=="],
+
+    "shopify/@decocms/runtime/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "slack-mcp/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
@@ -5881,6 +5904,10 @@
 
     "replicate/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
+    "shopify/@decocms/runtime/@decocms/bindings/@tanstack/react-router": ["@tanstack/react-router@1.169.2", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.169.2", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-OJM7Kguc7ERnweaNRWsyWgIKcl3z23rD1B4jaxjzd9RGdnzpt2HfrWa9rggbT0Hfzhfo4D2ZmsfoTme035tniQ=="],
+
+    "shopify/@decocms/runtime/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
+
     "slack-mcp/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 
     "slack-mcp/@decocms/bindings/@tanstack/react-router/@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
@@ -6544,6 +6571,10 @@
     "replicate/@decocms/runtime/@mastra/core/ai-v5/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.10", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ=="],
 
     "replicate/@decocms/runtime/@mastra/core/ai-v5/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "shopify/@decocms/runtime/@decocms/bindings/@tanstack/react-router/@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
+
+    "shopify/@decocms/runtime/@decocms/bindings/@tanstack/react-router/@tanstack/router-core": ["@tanstack/router-core@1.169.2", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-5sm0DJF1A7Mz+9gy4Gz/lLovNailK3yot4vYvz9MkBUPw26uLnhQiR8hSCYxucjE0wD6Mdlc5l+Z0/XTlZ7xHw=="],
 
     "sora/@decocms/runtime/@mastra/core/@ai-sdk/anthropic-v5/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
 

--- a/deploy.json
+++ b/deploy.json
@@ -502,5 +502,14 @@
       "youtube-search/**",
       "shared/**"
     ]
+  },
+  "shopify": {
+    "site": "shopify",
+    "entrypoint": "./dist/server/main.js",
+    "platformName": "kubernetes-bun",
+    "watch": [
+      "shopify/**",
+      "shared/**"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "registry",
     "replicate",
     "shared",
+    "shopify",
     "slack-mcp",
     "sora",
     "strapi",

--- a/registry.json
+++ b/registry.json
@@ -3019,6 +3019,55 @@
     }
   },
   {
+    "id": "deco/shopify",
+    "title": "Shopify",
+    "description": "Read-only MCP for the Shopify Admin GraphQL API — products, collections, orders, draft orders, customers, inventory, fulfillment, discounts, online store content, B2B, markets, Shopify Payments and ShopifyQL analytics.",
+    "is_public": true,
+    "_meta": {
+      "mcp.mesh": {
+        "verified": false,
+        "friendly_name": "Shopify",
+        "short_description": "Read-only access to Shopify stores: catalog, orders, customers, inventory and analytics.",
+        "owner": "deco",
+        "has_remote": true,
+        "has_oauth": true,
+        "tags": [
+          "shopify",
+          "ecommerce",
+          "orders",
+          "products",
+          "customers",
+          "inventory",
+          "analytics",
+          "api"
+        ],
+        "categories": [
+          "E-commerce"
+        ],
+        "readme": "The Shopify MCP gives AI agents read-only access to a Shopify store through the Admin GraphQL API. It can browse and search products, variants and collections, inspect orders (including draft orders, abandoned checkouts, returns, refund previews and fulfillment status), look up customers and segments, check inventory levels per location, review discounts and marketing activities, read online store content (pages, blogs, articles, menus, redirects and theme files), and pull financial data from Shopify Payments (payouts, balance, disputes). It also supports ShopifyQL analytics queries where available. Because every tool is a GraphQL query — never a mutation — the MCP can never modify store data. Connect with a custom-app Admin API access token (Authorization field) and the store's myshopify.com domain."
+      }
+    },
+    "server": {
+      "name": "shopify",
+      "title": "Shopify",
+      "description": "Read-only MCP for the Shopify Admin GraphQL API — products, collections, orders, draft orders, customers, inventory, fulfillment, discounts, online store content, B2B, markets, Shopify Payments and ShopifyQL analytics.",
+      "icons": [
+        {
+          "src": "https://github.com/shopify.png"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "HTTP",
+          "url": "https://sites-shopify.deco.site/mcp",
+          "name": "shopify",
+          "title": "Shopify",
+          "description": "Read-only MCP for the Shopify Admin GraphQL API — products, collections, orders, draft orders, customers, inventory, fulfillment, discounts, online store content, B2B, markets, Shopify Payments and ShopifyQL analytics."
+        }
+      ]
+    }
+  },
+  {
     "id": "deco/slack",
     "title": "Slack Bot Beta",
     "description": "Slack bot integration with intelligent thread management, AI agent commands, message handling and webhook support.",

--- a/shopify/README.md
+++ b/shopify/README.md
@@ -1,0 +1,57 @@
+# Shopify MCP
+
+Read-only MCP for the **Shopify Admin GraphQL API** (pinned to `2026-07`). Every tool is a
+GraphQL query — never a mutation — so the MCP can never modify store data.
+
+45 tools across 11 domains: products & collections, orders (drafts, abandoned checkouts,
+returns, refund previews), fulfillment & locations, inventory, customers & segments,
+discounts & marketing, online store content (pages, blogs, articles, menus, redirects,
+themes), store properties & localization, B2B companies & markets, Shopify Payments,
+and ShopifyQL analytics. See [TOOLS.md](./TOOLS.md) for the full catalog and scope map.
+
+## Setup
+
+1. In the Shopify admin, create a **custom app** (Settings → Apps and sales channels →
+   Develop apps) and give it the **read scopes** you need — e.g. `read_products`,
+   `read_orders`, `read_customers`, `read_inventory`, `read_fulfillments`, `read_locations`,
+   `read_discounts`, `read_content`, `read_themes`, `read_locales`, `read_translations`,
+   `read_marketing_events`, `read_users`, `read_companies`, `read_markets`,
+   `read_shopify_payments_payouts`, `read_shopify_payments_disputes`, `read_reports`.
+   Tools whose scope is missing fail with a clear ACCESS_DENIED hint; grant only what you use.
+2. Install the app on the store and copy the **Admin API access token** (`shpat_…`).
+3. Connect the MCP:
+   - **Token** (connection Authorization field): the Admin API access token
+   - **Store Domain** (config field): `my-store.myshopify.com`
+   - **API Version** (optional): defaults to `2026-07`
+
+Orders older than 60 days additionally require the `read_all_orders` scope, which Shopify
+only grants to approved apps.
+
+### Local development
+
+```sh
+SHOPIFY_STORE_DOMAIN=my-store.myshopify.com SHOPIFY_ACCESS_TOKEN=shpat_xxx bun run dev
+```
+
+Env vars are a fallback — connection state (`storeDomain`) and the Authorization header
+always win.
+
+## Development
+
+```sh
+bun run check             # typecheck
+bun test                  # unit tests (credential resolution, retry/backoff, connection flattening)
+bun run validate:queries  # validates every GraphQL document against the live Shopify schema
+```
+
+`validate:queries` posts each tool's query to shopify.dev's public GraphiQL proxy
+(`https://shopify.dev/admin-graphql-direct-proxy/<version>`), which validates against the
+real Admin API schema and executes on demo data — no store or token required. Run it when
+bumping the API version.
+
+## Auth notes
+
+Token auth only (same pattern as the Magento MCP). Shopify OAuth would require a registered
+partner app (client id/secret) and a per-store authorization URL, which the runtime `oauth`
+hook can't currently express — the shop domain isn't known when the authorization URL is
+built. If a partner app ever exists, the OAuth flow can be added in `server/main.ts`.

--- a/shopify/TOOLS.md
+++ b/shopify/TOOLS.md
@@ -1,0 +1,178 @@
+# Shopify MCP — Tool Selection (read-only)
+
+Final tool list for the new `shopify` MCP. **Decision: the MCP is read-only** — every tool
+wraps a query against the **Shopify Admin GraphQL API** (version `2026-07`, current stable).
+No mutations, so the MCP can never modify store data.
+
+All tools below are selected (`[x]`). The `Tier` column just indicates expected usage:
+**core** = day-1 essentials, **rec** = common, **opt** = niche but harmless to include.
+
+## API facts (verified 2026-07-14)
+
+- **GraphQL only.** The REST Admin API is legacy and closed to new apps — every tool wraps a
+  GraphQL query against `https://{store}.myshopify.com/admin/api/2026-07/graphql.json`.
+- **Auth:** single header `X-Shopify-Access-Token` (Admin API access token from a custom app).
+  Fits our `MESH_REQUEST_CONTEXT.authorization` pattern, **but we also need the store domain** —
+  see [Open questions](#open-questions).
+- **Scopes:** the token only needs **read scopes** (`read_products`, `read_orders`,
+  `read_customers`, …). Listed per domain below for the README.
+- **Rate limits:** cost-based bucket (1,000 points, restores 50/s on standard plans).
+- Docs: https://shopify.dev/docs/api/admin-graphql/latest ·
+  Full index: https://shopify.dev/docs/api/admin-graphql/2026-07/full-index
+
+## Selection at a glance
+
+~40 read-only tools across 11 domains: products & collections, orders (incl. drafts,
+returns, abandoned checkouts), fulfillment, inventory, customers, discounts, online store
+content, store properties, B2B, markets, and Shopify Payments.
+
+Excluded by decision (2026-07-14): gift cards, metafields/metaobjects, files, webhooks.
+
+---
+
+## 1. Products & Collections
+
+Scopes: `read_products`
+
+| Pick | Tool | GraphQL op | What it does | Tier |
+|---|---|---|---|---|
+| [x] | `SHOPIFY_LIST_PRODUCTS` | `products` | Paginated product list with Shopify search-syntax filters (status, vendor, tag, sku…) | core |
+| [x] | `SHOPIFY_GET_PRODUCT` | `product` / `productByIdentifier` | Fetch one product by ID or handle, incl. variants, options, media | core |
+| [x] | `SHOPIFY_LIST_PRODUCT_VARIANTS` | `productVariants` | List/search variants across the store (price, sku, barcode, inventory item) | core |
+| [x] | `SHOPIFY_LIST_COLLECTIONS` | `collections` | List custom + smart collections | core |
+| [x] | `SHOPIFY_GET_COLLECTION` | `collection` / `collectionByIdentifier` | Fetch a collection incl. products and smart-collection rules | core |
+| [x] | `SHOPIFY_LIST_PUBLICATIONS` | `publications` | Sales channels (Online Store, POS, custom apps) and what's published where | opt |
+
+## 2. Orders
+
+Scopes: `read_orders` (60-day history; `read_all_orders` for older), `read_returns`
+
+| Pick | Tool | GraphQL op | What it does | Tier |
+|---|---|---|---|---|
+| [x] | `SHOPIFY_LIST_ORDERS` | `orders` | Paginated order list with filters (status, financial/fulfillment status, date, customer) | core |
+| [x] | `SHOPIFY_GET_ORDER` | `order` | Full order: line items, transactions, fulfillments, refunds, timeline | core |
+| [x] | `SHOPIFY_LIST_DRAFT_ORDERS` | `draftOrders` | List draft orders | core |
+| [x] | `SHOPIFY_GET_DRAFT_ORDER` | `draftOrder` | Fetch a draft order | core |
+| [x] | `SHOPIFY_LIST_ABANDONED_CHECKOUTS` | `abandonedCheckouts` | Recoverable abandoned checkouts | rec |
+| [x] | `SHOPIFY_CALCULATE_REFUND` | `order.suggestedRefund` | Preview what a refund would amount to (pure calculation, changes nothing) | rec |
+| [x] | `SHOPIFY_LIST_RETURNS` | `order.returns` / `returnableFulfillments` | Returns on an order and what's still returnable | opt |
+
+## 3. Fulfillment & Shipping
+
+Scopes: `read_fulfillments`, `read_assigned_fulfillment_orders`, `read_locations`, `read_shipping`
+
+| Pick | Tool | GraphQL op | What it does | Tier |
+|---|---|---|---|---|
+| [x] | `SHOPIFY_LIST_FULFILLMENT_ORDERS` | `order.fulfillmentOrders` | Fulfillment orders for an order: assigned location, line items, holds, status | rec |
+| [x] | `SHOPIFY_LIST_LOCATIONS` | `locations` | Store locations (needed to interpret inventory + fulfillment data) | core |
+| [x] | `SHOPIFY_LIST_CARRIER_SERVICES` | `carrierServices` | Registered shipping-rate providers | opt |
+
+## 4. Inventory
+
+Scopes: `read_inventory`
+
+| Pick | Tool | GraphQL op | What it does | Tier |
+|---|---|---|---|---|
+| [x] | `SHOPIFY_GET_INVENTORY_LEVELS` | `inventoryItem.inventoryLevels` / `location.inventoryLevels` | Quantities (available, on-hand, committed, incoming) per item × location | core |
+| [x] | `SHOPIFY_GET_INVENTORY_ITEM` | `inventoryItem` | Item details: cost, tracked flag, country of origin, HS code | rec |
+
+## 5. Customers
+
+Scopes: `read_customers`
+
+| Pick | Tool | GraphQL op | What it does | Tier |
+|---|---|---|---|---|
+| [x] | `SHOPIFY_LIST_CUSTOMERS` | `customers` | Search customers (email, phone, tag, state, date filters) | core |
+| [x] | `SHOPIFY_GET_CUSTOMER` | `customer` / `customerByIdentifier` | Full profile: addresses, marketing consent, lifetime spend | core |
+| [x] | `SHOPIFY_GET_CUSTOMER_ORDERS` | `customer.orders` | Orders for one customer | core |
+| [x] | `SHOPIFY_LIST_SEGMENTS` | `segments`, `customerSegmentMembers` | Customer segments and their members | opt |
+
+## 6. Discounts
+
+Scopes: `read_discounts`, `read_marketing_events`
+
+| Pick | Tool | GraphQL op | What it does | Tier |
+|---|---|---|---|---|
+| [x] | `SHOPIFY_LIST_DISCOUNTS` | `discountNodes` | All discounts (code + automatic) with status/type filters | rec |
+| [x] | `SHOPIFY_GET_DISCOUNT` | `discountNode` | One discount incl. rules and usage counts | rec |
+| [x] | `SHOPIFY_LIST_MARKETING_ACTIVITIES` | `marketingActivities` | Marketing campaigns/activities | opt |
+
+## 7. Online Store Content
+
+Scopes: `read_content`, `read_online_store_navigation`, `read_themes`
+
+| Pick | Tool | GraphQL op | What it does | Tier |
+|---|---|---|---|---|
+| [x] | `SHOPIFY_LIST_PAGES` | `pages` | Store pages (body, SEO, publish state) | rec |
+| [x] | `SHOPIFY_LIST_BLOGS` | `blogs` | Blogs | rec |
+| [x] | `SHOPIFY_LIST_ARTICLES` | `articles` | Blog posts across blogs (author, tags, publish date) | rec |
+| [x] | `SHOPIFY_LIST_MENUS` | `menus` | Navigation menus | opt |
+| [x] | `SHOPIFY_LIST_REDIRECTS` | `urlRedirects` | URL redirects | opt |
+| [x] | `SHOPIFY_LIST_THEMES` | `themes` | Installed themes + roles (main, unpublished…) | opt |
+| [x] | `SHOPIFY_GET_THEME_FILES` | `theme.files` | Read theme files (liquid, JSON templates) | opt |
+
+## 8. Store Properties & Localization
+
+Scopes: none for `shop` basics; `read_locales`, `read_translations`, `read_users`
+
+| Pick | Tool | GraphQL op | What it does | Tier |
+|---|---|---|---|---|
+| [x] | `SHOPIFY_GET_SHOP_INFO` | `shop` | Name, domains, plan, currency, timezone, contact, features — also the natural "test connection" tool | core |
+| [x] | `SHOPIFY_LIST_LOCALES` | `shopLocales` | Enabled languages | opt |
+| [x] | `SHOPIFY_GET_TRANSLATIONS` | `translatableResources` | Translated content per resource | opt |
+| [x] | `SHOPIFY_LIST_STAFF` | `staffMembers` | Staff accounts | opt |
+| [x] | `SHOPIFY_LIST_EVENTS` | `events` | Timeline/audit events on resources | opt |
+
+## 9. B2B & Markets (Shopify Plus)
+
+Scopes: `read_companies`, `read_markets`
+
+| Pick | Tool | GraphQL op | What it does | Tier |
+|---|---|---|---|---|
+| [x] | `SHOPIFY_LIST_COMPANIES` | `companies` | B2B company accounts, contacts, locations | opt |
+| [x] | `SHOPIFY_LIST_MARKETS` | `markets` | Markets, regions, web presences, currency settings | opt |
+
+## 10. Shopify Payments / Finance
+
+Scopes: `read_shopify_payments_payouts`, `read_shopify_payments_disputes`
+
+| Pick | Tool | GraphQL op | What it does | Tier |
+|---|---|---|---|---|
+| [x] | `SHOPIFY_LIST_PAYOUTS` | `shopifyPaymentsAccount.payouts` | Payout history + schedule | opt |
+| [x] | `SHOPIFY_GET_PAYMENTS_BALANCE` | `shopifyPaymentsAccount.balance` | Pending balance | opt |
+| [x] | `SHOPIFY_LIST_DISPUTES` | `shopifyPaymentsAccount.disputes` | Chargebacks/inquiries | opt |
+| [x] | `SHOPIFY_LIST_BALANCE_TRANSACTIONS` | `shopifyPaymentsAccount.balanceTransactions` | Ledger of fees, charges, payouts | opt |
+
+## 11. Analytics
+
+Scopes: `read_reports`
+
+| Pick | Tool | GraphQL op | What it does | Tier |
+|---|---|---|---|---|
+| [x] | `SHOPIFY_RUN_SHOPIFYQL` | `shopifyqlQuery` | ShopifyQL analytics queries (sales, sessions over time) — historically gated/unstable, verify availability during implementation | opt |
+
+---
+
+## Excluded (and why)
+
+| Surface | Why excluded |
+|---|---|
+| **All mutations** | MCP is read-only by decision — no create/update/delete of any resource |
+| **Gift cards, metafields/metaobjects, files, webhooks** | Cut from scope by decision (2026-07-14) |
+| **Bulk operations** (`bulkOperationRunQuery`) | Read-only in effect, but implemented as mutations and add async/polling complexity; revisit if large exports become a need |
+| **Raw GraphQL passthrough** (`SHOPIFY_RUN_GRAPHQL`) | Can't guarantee read-only — a passthrough would accept mutations. Could add later as a query-only variant that rejects mutation documents |
+| **Subscriptions** (`subscriptionContracts`) | Readable only by the app that owns the contracts — useless with a generic custom-app token |
+| **Access/OAuth, Apps & Billing, Cart/Functions, Checkout branding, Retail/POS, Privacy** | App-developer or niche surface, not store insight |
+| **Storefront API / Customer Account API** | Different, buyer-facing APIs; this MCP targets Admin |
+
+## Decisions
+
+1. **Store domain configuration:** Magento approach — the Admin API access token goes in the
+   connection-level Authorization (Bearer) field, and `storeDomain` is a required field in the
+   connection `configSchema` (with `SHOPIFY_STORE_DOMAIN` / `SHOPIFY_ACCESS_TOKEN` env fallbacks
+   for local dev).
+2. **API version:** pinned to `2026-07`, overridable via the optional `apiVersion` config field.
+3. **OAuth:** not implemented in v1 — Shopify OAuth needs a registered partner app
+   (client id/secret) and a per-store authorization URL, which the current runtime `oauth`
+   hook can't express (the shop domain isn't known when building the URL). Token auth
+   (custom-app Admin token) is the supported flow, same as Magento.

--- a/shopify/app.json
+++ b/shopify/app.json
@@ -1,0 +1,40 @@
+{
+  "scopeName": "deco",
+  "name": "shopify",
+  "friendlyName": "Shopify",
+  "connection": {
+    "type": "HTTP",
+    "url": "https://sites-shopify.deco.site/mcp",
+    "configSchema": {
+      "type": "object",
+      "properties": {
+        "storeDomain": {
+          "type": "string",
+          "title": "Store Domain",
+          "description": "Shopify store domain, e.g. my-store.myshopify.com (the token goes in the connection's Authorization field)"
+        },
+        "apiVersion": {
+          "type": "string",
+          "title": "API Version",
+          "description": "Admin GraphQL API version (default 2026-07)"
+        }
+      },
+      "required": ["storeDomain"]
+    }
+  },
+  "description": "Read-only MCP for the Shopify Admin GraphQL API — products, collections, orders, draft orders, customers, inventory, fulfillment, discounts, online store content, B2B, markets, Shopify Payments and ShopifyQL analytics.",
+  "icon": "https://github.com/shopify.png",
+  "unlisted": false,
+  "auth": {
+    "type": "token",
+    "header": "Authorization",
+    "prefix": "Bearer"
+  },
+  "metadata": {
+    "categories": ["E-commerce"],
+    "official": false,
+    "tags": ["shopify", "ecommerce", "orders", "products", "customers", "inventory", "analytics", "api"],
+    "short_description": "Read-only access to Shopify stores: catalog, orders, customers, inventory and analytics.",
+    "mesh_description": "The Shopify MCP gives AI agents read-only access to a Shopify store through the Admin GraphQL API. It can browse and search products, variants and collections, inspect orders (including draft orders, abandoned checkouts, returns, refund previews and fulfillment status), look up customers and segments, check inventory levels per location, review discounts and marketing activities, read online store content (pages, blogs, articles, menus, redirects and theme files), and pull financial data from Shopify Payments (payouts, balance, disputes). It also supports ShopifyQL analytics queries where available. Because every tool is a GraphQL query — never a mutation — the MCP can never modify store data. Connect with a custom-app Admin API access token (Authorization field) and the store's myshopify.com domain."
+  }
+}

--- a/shopify/package.json
+++ b/shopify/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "shopify",
+  "version": "1.0.0",
+  "description": "Read-only MCP for the Shopify Admin GraphQL API - products, orders, customers, inventory, fulfillment, discounts, content and analytics",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun run --hot server/main.ts",
+    "check": "tsc --noEmit",
+    "test": "bun test",
+    "validate:queries": "bun run scripts/validate-queries.ts",
+    "build:server": "NODE_ENV=production bun build server/main.ts --target=bun --outfile=dist/server/main.js",
+    "build": "bun run build:server"
+  },
+  "dependencies": {
+    "@decocms/runtime": "^1.6.2",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@decocms/mcps-shared": "1.0.0",
+    "@types/bun": "^1.2.14",
+    "typescript": "^5.7.2"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/shopify/scripts/validate-queries.ts
+++ b/shopify/scripts/validate-queries.ts
@@ -1,0 +1,216 @@
+#!/usr/bin/env bun
+/**
+ * Validates every GraphQL document against the Shopify Admin API schema via
+ * shopify.dev's GraphiQL proxy (no store/token needed — it executes queries
+ * against demo data and reports full validation errors).
+ *
+ * Usage: bun run scripts/validate-queries.ts [--version 2026-07]
+ */
+import * as analytics from "../server/tools/analytics.ts";
+import * as b2b from "../server/tools/b2b.ts";
+import * as content from "../server/tools/content.ts";
+import * as customers from "../server/tools/customers.ts";
+import * as discounts from "../server/tools/discounts.ts";
+import * as fulfillment from "../server/tools/fulfillment.ts";
+import * as inventory from "../server/tools/inventory.ts";
+import * as orders from "../server/tools/orders.ts";
+import * as payments from "../server/tools/payments.ts";
+import * as products from "../server/tools/products.ts";
+import * as store from "../server/tools/store.ts";
+import { DEFAULT_API_VERSION } from "../server/constants.ts";
+
+const version =
+  process.argv.includes("--version") &&
+  process.argv[process.argv.indexOf("--version") + 1]
+    ? process.argv[process.argv.indexOf("--version") + 1]
+    : DEFAULT_API_VERSION;
+
+const PROXY_URL = `https://shopify.dev/admin-graphql-direct-proxy/${version}`;
+
+const GID = {
+  product: "gid://shopify/Product/1",
+  collection: "gid://shopify/Collection/1",
+  order: "gid://shopify/Order/1",
+  draftOrder: "gid://shopify/DraftOrder/1",
+  customer: "gid://shopify/Customer/1",
+  segment: "gid://shopify/Segment/1",
+  inventoryItem: "gid://shopify/InventoryItem/1",
+  productVariant: "gid://shopify/ProductVariant/1",
+  location: "gid://shopify/Location/1",
+  discountNode: "gid://shopify/DiscountNode/1",
+  theme: "gid://shopify/OnlineStoreTheme/1",
+  lineItem: "gid://shopify/LineItem/1",
+};
+
+/** Sample variables per exported *_QUERY document. */
+const SAMPLES: Record<string, Record<string, unknown>> = {
+  LIST_PRODUCTS_QUERY: { first: 1 },
+  GET_PRODUCT_BY_ID_QUERY: { id: GID.product },
+  GET_PRODUCT_BY_HANDLE_QUERY: { handle: "sample" },
+  LIST_PRODUCT_VARIANTS_QUERY: { first: 1 },
+  LIST_COLLECTIONS_QUERY: { first: 1 },
+  GET_COLLECTION_BY_ID_QUERY: { id: GID.collection, productsFirst: 1 },
+  GET_COLLECTION_BY_HANDLE_QUERY: { handle: "sample", productsFirst: 1 },
+  LIST_PUBLICATIONS_QUERY: { first: 1 },
+  LIST_ORDERS_QUERY: { first: 1 },
+  GET_ORDER_QUERY: { id: GID.order },
+  LIST_DRAFT_ORDERS_QUERY: { first: 1 },
+  GET_DRAFT_ORDER_QUERY: { id: GID.draftOrder },
+  LIST_ABANDONED_CHECKOUTS_QUERY: { first: 1 },
+  CALCULATE_REFUND_QUERY: {
+    orderId: GID.order,
+    refundLineItems: [{ lineItemId: GID.lineItem, quantity: 1 }],
+  },
+  LIST_RETURNS_QUERY: { orderId: GID.order, first: 1 },
+  LIST_FULFILLMENT_ORDERS_QUERY: { orderId: GID.order, first: 1 },
+  LIST_LOCATIONS_QUERY: { first: 1 },
+  LIST_CARRIER_SERVICES_QUERY: { first: 1 },
+  INVENTORY_LEVELS_BY_ITEM_QUERY: {
+    itemId: GID.inventoryItem,
+    first: 1,
+    names: ["available"],
+  },
+  INVENTORY_LEVELS_BY_VARIANT_QUERY: {
+    variantId: GID.productVariant,
+    first: 1,
+    names: ["available"],
+  },
+  INVENTORY_LEVELS_BY_LOCATION_QUERY: {
+    locationId: GID.location,
+    first: 1,
+    names: ["available"],
+  },
+  GET_INVENTORY_ITEM_QUERY: { id: GID.inventoryItem },
+  LIST_CUSTOMERS_QUERY: { first: 1 },
+  GET_CUSTOMER_QUERY: { id: GID.customer },
+  GET_CUSTOMER_ORDERS_QUERY: { id: GID.customer, first: 1 },
+  LIST_SEGMENTS_QUERY: { first: 1 },
+  LIST_SEGMENT_MEMBERS_QUERY: { segmentId: GID.segment, first: 1 },
+  LIST_DISCOUNTS_QUERY: { first: 1 },
+  GET_DISCOUNT_QUERY: { id: GID.discountNode },
+  LIST_MARKETING_ACTIVITIES_QUERY: { first: 1 },
+  LIST_PAGES_QUERY: { first: 1 },
+  LIST_BLOGS_QUERY: { first: 1 },
+  LIST_ARTICLES_QUERY: { first: 1 },
+  LIST_MENUS_QUERY: { first: 1 },
+  LIST_REDIRECTS_QUERY: { first: 1 },
+  LIST_THEMES_QUERY: { first: 1 },
+  GET_THEME_FILES_QUERY: { id: GID.theme, first: 1 },
+  GET_SHOP_INFO_QUERY: {},
+  LIST_LOCALES_QUERY: {},
+  GET_TRANSLATIONS_QUERY: {
+    resourceType: "PRODUCT",
+    locale: "pt-BR",
+    first: 1,
+  },
+  LIST_STAFF_QUERY: { first: 1 },
+  LIST_EVENTS_QUERY: { first: 1 },
+  LIST_COMPANIES_QUERY: { first: 1 },
+  LIST_MARKETS_QUERY: { first: 1 },
+  LIST_PAYOUTS_QUERY: { first: 1 },
+  GET_PAYMENTS_BALANCE_QUERY: {},
+  LIST_DISPUTES_QUERY: { first: 1 },
+  LIST_BALANCE_TRANSACTIONS_QUERY: { first: 1 },
+  RUN_SHOPIFYQL_QUERY: { query: "FROM sales SHOW total_sales SINCE -7d" },
+};
+
+const modules = {
+  products,
+  orders,
+  fulfillment,
+  inventory,
+  customers,
+  discounts,
+  content,
+  store,
+  b2b,
+  payments,
+  analytics,
+};
+
+interface Doc {
+  name: string;
+  module: string;
+  query: string;
+}
+
+const docs: Doc[] = [];
+for (const [moduleName, mod] of Object.entries(modules)) {
+  for (const [exportName, value] of Object.entries(mod)) {
+    if (exportName.endsWith("_QUERY") && typeof value === "string") {
+      docs.push({ name: exportName, module: moduleName, query: value });
+    }
+  }
+}
+
+// The includeBody variants built at runtime by content.ts handlers.
+docs.push({
+  name: "LIST_PAGES_QUERY(includeBody)",
+  module: "content",
+  query: content.LIST_PAGES_QUERY.replace(
+    "bodySummary",
+    "bodySummary\n      body",
+  ),
+});
+docs.push({
+  name: "LIST_ARTICLES_QUERY(includeBody)",
+  module: "content",
+  query: content.LIST_ARTICLES_QUERY.replace("summary", "summary\n      body"),
+});
+
+/** Errors that indicate a schema mismatch (vs runtime/data errors, which are fine here). */
+const VALIDATION_ERROR_PATTERN =
+  /doesn't exist on type|Cannot query field|Unknown argument|has no argument|was provided invalid value|expected type|Fragment .* was used, but not defined|can't be blank|Variable .* of type|must be an input type|isn't a defined input type|Field must have selections|selections on scalar|No such type/i;
+
+let failures = 0;
+let warnings = 0;
+
+for (const doc of docs) {
+  const baseName = doc.name.replace(/\(.*\)$/, "");
+  const variables = SAMPLES[baseName];
+  if (!variables) {
+    console.log(`⚠️  ${doc.name}: no sample variables registered — skipping`);
+    warnings++;
+    continue;
+  }
+
+  const response = await fetch(PROXY_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query: doc.query, variables }),
+  });
+
+  if (!response.ok) {
+    console.log(`❌ ${doc.name}: HTTP ${response.status}`);
+    failures++;
+    continue;
+  }
+
+  const payload = (await response.json()) as {
+    errors?: { message: string }[];
+  };
+
+  if (!payload.errors?.length) {
+    console.log(`✅ ${doc.name}`);
+    continue;
+  }
+
+  const messages = payload.errors.map((e) => e.message);
+  const isValidationError = messages.some((m) =>
+    VALIDATION_ERROR_PATTERN.test(m),
+  );
+  if (isValidationError) {
+    console.log(`❌ ${doc.name}:`);
+    for (const m of messages) console.log(`     ${m}`);
+    failures++;
+  } else {
+    console.log(`⚠️  ${doc.name} (runtime error, likely fine on real stores):`);
+    for (const m of messages) console.log(`     ${m}`);
+    warnings++;
+  }
+}
+
+console.log(
+  `\n${docs.length} documents checked against ${version}: ${docs.length - failures - warnings} ok, ${warnings} warnings, ${failures} failures`,
+);
+process.exit(failures > 0 ? 1 : 0);

--- a/shopify/server/constants.ts
+++ b/shopify/server/constants.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_API_VERSION = "2026-07";
+export const REQUEST_TIMEOUT_MS = 30_000;
+export const MAX_RETRIES = 3;
+export const INITIAL_RETRY_DELAY_MS = 500;
+export const DEFAULT_PAGE_SIZE = 20;
+export const MAX_PAGE_SIZE = 100;

--- a/shopify/server/lib/client.test.ts
+++ b/shopify/server/lib/client.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  assertValidCredentials,
+  buildGraphqlUrl,
+  flattenConnection,
+  normalizeStoreDomain,
+  resolveCredentials,
+  shopifyGraphql,
+  toGid,
+} from "./client.ts";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  delete process.env.SHOPIFY_STORE_DOMAIN;
+  delete process.env.SHOPIFY_ACCESS_TOKEN;
+  delete process.env.SHOPIFY_API_VERSION;
+});
+
+describe("normalizeStoreDomain", () => {
+  test("keeps a full myshopify domain", () => {
+    expect(normalizeStoreDomain("my-store.myshopify.com")).toBe(
+      "my-store.myshopify.com",
+    );
+  });
+
+  test("strips protocol and path", () => {
+    expect(normalizeStoreDomain("https://my-store.myshopify.com/admin")).toBe(
+      "my-store.myshopify.com",
+    );
+  });
+
+  test("expands a bare store name", () => {
+    expect(normalizeStoreDomain("my-store")).toBe("my-store.myshopify.com");
+  });
+
+  test("keeps custom domains", () => {
+    expect(normalizeStoreDomain("shop.example.com")).toBe("shop.example.com");
+  });
+});
+
+describe("resolveCredentials", () => {
+  test("reads token from authorization (strips Bearer) and domain from state", () => {
+    const creds = resolveCredentials({
+      authorization: "Bearer shpat_abc123",
+      state: { storeDomain: "my-store" },
+    });
+    expect(creds.accessToken).toBe("shpat_abc123");
+    expect(creds.storeDomain).toBe("my-store.myshopify.com");
+    expect(creds.apiVersion).toBe("2026-07");
+    expect(creds.sources).toEqual({
+      storeDomain: "state",
+      accessToken: "authorization",
+    });
+  });
+
+  test("accepts a raw token without Bearer prefix", () => {
+    const creds = resolveCredentials({
+      authorization: "shpat_raw",
+      state: { storeDomain: "my-store.myshopify.com" },
+    });
+    expect(creds.accessToken).toBe("shpat_raw");
+  });
+
+  test("falls back to env vars", () => {
+    process.env.SHOPIFY_STORE_DOMAIN = "env-store.myshopify.com";
+    process.env.SHOPIFY_ACCESS_TOKEN = "shpat_env";
+    const creds = resolveCredentials(undefined);
+    expect(creds.storeDomain).toBe("env-store.myshopify.com");
+    expect(creds.accessToken).toBe("shpat_env");
+    expect(creds.sources).toEqual({
+      storeDomain: "env",
+      accessToken: "env",
+    });
+  });
+
+  test("state overrides env for domain; authorization overrides env for token", () => {
+    process.env.SHOPIFY_STORE_DOMAIN = "env-store.myshopify.com";
+    process.env.SHOPIFY_ACCESS_TOKEN = "shpat_env";
+    const creds = resolveCredentials({
+      authorization: "Bearer shpat_conn",
+      state: { storeDomain: "state-store.myshopify.com" },
+    });
+    expect(creds.storeDomain).toBe("state-store.myshopify.com");
+    expect(creds.accessToken).toBe("shpat_conn");
+  });
+
+  test("handles null authorization", () => {
+    const creds = resolveCredentials({
+      authorization: null,
+      state: { storeDomain: "my-store" },
+    });
+    expect(creds.accessToken).toBe("");
+    expect(creds.sources.accessToken).toBe("missing");
+  });
+
+  test("respects apiVersion from state", () => {
+    const creds = resolveCredentials({
+      authorization: "Bearer t",
+      state: { storeDomain: "s", apiVersion: "2026-04" },
+    });
+    expect(creds.apiVersion).toBe("2026-04");
+  });
+});
+
+describe("assertValidCredentials", () => {
+  test("throws a descriptive error when the domain is missing", () => {
+    const creds = resolveCredentials({ authorization: "Bearer t" });
+    expect(() =>
+      assertValidCredentials(creds, "SHOPIFY_GET_SHOP_INFO"),
+    ).toThrow(/storeDomain is missing.*SHOPIFY_GET_SHOP_INFO/s);
+  });
+
+  test("throws a descriptive error when the token is missing", () => {
+    const creds = resolveCredentials({ state: { storeDomain: "my-store" } });
+    expect(() => assertValidCredentials(creds)).toThrow(
+      /access token is missing/,
+    );
+  });
+});
+
+describe("buildGraphqlUrl", () => {
+  test("builds the versioned admin endpoint", () => {
+    expect(
+      buildGraphqlUrl({
+        storeDomain: "my-store.myshopify.com",
+        accessToken: "t",
+        apiVersion: "2026-07",
+      }),
+    ).toBe("https://my-store.myshopify.com/admin/api/2026-07/graphql.json");
+  });
+});
+
+describe("toGid", () => {
+  test("wraps numeric ids", () => {
+    expect(toGid("Product", "123")).toBe("gid://shopify/Product/123");
+  });
+
+  test("passes through existing gids", () => {
+    expect(toGid("Product", "gid://shopify/Product/123")).toBe(
+      "gid://shopify/Product/123",
+    );
+  });
+});
+
+describe("flattenConnection", () => {
+  test("flattens nodes", () => {
+    const page = flattenConnection({
+      nodes: [{ id: 1 }],
+      pageInfo: { hasNextPage: true, endCursor: "abc" },
+    });
+    expect(page.items).toEqual([{ id: 1 }]);
+    expect(page.pageInfo).toEqual({ hasNextPage: true, endCursor: "abc" });
+  });
+
+  test("flattens edges", () => {
+    const page = flattenConnection({ edges: [{ node: { id: 2 } }] });
+    expect(page.items).toEqual([{ id: 2 }]);
+    expect(page.pageInfo).toEqual({ hasNextPage: false, endCursor: null });
+  });
+
+  test("tolerates null", () => {
+    expect(flattenConnection(null).items).toEqual([]);
+  });
+});
+
+const CREDS = {
+  storeDomain: "my-store.myshopify.com",
+  accessToken: "shpat_test",
+  apiVersion: "2026-07",
+};
+
+function mockFetch(
+  handler: (url: string, init: RequestInit) => Response | Promise<Response>,
+): { calls: { url: string; init: RequestInit }[] } {
+  const calls: { url: string; init: RequestInit }[] = [];
+  globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+    const url = String(input);
+    calls.push({ url, init: init ?? {} });
+    return handler(url, init ?? {});
+  }) as typeof fetch;
+  return { calls };
+}
+
+describe("shopifyGraphql", () => {
+  test("sends the access token header to the versioned endpoint", async () => {
+    const { calls } = mockFetch(() =>
+      Response.json({ data: { shop: { name: "Test" } } }),
+    );
+    const data = await shopifyGraphql<{ shop: { name: string } }>(
+      CREDS,
+      "{ shop { name } }",
+    );
+    expect(data.shop.name).toBe("Test");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe(
+      "https://my-store.myshopify.com/admin/api/2026-07/graphql.json",
+    );
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers["X-Shopify-Access-Token"]).toBe("shpat_test");
+    const body = JSON.parse(String(calls[0].init.body));
+    expect(body.query).toBe("{ shop { name } }");
+  });
+
+  test("throws with a scope hint on ACCESS_DENIED", async () => {
+    mockFetch(() =>
+      Response.json({
+        errors: [
+          {
+            message: "Access denied for products",
+            extensions: { code: "ACCESS_DENIED" },
+          },
+        ],
+      }),
+    );
+    expect(shopifyGraphql(CREDS, "{ products { id } }")).rejects.toThrow(
+      /Access denied.*missing a required read scope/s,
+    );
+  });
+
+  test("retries THROTTLED errors and succeeds", async () => {
+    let attempt = 0;
+    const { calls } = mockFetch(() => {
+      attempt++;
+      if (attempt === 1) {
+        return Response.json({
+          errors: [{ message: "Throttled", extensions: { code: "THROTTLED" } }],
+        });
+      }
+      return Response.json({ data: { ok: true } });
+    });
+    const data = await shopifyGraphql<{ ok: boolean }>(CREDS, "{ ok }");
+    expect(data.ok).toBe(true);
+    expect(calls).toHaveLength(2);
+  });
+
+  test("retries 5xx responses", async () => {
+    let attempt = 0;
+    const { calls } = mockFetch(() => {
+      attempt++;
+      if (attempt === 1) {
+        return new Response("upstream error", { status: 502 });
+      }
+      return Response.json({ data: { ok: true } });
+    });
+    const data = await shopifyGraphql<{ ok: boolean }>(CREDS, "{ ok }");
+    expect(data.ok).toBe(true);
+    expect(calls).toHaveLength(2);
+  });
+
+  test("does not retry 401 and includes an auth hint", async () => {
+    const { calls } = mockFetch(
+      () => new Response("Invalid API key or access token", { status: 401 }),
+    );
+    expect(shopifyGraphql(CREDS, "{ shop { name } }")).rejects.toThrow(
+      /401.*check that the Admin API access token/s,
+    );
+    await Bun.sleep(10);
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/shopify/server/lib/client.ts
+++ b/shopify/server/lib/client.ts
@@ -1,0 +1,258 @@
+/**
+ * Shopify Admin GraphQL client — credential resolution, endpoint building and
+ * a retrying fetch wrapper. Mirrors magento/server/lib/client.ts: the access
+ * token comes from the connection-level Authorization field
+ * (MESH_REQUEST_CONTEXT.authorization) and the store domain from state.
+ */
+import {
+  DEFAULT_API_VERSION,
+  INITIAL_RETRY_DELAY_MS,
+  MAX_RETRIES,
+  REQUEST_TIMEOUT_MS,
+} from "../constants.ts";
+import type { ShopifyCredentials } from "../types/env.ts";
+
+export type { ShopifyCredentials };
+
+type CredentialSource = "authorization" | "state" | "env" | "missing";
+
+export interface ResolvedCredentials extends ShopifyCredentials {
+  /** Where each credential value came from — useful for diagnosing missing config. */
+  sources: {
+    storeDomain: CredentialSource;
+    accessToken: CredentialSource;
+  };
+}
+
+export interface MeshRequestContext {
+  authorization?: string | null;
+  state?: { storeDomain?: string; apiVersion?: string };
+}
+
+/**
+ * Normalize a store domain: accepts "my-store", "my-store.myshopify.com",
+ * "https://my-store.myshopify.com/" or a custom domain, returns a bare host.
+ */
+export function normalizeStoreDomain(input: string): string {
+  let domain = input.trim().replace(/^https?:\/\//i, "");
+  domain = domain.replace(/\/.*$/, "").replace(/\.$/, "");
+  if (domain && !domain.includes(".")) {
+    domain = `${domain}.myshopify.com`;
+  }
+  return domain;
+}
+
+export function resolveCredentials(
+  ctx: MeshRequestContext | undefined,
+): ResolvedCredentials {
+  const state = ctx?.state ?? {};
+
+  let storeDomain: { value: string; source: CredentialSource };
+  if (state.storeDomain) {
+    storeDomain = { value: state.storeDomain, source: "state" };
+  } else if (process.env.SHOPIFY_STORE_DOMAIN) {
+    storeDomain = { value: process.env.SHOPIFY_STORE_DOMAIN, source: "env" };
+  } else {
+    storeDomain = { value: "", source: "missing" };
+  }
+
+  const rawAuth = ctx?.authorization;
+  const tokenFromAuth = rawAuth
+    ? rawAuth.replace(/^Bearer\s+/i, "").trim()
+    : undefined;
+  let accessToken: { value: string; source: CredentialSource };
+  if (tokenFromAuth) {
+    accessToken = { value: tokenFromAuth, source: "authorization" };
+  } else if (process.env.SHOPIFY_ACCESS_TOKEN) {
+    accessToken = { value: process.env.SHOPIFY_ACCESS_TOKEN, source: "env" };
+  } else {
+    accessToken = { value: "", source: "missing" };
+  }
+
+  return {
+    storeDomain: storeDomain.value
+      ? normalizeStoreDomain(storeDomain.value)
+      : "",
+    accessToken: accessToken.value,
+    apiVersion:
+      state.apiVersion ||
+      process.env.SHOPIFY_API_VERSION ||
+      DEFAULT_API_VERSION,
+    sources: {
+      storeDomain: storeDomain.source,
+      accessToken: accessToken.source,
+    },
+  };
+}
+
+export function assertValidCredentials(
+  creds: ResolvedCredentials,
+  toolId?: string,
+): void {
+  const where = toolId ? ` (tool=${toolId})` : "";
+  if (!creds.storeDomain) {
+    throw new Error(
+      `Shopify storeDomain is missing${where} — set the Store Domain field in the MCP connection (e.g. my-store.myshopify.com) or the SHOPIFY_STORE_DOMAIN env var.`,
+    );
+  }
+  if (!creds.accessToken) {
+    throw new Error(
+      `Shopify access token is missing${where} — set the Token field in the MCP connection (Authorization: Bearer, an Admin API access token from a custom app) or the SHOPIFY_ACCESS_TOKEN env var.`,
+    );
+  }
+}
+
+export function buildGraphqlUrl(creds: ShopifyCredentials): string {
+  const version = creds.apiVersion || DEFAULT_API_VERSION;
+  return `https://${creds.storeDomain}/admin/api/${version}/graphql.json`;
+}
+
+interface GraphqlError {
+  message: string;
+  extensions?: { code?: string; [key: string]: unknown };
+}
+
+interface GraphqlResponse<T> {
+  data?: T;
+  errors?: GraphqlError[];
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function isThrottled(errors: GraphqlError[] | undefined): boolean {
+  return Boolean(errors?.some((e) => e.extensions?.code === "THROTTLED"));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function backoff(attempt: number): Promise<void> {
+  return sleep(
+    INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt) + Math.random() * 200,
+  );
+}
+
+/**
+ * Execute an Admin GraphQL query with timeout + retry (429/5xx/network and
+ * GraphQL THROTTLED errors). Throws a descriptive error on HTTP failure or
+ * when the response carries GraphQL errors.
+ */
+export async function shopifyGraphql<T = unknown>(
+  creds: ShopifyCredentials,
+  query: string,
+  variables: Record<string, unknown> = {},
+  toolId?: string,
+): Promise<T> {
+  const url = buildGraphqlUrl(creds);
+  const where = toolId ? ` [tool=${toolId}]` : "";
+
+  let lastError: Error | null = null;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          "X-Shopify-Access-Token": creds.accessToken,
+        },
+        body: JSON.stringify({ query, variables }),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+    } catch (err) {
+      lastError =
+        err instanceof Error ? err : new Error("Shopify request failed");
+      if (attempt < MAX_RETRIES) {
+        await backoff(attempt);
+        continue;
+      }
+      break;
+    }
+
+    if (!response.ok) {
+      const bodyText = await response.text();
+      const authHint =
+        response.status === 401 || response.status === 403
+          ? " Hint: check that the Admin API access token is valid and has the required read scopes."
+          : response.status === 404
+            ? " Hint: a 404 usually means the store domain is wrong (expected my-store.myshopify.com)."
+            : "";
+      lastError = new Error(
+        `Shopify API Error: ${response.status}${where} — ${bodyText.slice(0, 500)}${authHint}`,
+      );
+      if (attempt < MAX_RETRIES && isRetryableStatus(response.status)) {
+        await backoff(attempt);
+        continue;
+      }
+      break;
+    }
+
+    const payload = (await response.json()) as GraphqlResponse<T>;
+
+    if (payload.errors?.length) {
+      if (isThrottled(payload.errors) && attempt < MAX_RETRIES) {
+        await backoff(attempt);
+        continue;
+      }
+      const scopeHint = payload.errors.some(
+        (e) => e.extensions?.code === "ACCESS_DENIED",
+      )
+        ? " Hint: the access token is missing a required read scope for this resource."
+        : "";
+      lastError = new Error(
+        `Shopify GraphQL Error${where}: ${payload.errors
+          .map((e) => e.message)
+          .join("; ")
+          .slice(0, 800)}${scopeHint}`,
+      );
+      break;
+    }
+
+    if (payload.data === undefined || payload.data === null) {
+      lastError = new Error(`Shopify GraphQL Error${where}: empty response`);
+      break;
+    }
+
+    return payload.data;
+  }
+
+  throw lastError ?? new Error("Shopify request failed");
+}
+
+/** Shape of a flattened GraphQL connection. */
+export interface Page<T> {
+  items: T[];
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+}
+
+interface Connection<T> {
+  nodes?: T[];
+  edges?: { node: T; cursor?: string }[];
+  pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+}
+
+/** Flatten a GraphQL connection ({nodes|edges, pageInfo}) into {items, pageInfo}. */
+export function flattenConnection<T = unknown>(raw: unknown): Page<T> {
+  const connection = (raw ?? {}) as Connection<T>;
+  const items = connection.nodes ?? connection.edges?.map((e) => e.node) ?? [];
+  return {
+    items,
+    pageInfo: {
+      hasNextPage: connection.pageInfo?.hasNextPage ?? false,
+      endCursor: connection.pageInfo?.endCursor ?? null,
+    },
+  };
+}
+
+/**
+ * Coerce a numeric/legacy id or bare handle-safe id to a Shopify GID.
+ * "123" → "gid://shopify/Product/123"; existing gid:// values pass through.
+ */
+export function toGid(resource: string, id: string): string {
+  if (id.startsWith("gid://")) return id;
+  return `gid://shopify/${resource}/${id}`;
+}

--- a/shopify/server/lib/gql.ts
+++ b/shopify/server/lib/gql.ts
@@ -1,0 +1,18 @@
+/** Shared GraphQL selection snippets used across tool documents. */
+
+export const MONEY = `{ amount currencyCode }`;
+export const MONEY_BAG = `{ shopMoney { amount currencyCode } }`;
+export const PAGE_INFO = `pageInfo { hasNextPage endCursor }`;
+export const ADDRESS = `{
+  name
+  company
+  address1
+  address2
+  city
+  province
+  provinceCode
+  zip
+  country
+  countryCodeV2
+  phone
+}`;

--- a/shopify/server/lib/tool.ts
+++ b/shopify/server/lib/tool.ts
@@ -1,0 +1,61 @@
+/**
+ * Factory for read-only Shopify tools: resolves credentials from the mesh
+ * request context, validates them, and delegates to the handler.
+ */
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import type { Env } from "../types/env.ts";
+import {
+  assertValidCredentials,
+  type ResolvedCredentials,
+  resolveCredentials,
+} from "./client.ts";
+
+export function createShopifyTool<
+  TSchema extends z.ZodObject<z.ZodRawShape>,
+>(config: {
+  id: string;
+  description: string;
+  inputSchema: TSchema;
+  handler: (
+    input: z.infer<TSchema>,
+    creds: ResolvedCredentials,
+  ) => Promise<Record<string, unknown>>;
+}) {
+  return (_env: Env) =>
+    createTool({
+      id: config.id,
+      description: config.description,
+      inputSchema: config.inputSchema,
+      annotations: { readOnlyHint: true },
+      execute: async ({ context, runtimeContext }) => {
+        const env = runtimeContext.env as Env;
+        const creds = resolveCredentials(env.MESH_REQUEST_CONTEXT);
+        assertValidCredentials(creds, config.id);
+        return config.handler(context as z.infer<TSchema>, creds);
+      },
+    });
+}
+
+// ── Shared input schema fragments ────────────────────────────────────────────
+
+export const paginationSchema = {
+  first: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe("Results per page (default 20, max 100)"),
+  after: z
+    .string()
+    .optional()
+    .describe("Pagination cursor from a previous page's pageInfo.endCursor"),
+};
+
+export const searchQuerySchema = z
+  .string()
+  .optional()
+  .describe(
+    'Shopify search syntax filter, e.g. "status:active vendor:Nike" — see https://shopify.dev/docs/api/usage/search-syntax',
+  );

--- a/shopify/server/main.ts
+++ b/shopify/server/main.ts
@@ -1,0 +1,26 @@
+/**
+ * Shopify MCP
+ *
+ * Read-only MCP for the Shopify Admin GraphQL API — products, collections,
+ * orders, customers, inventory, fulfillment, discounts, online store content,
+ * B2B, markets, Shopify Payments and ShopifyQL analytics.
+ */
+import { serve } from "@decocms/mcps-shared/serve";
+import { withRuntime } from "@decocms/runtime";
+import { tools } from "./tools/index.ts";
+import { type Env, StateSchema } from "./types/env.ts";
+import packageJson from "../package.json" with { type: "json" };
+
+console.log(`Shopify MCP v${packageJson.version}`);
+
+export type { Env };
+export { StateSchema };
+
+const runtime = withRuntime<Env, typeof StateSchema>({
+  configuration: {
+    state: StateSchema,
+  },
+  tools,
+});
+
+serve(runtime.fetch);

--- a/shopify/server/tools/analytics.ts
+++ b/shopify/server/tools/analytics.ts
@@ -1,0 +1,42 @@
+/**
+ * Analytics tools (read-only): ShopifyQL queries.
+ */
+import { z } from "zod";
+import { shopifyGraphql } from "../lib/client.ts";
+import { createShopifyTool } from "../lib/tool.ts";
+
+export const RUN_SHOPIFYQL_QUERY = `
+query RunShopifyql($query: String!) {
+  shopifyqlQuery(query: $query) {
+    __typename
+    tableData {
+      columns { name dataType displayName }
+      rowData
+    }
+    parseErrors { code message }
+  }
+}`;
+
+export const runShopifyql = createShopifyTool({
+  id: "SHOPIFY_RUN_SHOPIFYQL",
+  description:
+    'Run a ShopifyQL analytics query, e.g. "FROM sales SHOW total_sales BY month SINCE -3m". Requires the read_reports scope; availability varies by plan.',
+  inputSchema: z.object({
+    query: z
+      .string()
+      .describe(
+        'ShopifyQL query, e.g. "FROM sales SHOW total_sales, net_sales BY day SINCE -30d ORDER BY day"',
+      ),
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ shopifyqlQuery: unknown }>(
+      creds,
+      RUN_SHOPIFYQL_QUERY,
+      { query: input.query },
+      "SHOPIFY_RUN_SHOPIFYQL",
+    );
+    return { result: data.shopifyqlQuery };
+  },
+});
+
+export const analyticsTools = [runShopifyql];

--- a/shopify/server/tools/b2b.ts
+++ b/shopify/server/tools/b2b.ts
@@ -1,0 +1,104 @@
+/**
+ * B2B & markets tools (read-only) — Shopify Plus features.
+ */
+import { z } from "zod";
+import { DEFAULT_PAGE_SIZE } from "../constants.ts";
+import { flattenConnection, shopifyGraphql } from "../lib/client.ts";
+import { MONEY, PAGE_INFO } from "../lib/gql.ts";
+import {
+  createShopifyTool,
+  paginationSchema,
+  searchQuerySchema,
+} from "../lib/tool.ts";
+
+export const LIST_COMPANIES_QUERY = `
+query ListCompanies($first: Int!, $after: String, $query: String) {
+  companies(first: $first, after: $after, query: $query) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      name
+      externalId
+      note
+      createdAt
+      updatedAt
+      customerSince
+      lifetimeDuration
+      ordersCount { count }
+      contactsCount { count }
+      locationsCount { count }
+      totalSpent ${MONEY}
+      mainContact {
+        id
+        customer { id displayName defaultEmailAddress { emailAddress } }
+      }
+    }
+  }
+}`;
+
+export const listCompanies = createShopifyTool({
+  id: "SHOPIFY_LIST_COMPANIES",
+  description:
+    "List B2B company accounts with contacts/locations counts and total spend (Shopify Plus).",
+  inputSchema: z.object({
+    ...paginationSchema,
+    query: searchQuerySchema,
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ companies: unknown }>(
+      creds,
+      LIST_COMPANIES_QUERY,
+      {
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+        query: input.query,
+      },
+      "SHOPIFY_LIST_COMPANIES",
+    );
+    return { companies: flattenConnection(data.companies) };
+  },
+});
+
+export const LIST_MARKETS_QUERY = `
+query ListMarkets($first: Int!, $after: String) {
+  markets(first: $first, after: $after) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      name
+      handle
+      status
+      type
+      currencySettings {
+        baseCurrency { currencyCode currencyName }
+        localCurrencies
+      }
+      webPresences(first: 5) {
+        nodes {
+          id
+          domain { host }
+          defaultLocale { locale }
+          subfolderSuffix
+        }
+      }
+    }
+  }
+}`;
+
+export const listMarkets = createShopifyTool({
+  id: "SHOPIFY_LIST_MARKETS",
+  description:
+    "List markets (international selling regions) with currency settings and web presences.",
+  inputSchema: z.object({ ...paginationSchema }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ markets: unknown }>(
+      creds,
+      LIST_MARKETS_QUERY,
+      { first: input.first ?? DEFAULT_PAGE_SIZE, after: input.after },
+      "SHOPIFY_LIST_MARKETS",
+    );
+    return { markets: flattenConnection(data.markets) };
+  },
+});
+
+export const b2bTools = [listCompanies, listMarkets];

--- a/shopify/server/tools/content.ts
+++ b/shopify/server/tools/content.ts
@@ -1,0 +1,350 @@
+/**
+ * Online store content tools (read-only): pages, blogs, articles, menus,
+ * redirects and themes.
+ */
+import { z } from "zod";
+import { DEFAULT_PAGE_SIZE } from "../constants.ts";
+import { flattenConnection, shopifyGraphql, toGid } from "../lib/client.ts";
+import { PAGE_INFO } from "../lib/gql.ts";
+import {
+  createShopifyTool,
+  paginationSchema,
+  searchQuerySchema,
+} from "../lib/tool.ts";
+
+export const LIST_PAGES_QUERY = `
+query ListPages($first: Int!, $after: String, $query: String) {
+  pages(first: $first, after: $after, query: $query) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      title
+      handle
+      bodySummary
+      isPublished
+      publishedAt
+      createdAt
+      updatedAt
+      templateSuffix
+    }
+  }
+}`;
+
+export const listPages = createShopifyTool({
+  id: "SHOPIFY_LIST_PAGES",
+  description:
+    "List online store pages (title, handle, body summary, publish state).",
+  inputSchema: z.object({
+    ...paginationSchema,
+    query: searchQuerySchema,
+    includeBody: z
+      .boolean()
+      .optional()
+      .describe("Include the full HTML body of each page"),
+  }),
+  handler: async (input, creds) => {
+    const query = input.includeBody
+      ? LIST_PAGES_QUERY.replace("bodySummary", "bodySummary\n      body")
+      : LIST_PAGES_QUERY;
+    const data = await shopifyGraphql<{ pages: unknown }>(
+      creds,
+      query,
+      {
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+        query: input.query,
+      },
+      "SHOPIFY_LIST_PAGES",
+    );
+    return { pages: flattenConnection(data.pages) };
+  },
+});
+
+export const LIST_BLOGS_QUERY = `
+query ListBlogs($first: Int!, $after: String) {
+  blogs(first: $first, after: $after) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      title
+      handle
+      commentPolicy
+      createdAt
+      updatedAt
+      tags
+      articlesCount { count }
+    }
+  }
+}`;
+
+export const listBlogs = createShopifyTool({
+  id: "SHOPIFY_LIST_BLOGS",
+  description: "List the store's blogs.",
+  inputSchema: z.object({ ...paginationSchema }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ blogs: unknown }>(
+      creds,
+      LIST_BLOGS_QUERY,
+      { first: input.first ?? DEFAULT_PAGE_SIZE, after: input.after },
+      "SHOPIFY_LIST_BLOGS",
+    );
+    return { blogs: flattenConnection(data.blogs) };
+  },
+});
+
+export const LIST_ARTICLES_QUERY = `
+query ListArticles($first: Int!, $after: String, $query: String) {
+  articles(first: $first, after: $after, query: $query) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      title
+      handle
+      summary
+      tags
+      isPublished
+      publishedAt
+      createdAt
+      updatedAt
+      templateSuffix
+      author { name }
+      blog { id title handle }
+      image { url altText }
+      commentsCount { count }
+    }
+  }
+}`;
+
+export const listArticles = createShopifyTool({
+  id: "SHOPIFY_LIST_ARTICLES",
+  description:
+    "List blog posts across all blogs (author, tags, publish state). Use includeBody for full HTML content.",
+  inputSchema: z.object({
+    ...paginationSchema,
+    query: searchQuerySchema,
+    includeBody: z
+      .boolean()
+      .optional()
+      .describe("Include the full HTML body of each article"),
+  }),
+  handler: async (input, creds) => {
+    const query = input.includeBody
+      ? LIST_ARTICLES_QUERY.replace("summary", "summary\n      body")
+      : LIST_ARTICLES_QUERY;
+    const data = await shopifyGraphql<{ articles: unknown }>(
+      creds,
+      query,
+      {
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+        query: input.query,
+      },
+      "SHOPIFY_LIST_ARTICLES",
+    );
+    return { articles: flattenConnection(data.articles) };
+  },
+});
+
+export const LIST_MENUS_QUERY = `
+query ListMenus($first: Int!, $after: String) {
+  menus(first: $first, after: $after) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      title
+      handle
+      isDefault
+      items {
+        id
+        title
+        type
+        url
+        items {
+          id
+          title
+          type
+          url
+          items { id title type url }
+        }
+      }
+    }
+  }
+}`;
+
+export const listMenus = createShopifyTool({
+  id: "SHOPIFY_LIST_MENUS",
+  description: "List navigation menus with up to three levels of items.",
+  inputSchema: z.object({ ...paginationSchema }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ menus: unknown }>(
+      creds,
+      LIST_MENUS_QUERY,
+      { first: input.first ?? DEFAULT_PAGE_SIZE, after: input.after },
+      "SHOPIFY_LIST_MENUS",
+    );
+    return { menus: flattenConnection(data.menus) };
+  },
+});
+
+export const LIST_REDIRECTS_QUERY = `
+query ListRedirects($first: Int!, $after: String, $query: String) {
+  urlRedirects(first: $first, after: $after, query: $query) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      path
+      target
+    }
+  }
+}`;
+
+export const listRedirects = createShopifyTool({
+  id: "SHOPIFY_LIST_REDIRECTS",
+  description: "List URL redirects (path → target).",
+  inputSchema: z.object({
+    ...paginationSchema,
+    query: searchQuerySchema,
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ urlRedirects: unknown }>(
+      creds,
+      LIST_REDIRECTS_QUERY,
+      {
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+        query: input.query,
+      },
+      "SHOPIFY_LIST_REDIRECTS",
+    );
+    return { redirects: flattenConnection(data.urlRedirects) };
+  },
+});
+
+export const LIST_THEMES_QUERY = `
+query ListThemes($first: Int!, $roles: [ThemeRole!]) {
+  themes(first: $first, roles: $roles) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      name
+      role
+      prefix
+      processing
+      processingFailed
+      themeStoreId
+      createdAt
+      updatedAt
+    }
+  }
+}`;
+
+export const listThemes = createShopifyTool({
+  id: "SHOPIFY_LIST_THEMES",
+  description:
+    "List installed themes and their roles (MAIN is the live theme).",
+  inputSchema: z.object({
+    first: z
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .optional()
+      .describe("Results to return (default 20)"),
+    roles: z
+      .array(
+        z.enum([
+          "MAIN",
+          "UNPUBLISHED",
+          "DEMO",
+          "DEVELOPMENT",
+          "ARCHIVED",
+          "LOCKED",
+          "MOBILE",
+        ]),
+      )
+      .optional()
+      .describe("Filter by theme role"),
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ themes: unknown }>(
+      creds,
+      LIST_THEMES_QUERY,
+      { first: input.first ?? DEFAULT_PAGE_SIZE, roles: input.roles },
+      "SHOPIFY_LIST_THEMES",
+    );
+    return { themes: flattenConnection(data.themes) };
+  },
+});
+
+export const GET_THEME_FILES_QUERY = `
+query GetThemeFiles($id: ID!, $first: Int!, $after: String, $filenames: [String!]) {
+  theme(id: $id) {
+    id
+    name
+    role
+    files(first: $first, after: $after, filenames: $filenames) {
+      ${PAGE_INFO}
+      nodes {
+        filename
+        size
+        contentType
+        checksumMd5
+        createdAt
+        updatedAt
+        body {
+          __typename
+          ... on OnlineStoreThemeFileBodyText { content }
+          ... on OnlineStoreThemeFileBodyBase64 { contentBase64 }
+          ... on OnlineStoreThemeFileBodyUrl { url }
+        }
+      }
+    }
+  }
+}`;
+
+export const getThemeFiles = createShopifyTool({
+  id: "SHOPIFY_GET_THEME_FILES",
+  description:
+    'Read theme files (Liquid templates, JSON settings, assets). Filter by exact filenames like ["layout/theme.liquid"] or wildcards like ["templates/*"].',
+  inputSchema: z.object({
+    themeId: z
+      .string()
+      .describe(
+        'Theme ID — numeric or GID ("gid://shopify/OnlineStoreTheme/123")',
+      ),
+    filenames: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Filenames to fetch, supports wildcards (e.g. ["config/*", "layout/theme.liquid"])',
+      ),
+    ...paginationSchema,
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ theme: unknown }>(
+      creds,
+      GET_THEME_FILES_QUERY,
+      {
+        id: toGid("OnlineStoreTheme", input.themeId),
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+        filenames: input.filenames,
+      },
+      "SHOPIFY_GET_THEME_FILES",
+    );
+    if (!data.theme) {
+      throw new Error(`Theme not found: ${input.themeId}`);
+    }
+    return { theme: data.theme };
+  },
+});
+
+export const contentTools = [
+  listPages,
+  listBlogs,
+  listArticles,
+  listMenus,
+  listRedirects,
+  listThemes,
+  getThemeFiles,
+];

--- a/shopify/server/tools/customers.ts
+++ b/shopify/server/tools/customers.ts
@@ -1,0 +1,242 @@
+/**
+ * Customers tools (read-only): customers, their orders and segments.
+ */
+import { z } from "zod";
+import { DEFAULT_PAGE_SIZE } from "../constants.ts";
+import { flattenConnection, shopifyGraphql, toGid } from "../lib/client.ts";
+import { ADDRESS, MONEY, MONEY_BAG, PAGE_INFO } from "../lib/gql.ts";
+import {
+  createShopifyTool,
+  paginationSchema,
+  searchQuerySchema,
+} from "../lib/tool.ts";
+
+const CUSTOMER_SUMMARY = `
+  id
+  legacyResourceId
+  displayName
+  firstName
+  lastName
+  state
+  note
+  verifiedEmail
+  createdAt
+  updatedAt
+  tags
+  numberOfOrders
+  amountSpent ${MONEY}
+  defaultEmailAddress { emailAddress marketingState }
+  defaultPhoneNumber { phoneNumber marketingState }
+  defaultAddress { city province country }
+`;
+
+export const LIST_CUSTOMERS_QUERY = `
+query ListCustomers($first: Int!, $after: String, $query: String, $sortKey: CustomerSortKeys, $reverse: Boolean) {
+  customers(first: $first, after: $after, query: $query, sortKey: $sortKey, reverse: $reverse) {
+    ${PAGE_INFO}
+    nodes {
+      ${CUSTOMER_SUMMARY}
+    }
+  }
+}`;
+
+export const listCustomers = createShopifyTool({
+  id: "SHOPIFY_LIST_CUSTOMERS",
+  description:
+    'Search customers with pagination and filters (e.g. "email:jane@example.com", "orders_count:>5 customer_date:>=2026-01-01", "tag:vip").',
+  inputSchema: z.object({
+    ...paginationSchema,
+    query: searchQuerySchema,
+    sortKey: z
+      .enum(["CREATED_AT", "UPDATED_AT", "NAME", "LOCATION", "ID", "RELEVANCE"])
+      .optional()
+      .describe("Sort key (default ID)"),
+    reverse: z.boolean().optional().describe("Reverse the sort order"),
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ customers: unknown }>(
+      creds,
+      LIST_CUSTOMERS_QUERY,
+      {
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+        query: input.query,
+        sortKey: input.sortKey,
+        reverse: input.reverse,
+      },
+      "SHOPIFY_LIST_CUSTOMERS",
+    );
+    return { customers: flattenConnection(data.customers) };
+  },
+});
+
+export const GET_CUSTOMER_QUERY = `
+query GetCustomer($id: ID!) {
+  customer(id: $id) {
+    ${CUSTOMER_SUMMARY}
+    locale
+    lifetimeDuration
+    taxExempt
+    taxExemptions
+    canDelete
+    defaultAddress ${ADDRESS}
+    addressesV2(first: 10) { nodes ${ADDRESS} }
+    lastOrder { id name createdAt }
+    companyContactProfiles { company { id name } }
+  }
+}`;
+
+export const getCustomer = createShopifyTool({
+  id: "SHOPIFY_GET_CUSTOMER",
+  description:
+    "Fetch one customer by ID: profile, marketing consent, addresses, lifetime spend and B2B company links.",
+  inputSchema: z.object({
+    id: z
+      .string()
+      .describe('Customer ID — numeric or GID ("gid://shopify/Customer/123")'),
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ customer: unknown }>(
+      creds,
+      GET_CUSTOMER_QUERY,
+      { id: toGid("Customer", input.id) },
+      "SHOPIFY_GET_CUSTOMER",
+    );
+    if (!data.customer) {
+      throw new Error(`Customer not found: ${input.id}`);
+    }
+    return { customer: data.customer };
+  },
+});
+
+export const GET_CUSTOMER_ORDERS_QUERY = `
+query GetCustomerOrders($id: ID!, $first: Int!, $after: String) {
+  customer(id: $id) {
+    id
+    displayName
+    numberOfOrders
+    orders(first: $first, after: $after, sortKey: CREATED_AT, reverse: true) {
+      ${PAGE_INFO}
+      nodes {
+        id
+        name
+        createdAt
+        displayFinancialStatus
+        displayFulfillmentStatus
+        totalPriceSet ${MONEY_BAG}
+      }
+    }
+  }
+}`;
+
+export const getCustomerOrders = createShopifyTool({
+  id: "SHOPIFY_GET_CUSTOMER_ORDERS",
+  description: "List orders for one customer, most recent first.",
+  inputSchema: z.object({
+    id: z
+      .string()
+      .describe('Customer ID — numeric or GID ("gid://shopify/Customer/123")'),
+    ...paginationSchema,
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ customer: unknown }>(
+      creds,
+      GET_CUSTOMER_ORDERS_QUERY,
+      {
+        id: toGid("Customer", input.id),
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+      },
+      "SHOPIFY_GET_CUSTOMER_ORDERS",
+    );
+    if (!data.customer) {
+      throw new Error(`Customer not found: ${input.id}`);
+    }
+    return { customer: data.customer };
+  },
+});
+
+export const LIST_SEGMENTS_QUERY = `
+query ListSegments($first: Int!, $after: String, $query: String) {
+  segments(first: $first, after: $after, query: $query) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      name
+      query
+      creationDate
+      lastEditDate
+    }
+  }
+}`;
+
+export const listSegments = createShopifyTool({
+  id: "SHOPIFY_LIST_SEGMENTS",
+  description: "List customer segments and their definition queries.",
+  inputSchema: z.object({
+    ...paginationSchema,
+    query: searchQuerySchema,
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ segments: unknown }>(
+      creds,
+      LIST_SEGMENTS_QUERY,
+      {
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+        query: input.query,
+      },
+      "SHOPIFY_LIST_SEGMENTS",
+    );
+    return { segments: flattenConnection(data.segments) };
+  },
+});
+
+export const LIST_SEGMENT_MEMBERS_QUERY = `
+query ListSegmentMembers($segmentId: ID!, $first: Int!, $after: String) {
+  customerSegmentMembers(segmentId: $segmentId, first: $first, after: $after) {
+    ${PAGE_INFO}
+    edges {
+      node {
+        id
+        displayName
+        numberOfOrders
+        lastOrderId
+        amountSpent ${MONEY}
+        defaultEmailAddress { emailAddress }
+      }
+    }
+  }
+}`;
+
+export const listSegmentMembers = createShopifyTool({
+  id: "SHOPIFY_LIST_SEGMENT_MEMBERS",
+  description: "List the customers that belong to a segment.",
+  inputSchema: z.object({
+    segmentId: z
+      .string()
+      .describe('Segment ID — numeric or GID ("gid://shopify/Segment/123")'),
+    ...paginationSchema,
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ customerSegmentMembers: unknown }>(
+      creds,
+      LIST_SEGMENT_MEMBERS_QUERY,
+      {
+        segmentId: toGid("Segment", input.segmentId),
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+      },
+      "SHOPIFY_LIST_SEGMENT_MEMBERS",
+    );
+    return { members: flattenConnection(data.customerSegmentMembers) };
+  },
+});
+
+export const customerTools = [
+  listCustomers,
+  getCustomer,
+  getCustomerOrders,
+  listSegments,
+  listSegmentMembers,
+];

--- a/shopify/server/tools/discounts.ts
+++ b/shopify/server/tools/discounts.ts
@@ -1,0 +1,170 @@
+/**
+ * Discounts & marketing tools (read-only).
+ */
+import { z } from "zod";
+import { DEFAULT_PAGE_SIZE } from "../constants.ts";
+import { flattenConnection, shopifyGraphql, toGid } from "../lib/client.ts";
+import { MONEY, PAGE_INFO } from "../lib/gql.ts";
+import {
+  createShopifyTool,
+  paginationSchema,
+  searchQuerySchema,
+} from "../lib/tool.ts";
+
+const CODE_DISCOUNT_FIELDS = `
+  title
+  status
+  summary
+  startsAt
+  endsAt
+  asyncUsageCount
+  usageLimit
+  codes(first: 5) { nodes { code } }
+  codesCount { count }
+`;
+
+const AUTOMATIC_DISCOUNT_FIELDS = `
+  title
+  status
+  summary
+  startsAt
+  endsAt
+  asyncUsageCount
+`;
+
+const DISCOUNT_SELECTION = `
+  __typename
+  ... on DiscountCodeBasic { ${CODE_DISCOUNT_FIELDS} }
+  ... on DiscountCodeBxgy { ${CODE_DISCOUNT_FIELDS} }
+  ... on DiscountCodeFreeShipping { ${CODE_DISCOUNT_FIELDS} }
+  ... on DiscountCodeApp { title status startsAt endsAt asyncUsageCount usageLimit codes(first: 5) { nodes { code } } }
+  ... on DiscountAutomaticBasic { ${AUTOMATIC_DISCOUNT_FIELDS} }
+  ... on DiscountAutomaticBxgy { ${AUTOMATIC_DISCOUNT_FIELDS} }
+  ... on DiscountAutomaticFreeShipping { ${AUTOMATIC_DISCOUNT_FIELDS} }
+  ... on DiscountAutomaticApp { title status startsAt endsAt asyncUsageCount }
+`;
+
+export const LIST_DISCOUNTS_QUERY = `
+query ListDiscounts($first: Int!, $after: String, $query: String) {
+  discountNodes(first: $first, after: $after, query: $query) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      discount {
+        ${DISCOUNT_SELECTION}
+      }
+    }
+  }
+}`;
+
+export const listDiscounts = createShopifyTool({
+  id: "SHOPIFY_LIST_DISCOUNTS",
+  description:
+    'List all discounts — code and automatic — with status, dates, usage counts and codes. Supports filters like "status:active" or "type:code_discount".',
+  inputSchema: z.object({
+    ...paginationSchema,
+    query: searchQuerySchema,
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ discountNodes: unknown }>(
+      creds,
+      LIST_DISCOUNTS_QUERY,
+      {
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+        query: input.query,
+      },
+      "SHOPIFY_LIST_DISCOUNTS",
+    );
+    return { discounts: flattenConnection(data.discountNodes) };
+  },
+});
+
+const COMBINES_WITH = `combinesWith { orderDiscounts productDiscounts shippingDiscounts }`;
+
+export const GET_DISCOUNT_QUERY = `
+query GetDiscount($id: ID!) {
+  discountNode(id: $id) {
+    id
+    discount {
+      __typename
+      ... on DiscountCodeBasic { ${CODE_DISCOUNT_FIELDS} appliesOncePerCustomer recurringCycleLimit totalSales ${MONEY} ${COMBINES_WITH} }
+      ... on DiscountCodeBxgy { ${CODE_DISCOUNT_FIELDS} appliesOncePerCustomer ${COMBINES_WITH} }
+      ... on DiscountCodeFreeShipping { ${CODE_DISCOUNT_FIELDS} appliesOncePerCustomer recurringCycleLimit ${COMBINES_WITH} }
+      ... on DiscountCodeApp { title status startsAt endsAt asyncUsageCount usageLimit codes(first: 5) { nodes { code } } ${COMBINES_WITH} }
+      ... on DiscountAutomaticBasic { ${AUTOMATIC_DISCOUNT_FIELDS} recurringCycleLimit ${COMBINES_WITH} }
+      ... on DiscountAutomaticBxgy { ${AUTOMATIC_DISCOUNT_FIELDS} ${COMBINES_WITH} }
+      ... on DiscountAutomaticFreeShipping { ${AUTOMATIC_DISCOUNT_FIELDS} recurringCycleLimit ${COMBINES_WITH} }
+      ... on DiscountAutomaticApp { title status startsAt endsAt asyncUsageCount ${COMBINES_WITH} }
+    }
+  }
+}`;
+
+export const getDiscount = createShopifyTool({
+  id: "SHOPIFY_GET_DISCOUNT",
+  description:
+    "Fetch one discount by ID with rules, usage counts, codes and combination settings.",
+  inputSchema: z.object({
+    id: z
+      .string()
+      .describe(
+        'Discount node ID — numeric or GID ("gid://shopify/DiscountNode/123")',
+      ),
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ discountNode: unknown }>(
+      creds,
+      GET_DISCOUNT_QUERY,
+      { id: toGid("DiscountNode", input.id) },
+      "SHOPIFY_GET_DISCOUNT",
+    );
+    if (!data.discountNode) {
+      throw new Error(`Discount not found: ${input.id}`);
+    }
+    return { discount: data.discountNode };
+  },
+});
+
+export const LIST_MARKETING_ACTIVITIES_QUERY = `
+query ListMarketingActivities($first: Int!, $after: String) {
+  marketingActivities(first: $first, after: $after) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      title
+      status
+      statusLabel
+      tactic
+      marketingChannelType
+      createdAt
+      updatedAt
+      adSpend ${MONEY}
+      budget { budgetType total ${MONEY} }
+      utmParameters { campaign source medium }
+    }
+  }
+}`;
+
+export const listMarketingActivities = createShopifyTool({
+  id: "SHOPIFY_LIST_MARKETING_ACTIVITIES",
+  description:
+    "List marketing activities (campaigns) with status, channel, budget and UTM parameters.",
+  inputSchema: z.object({ ...paginationSchema }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ marketingActivities: unknown }>(
+      creds,
+      LIST_MARKETING_ACTIVITIES_QUERY,
+      { first: input.first ?? DEFAULT_PAGE_SIZE, after: input.after },
+      "SHOPIFY_LIST_MARKETING_ACTIVITIES",
+    );
+    return {
+      marketingActivities: flattenConnection(data.marketingActivities),
+    };
+  },
+});
+
+export const discountTools = [
+  listDiscounts,
+  getDiscount,
+  listMarketingActivities,
+];

--- a/shopify/server/tools/fulfillment.ts
+++ b/shopify/server/tools/fulfillment.ts
@@ -1,0 +1,164 @@
+/**
+ * Fulfillment & shipping tools (read-only): fulfillment orders, locations,
+ * carrier services.
+ */
+import { z } from "zod";
+import { DEFAULT_PAGE_SIZE } from "../constants.ts";
+import { flattenConnection, shopifyGraphql, toGid } from "../lib/client.ts";
+import { PAGE_INFO } from "../lib/gql.ts";
+import {
+  createShopifyTool,
+  paginationSchema,
+  searchQuerySchema,
+} from "../lib/tool.ts";
+
+export const LIST_FULFILLMENT_ORDERS_QUERY = `
+query ListFulfillmentOrders($orderId: ID!, $first: Int!) {
+  order(id: $orderId) {
+    id
+    name
+    displayFulfillmentStatus
+    fulfillmentOrders(first: $first) {
+      ${PAGE_INFO}
+      nodes {
+        id
+        status
+        requestStatus
+        createdAt
+        updatedAt
+        fulfillAt
+        fulfillBy
+        orderName
+        assignedLocation { name address1 city zip countryCode phone location { id name } }
+        deliveryMethod { methodType }
+        destination { firstName lastName company address1 address2 city province zip countryCode email phone }
+        lineItems(first: 50) {
+          nodes {
+            id
+            sku
+            productTitle
+            variantTitle
+            remainingQuantity
+            totalQuantity
+          }
+        }
+        fulfillmentHolds { reason reasonNotes }
+        supportedActions { action externalUrl }
+      }
+    }
+  }
+}`;
+
+export const listFulfillmentOrders = createShopifyTool({
+  id: "SHOPIFY_LIST_FULFILLMENT_ORDERS",
+  description:
+    "List fulfillment orders for an order — the units of fulfillment work with assigned location, line items, holds and supported actions.",
+  inputSchema: z.object({
+    orderId: z
+      .string()
+      .describe('Order ID — numeric or GID ("gid://shopify/Order/123")'),
+    first: z
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .optional()
+      .describe("How many fulfillment orders to fetch (default 20)"),
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ order: unknown }>(
+      creds,
+      LIST_FULFILLMENT_ORDERS_QUERY,
+      {
+        orderId: toGid("Order", input.orderId),
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+      },
+      "SHOPIFY_LIST_FULFILLMENT_ORDERS",
+    );
+    if (!data.order) {
+      throw new Error(`Order not found: ${input.orderId}`);
+    }
+    return { order: data.order };
+  },
+});
+
+export const LIST_LOCATIONS_QUERY = `
+query ListLocations($first: Int!, $after: String, $query: String, $includeInactive: Boolean) {
+  locations(first: $first, after: $after, query: $query, includeInactive: $includeInactive) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      name
+      isActive
+      fulfillsOnlineOrders
+      shipsInventory
+      hasActiveInventory
+      address { address1 address2 city province provinceCode zip country countryCode phone }
+    }
+  }
+}`;
+
+export const listLocations = createShopifyTool({
+  id: "SHOPIFY_LIST_LOCATIONS",
+  description:
+    "List store locations (needed to interpret inventory levels and fulfillment assignments).",
+  inputSchema: z.object({
+    ...paginationSchema,
+    query: searchQuerySchema,
+    includeInactive: z
+      .boolean()
+      .optional()
+      .describe("Include deactivated locations"),
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ locations: unknown }>(
+      creds,
+      LIST_LOCATIONS_QUERY,
+      {
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+        query: input.query,
+        includeInactive: input.includeInactive,
+      },
+      "SHOPIFY_LIST_LOCATIONS",
+    );
+    return { locations: flattenConnection(data.locations) };
+  },
+});
+
+export const LIST_CARRIER_SERVICES_QUERY = `
+query ListCarrierServices($first: Int!, $after: String) {
+  carrierServices(first: $first, after: $after) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      name
+      active
+      callbackUrl
+      formattedName
+      supportsServiceDiscovery
+    }
+  }
+}`;
+
+export const listCarrierServices = createShopifyTool({
+  id: "SHOPIFY_LIST_CARRIER_SERVICES",
+  description:
+    "List registered carrier services (external shipping-rate providers).",
+  inputSchema: z.object({ ...paginationSchema }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ carrierServices: unknown }>(
+      creds,
+      LIST_CARRIER_SERVICES_QUERY,
+      { first: input.first ?? DEFAULT_PAGE_SIZE, after: input.after },
+      "SHOPIFY_LIST_CARRIER_SERVICES",
+    );
+    return { carrierServices: flattenConnection(data.carrierServices) };
+  },
+});
+
+export const fulfillmentTools = [
+  listFulfillmentOrders,
+  listLocations,
+  listCarrierServices,
+];

--- a/shopify/server/tools/index.ts
+++ b/shopify/server/tools/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Central export point for all Shopify tools (all read-only).
+ */
+import { analyticsTools } from "./analytics.ts";
+import { b2bTools } from "./b2b.ts";
+import { contentTools } from "./content.ts";
+import { customerTools } from "./customers.ts";
+import { discountTools } from "./discounts.ts";
+import { fulfillmentTools } from "./fulfillment.ts";
+import { inventoryTools } from "./inventory.ts";
+import { orderTools } from "./orders.ts";
+import { paymentTools } from "./payments.ts";
+import { productTools } from "./products.ts";
+import { storeTools } from "./store.ts";
+
+export const tools = [
+  ...productTools,
+  ...orderTools,
+  ...fulfillmentTools,
+  ...inventoryTools,
+  ...customerTools,
+  ...discountTools,
+  ...contentTools,
+  ...storeTools,
+  ...b2bTools,
+  ...paymentTools,
+  ...analyticsTools,
+];

--- a/shopify/server/tools/inventory.ts
+++ b/shopify/server/tools/inventory.ts
@@ -1,0 +1,238 @@
+/**
+ * Inventory tools (read-only): levels per item x location and item details.
+ */
+import { z } from "zod";
+import { shopifyGraphql, toGid } from "../lib/client.ts";
+import { MONEY, PAGE_INFO } from "../lib/gql.ts";
+import { createShopifyTool } from "../lib/tool.ts";
+
+const DEFAULT_QUANTITY_NAMES = [
+  "available",
+  "committed",
+  "incoming",
+  "on_hand",
+  "reserved",
+];
+
+const quantityNamesSchema = z
+  .array(z.string())
+  .optional()
+  .describe(
+    'Quantity states to return (default ["available","committed","incoming","on_hand","reserved"]; also "damaged", "quality_control", "safety_stock")',
+  );
+
+export const INVENTORY_LEVELS_BY_ITEM_QUERY = `
+query InventoryLevelsByItem($itemId: ID!, $first: Int!, $names: [String!]!) {
+  inventoryItem(id: $itemId) {
+    id
+    sku
+    tracked
+    inventoryLevels(first: $first) {
+      ${PAGE_INFO}
+      nodes {
+        id
+        updatedAt
+        location { id name }
+        quantities(names: $names) { name quantity }
+      }
+    }
+  }
+}`;
+
+export const INVENTORY_LEVELS_BY_VARIANT_QUERY = `
+query InventoryLevelsByVariant($variantId: ID!, $first: Int!, $names: [String!]!) {
+  productVariant(id: $variantId) {
+    id
+    displayName
+    sku
+    inventoryItem {
+      id
+      sku
+      tracked
+      inventoryLevels(first: $first) {
+        ${PAGE_INFO}
+        nodes {
+          id
+          updatedAt
+          location { id name }
+          quantities(names: $names) { name quantity }
+        }
+      }
+    }
+  }
+}`;
+
+export const INVENTORY_LEVELS_BY_LOCATION_QUERY = `
+query InventoryLevelsByLocation($locationId: ID!, $first: Int!, $after: String, $query: String, $names: [String!]!) {
+  location(id: $locationId) {
+    id
+    name
+    inventoryLevels(first: $first, after: $after, query: $query) {
+      ${PAGE_INFO}
+      nodes {
+        id
+        updatedAt
+        item { id sku variant { id displayName } }
+        quantities(names: $names) { name quantity }
+      }
+    }
+  }
+}`;
+
+export const getInventoryLevels = createShopifyTool({
+  id: "SHOPIFY_GET_INVENTORY_LEVELS",
+  description:
+    "Get inventory quantities (available, on-hand, committed, incoming, reserved) per location. Provide exactly one of inventoryItemId, productVariantId or locationId.",
+  inputSchema: z
+    .object({
+      inventoryItemId: z
+        .string()
+        .optional()
+        .describe(
+          'Inventory item ID — numeric or GID ("gid://shopify/InventoryItem/123")',
+        ),
+      productVariantId: z
+        .string()
+        .optional()
+        .describe(
+          'Product variant ID — numeric or GID ("gid://shopify/ProductVariant/123")',
+        ),
+      locationId: z
+        .string()
+        .optional()
+        .describe(
+          'Location ID — numeric or GID ("gid://shopify/Location/123")',
+        ),
+      first: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe("Results per page (default 50)"),
+      after: z
+        .string()
+        .optional()
+        .describe("Pagination cursor (only for locationId lookups)"),
+      query: z
+        .string()
+        .optional()
+        .describe(
+          'Filter for location inventory, e.g. "sku:ABC-123" (only for locationId lookups)',
+        ),
+      quantityNames: quantityNamesSchema,
+    })
+    .refine(
+      (v) =>
+        [v.inventoryItemId, v.productVariantId, v.locationId].filter(Boolean)
+          .length === 1,
+      {
+        message:
+          "Provide exactly one of inventoryItemId, productVariantId or locationId",
+      },
+    ),
+  handler: async (input, creds) => {
+    const names = input.quantityNames?.length
+      ? input.quantityNames
+      : DEFAULT_QUANTITY_NAMES;
+    const first = input.first ?? 50;
+
+    if (input.inventoryItemId) {
+      const data = await shopifyGraphql<{ inventoryItem: unknown }>(
+        creds,
+        INVENTORY_LEVELS_BY_ITEM_QUERY,
+        {
+          itemId: toGid("InventoryItem", input.inventoryItemId),
+          first,
+          names,
+        },
+        "SHOPIFY_GET_INVENTORY_LEVELS",
+      );
+      if (!data.inventoryItem) {
+        throw new Error(`Inventory item not found: ${input.inventoryItemId}`);
+      }
+      return { inventoryItem: data.inventoryItem };
+    }
+
+    if (input.productVariantId) {
+      const data = await shopifyGraphql<{ productVariant: unknown }>(
+        creds,
+        INVENTORY_LEVELS_BY_VARIANT_QUERY,
+        {
+          variantId: toGid("ProductVariant", input.productVariantId),
+          first,
+          names,
+        },
+        "SHOPIFY_GET_INVENTORY_LEVELS",
+      );
+      if (!data.productVariant) {
+        throw new Error(`Product variant not found: ${input.productVariantId}`);
+      }
+      return { productVariant: data.productVariant };
+    }
+
+    const data = await shopifyGraphql<{ location: unknown }>(
+      creds,
+      INVENTORY_LEVELS_BY_LOCATION_QUERY,
+      {
+        locationId: toGid("Location", input.locationId as string),
+        first,
+        after: input.after,
+        query: input.query,
+        names,
+      },
+      "SHOPIFY_GET_INVENTORY_LEVELS",
+    );
+    if (!data.location) {
+      throw new Error(`Location not found: ${input.locationId}`);
+    }
+    return { location: data.location };
+  },
+});
+
+export const GET_INVENTORY_ITEM_QUERY = `
+query GetInventoryItem($id: ID!) {
+  inventoryItem(id: $id) {
+    id
+    legacyResourceId
+    sku
+    tracked
+    requiresShipping
+    countryCodeOfOrigin
+    provinceCodeOfOrigin
+    harmonizedSystemCode
+    createdAt
+    updatedAt
+    unitCost ${MONEY}
+    measurement { weight { value unit } }
+    locationsCount { count }
+    variants(first: 5) { nodes { id displayName product { id title } } }
+  }
+}`;
+
+export const getInventoryItem = createShopifyTool({
+  id: "SHOPIFY_GET_INVENTORY_ITEM",
+  description:
+    "Get inventory item details: unit cost, tracked flag, country of origin, HS code, weight and linked variants.",
+  inputSchema: z.object({
+    id: z
+      .string()
+      .describe(
+        'Inventory item ID — numeric or GID ("gid://shopify/InventoryItem/123")',
+      ),
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ inventoryItem: unknown }>(
+      creds,
+      GET_INVENTORY_ITEM_QUERY,
+      { id: toGid("InventoryItem", input.id) },
+      "SHOPIFY_GET_INVENTORY_ITEM",
+    );
+    if (!data.inventoryItem) {
+      throw new Error(`Inventory item not found: ${input.id}`);
+    }
+    return { inventoryItem: data.inventoryItem };
+  },
+});
+
+export const inventoryTools = [getInventoryLevels, getInventoryItem];

--- a/shopify/server/tools/orders.ts
+++ b/shopify/server/tools/orders.ts
@@ -1,0 +1,506 @@
+/**
+ * Orders tools (read-only): orders, draft orders, abandoned checkouts,
+ * refund previews and returns.
+ */
+import { z } from "zod";
+import { DEFAULT_PAGE_SIZE } from "../constants.ts";
+import { flattenConnection, shopifyGraphql, toGid } from "../lib/client.ts";
+import { ADDRESS, MONEY_BAG, PAGE_INFO } from "../lib/gql.ts";
+import {
+  createShopifyTool,
+  paginationSchema,
+  searchQuerySchema,
+} from "../lib/tool.ts";
+
+const ORDER_SUMMARY = `
+  id
+  legacyResourceId
+  name
+  confirmationNumber
+  createdAt
+  processedAt
+  updatedAt
+  closed
+  cancelledAt
+  cancelReason
+  test
+  sourceName
+  displayFinancialStatus
+  displayFulfillmentStatus
+  returnStatus
+  email
+  phone
+  note
+  tags
+  currencyCode
+  subtotalLineItemsQuantity
+  customer { id displayName }
+  totalPriceSet ${MONEY_BAG}
+  subtotalPriceSet ${MONEY_BAG}
+  totalShippingPriceSet ${MONEY_BAG}
+  totalTaxSet ${MONEY_BAG}
+  totalRefundedSet ${MONEY_BAG}
+  totalOutstandingSet ${MONEY_BAG}
+`;
+
+export const LIST_ORDERS_QUERY = `
+query ListOrders($first: Int!, $after: String, $query: String, $sortKey: OrderSortKeys, $reverse: Boolean) {
+  orders(first: $first, after: $after, query: $query, sortKey: $sortKey, reverse: $reverse) {
+    ${PAGE_INFO}
+    nodes {
+      ${ORDER_SUMMARY}
+    }
+  }
+}`;
+
+export const listOrders = createShopifyTool({
+  id: "SHOPIFY_LIST_ORDERS",
+  description:
+    'List orders with pagination and search filters (e.g. "financial_status:paid fulfillment_status:unfulfilled created_at:>=2026-01-01"). Note: tokens see the last 60 days unless they have the read_all_orders scope.',
+  inputSchema: z.object({
+    ...paginationSchema,
+    query: searchQuerySchema,
+    sortKey: z
+      .enum([
+        "CREATED_AT",
+        "UPDATED_AT",
+        "PROCESSED_AT",
+        "ORDER_NUMBER",
+        "TOTAL_PRICE",
+        "CUSTOMER_NAME",
+        "FINANCIAL_STATUS",
+        "FULFILLMENT_STATUS",
+        "DESTINATION",
+        "ID",
+        "RELEVANCE",
+      ])
+      .optional()
+      .describe("Sort key (default PROCESSED_AT)"),
+    reverse: z.boolean().optional().describe("Reverse the sort order"),
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ orders: unknown }>(
+      creds,
+      LIST_ORDERS_QUERY,
+      {
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+        query: input.query,
+        sortKey: input.sortKey,
+        reverse: input.reverse,
+      },
+      "SHOPIFY_LIST_ORDERS",
+    );
+    return { orders: flattenConnection(data.orders) };
+  },
+});
+
+export const GET_ORDER_QUERY = `
+query GetOrder($id: ID!) {
+  order(id: $id) {
+    ${ORDER_SUMMARY}
+    statusPageUrl
+    paymentGatewayNames
+    customAttributes { key value }
+    shippingAddress ${ADDRESS}
+    billingAddress ${ADDRESS}
+    customer { id displayName defaultEmailAddress { emailAddress } defaultPhoneNumber { phoneNumber } }
+    lineItems(first: 100) {
+      ${PAGE_INFO}
+      nodes {
+        id
+        title
+        name
+        quantity
+        currentQuantity
+        unfulfilledQuantity
+        sku
+        vendor
+        variantTitle
+        requiresShipping
+        variant { id }
+        product { id }
+        originalUnitPriceSet ${MONEY_BAG}
+        discountedTotalSet ${MONEY_BAG}
+        totalDiscountSet ${MONEY_BAG}
+      }
+    }
+    transactions {
+      id
+      kind
+      status
+      gateway
+      processedAt
+      test
+      errorCode
+      amountSet ${MONEY_BAG}
+    }
+    fulfillments(first: 50) {
+      id
+      name
+      status
+      displayStatus
+      createdAt
+      deliveredAt
+      estimatedDeliveryAt
+      totalQuantity
+      trackingInfo(first: 10) { number company url }
+    }
+    refunds {
+      id
+      note
+      createdAt
+      totalRefundedSet ${MONEY_BAG}
+    }
+    returns(first: 10) {
+      nodes { id name status totalQuantity }
+    }
+  }
+}`;
+
+export const getOrder = createShopifyTool({
+  id: "SHOPIFY_GET_ORDER",
+  description:
+    "Fetch one order by ID with line items, addresses, transactions, fulfillments, refunds and returns.",
+  inputSchema: z.object({
+    id: z
+      .string()
+      .describe(
+        'Order ID — numeric ("123") or GID ("gid://shopify/Order/123")',
+      ),
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ order: unknown }>(
+      creds,
+      GET_ORDER_QUERY,
+      { id: toGid("Order", input.id) },
+      "SHOPIFY_GET_ORDER",
+    );
+    if (!data.order) {
+      throw new Error(
+        `Order not found: ${input.id}. Orders older than 60 days require the read_all_orders scope.`,
+      );
+    }
+    return { order: data.order };
+  },
+});
+
+const DRAFT_ORDER_SUMMARY = `
+  id
+  legacyResourceId
+  name
+  status
+  createdAt
+  updatedAt
+  completedAt
+  invoiceUrl
+  invoiceSentAt
+  tags
+  note2
+  email
+  phone
+  taxExempt
+  currencyCode
+  totalQuantityOfLineItems
+  customer { id displayName }
+  totalPriceSet ${MONEY_BAG}
+  subtotalPriceSet ${MONEY_BAG}
+  totalTaxSet ${MONEY_BAG}
+`;
+
+export const LIST_DRAFT_ORDERS_QUERY = `
+query ListDraftOrders($first: Int!, $after: String, $query: String) {
+  draftOrders(first: $first, after: $after, query: $query) {
+    ${PAGE_INFO}
+    nodes {
+      ${DRAFT_ORDER_SUMMARY}
+    }
+  }
+}`;
+
+export const listDraftOrders = createShopifyTool({
+  id: "SHOPIFY_LIST_DRAFT_ORDERS",
+  description:
+    'List draft orders with pagination and search filters (e.g. "status:open").',
+  inputSchema: z.object({
+    ...paginationSchema,
+    query: searchQuerySchema,
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ draftOrders: unknown }>(
+      creds,
+      LIST_DRAFT_ORDERS_QUERY,
+      {
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+        query: input.query,
+      },
+      "SHOPIFY_LIST_DRAFT_ORDERS",
+    );
+    return { draftOrders: flattenConnection(data.draftOrders) };
+  },
+});
+
+export const GET_DRAFT_ORDER_QUERY = `
+query GetDraftOrder($id: ID!) {
+  draftOrder(id: $id) {
+    ${DRAFT_ORDER_SUMMARY}
+    shippingAddress ${ADDRESS}
+    billingAddress ${ADDRESS}
+    shippingLine { title }
+    appliedDiscount { title description value valueType amountSet ${MONEY_BAG} }
+    order { id name }
+    lineItems(first: 100) {
+      ${PAGE_INFO}
+      nodes {
+        id
+        title
+        name
+        quantity
+        sku
+        vendor
+        custom
+        variant { id title }
+        product { id title }
+        originalUnitPriceSet ${MONEY_BAG}
+        totalDiscountSet ${MONEY_BAG}
+      }
+    }
+  }
+}`;
+
+export const getDraftOrder = createShopifyTool({
+  id: "SHOPIFY_GET_DRAFT_ORDER",
+  description:
+    "Fetch one draft order by ID with line items, addresses, discounts and the completed order reference.",
+  inputSchema: z.object({
+    id: z
+      .string()
+      .describe(
+        'Draft order ID — numeric or GID ("gid://shopify/DraftOrder/123")',
+      ),
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ draftOrder: unknown }>(
+      creds,
+      GET_DRAFT_ORDER_QUERY,
+      { id: toGid("DraftOrder", input.id) },
+      "SHOPIFY_GET_DRAFT_ORDER",
+    );
+    if (!data.draftOrder) {
+      throw new Error(`Draft order not found: ${input.id}`);
+    }
+    return { draftOrder: data.draftOrder };
+  },
+});
+
+export const LIST_ABANDONED_CHECKOUTS_QUERY = `
+query ListAbandonedCheckouts($first: Int!, $after: String, $query: String) {
+  abandonedCheckouts(first: $first, after: $after, query: $query) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      name
+      abandonedCheckoutUrl
+      createdAt
+      updatedAt
+      completedAt
+      note
+      discountCodes
+      taxesIncluded
+      totalPriceSet ${MONEY_BAG}
+      subtotalPriceSet ${MONEY_BAG}
+      customer { id displayName }
+      lineItems(first: 20) { nodes { title quantity } }
+    }
+  }
+}`;
+
+export const listAbandonedCheckouts = createShopifyTool({
+  id: "SHOPIFY_LIST_ABANDONED_CHECKOUTS",
+  description:
+    "List abandoned checkouts (carts that reached checkout but were not completed), with recovery URLs.",
+  inputSchema: z.object({
+    ...paginationSchema,
+    query: searchQuerySchema,
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ abandonedCheckouts: unknown }>(
+      creds,
+      LIST_ABANDONED_CHECKOUTS_QUERY,
+      {
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+        query: input.query,
+      },
+      "SHOPIFY_LIST_ABANDONED_CHECKOUTS",
+    );
+    return { abandonedCheckouts: flattenConnection(data.abandonedCheckouts) };
+  },
+});
+
+export const CALCULATE_REFUND_QUERY = `
+query CalculateRefund($orderId: ID!, $refundLineItems: [RefundLineItemInput!], $suggestFullRefund: Boolean) {
+  order(id: $orderId) {
+    id
+    name
+    suggestedRefund(refundLineItems: $refundLineItems, suggestFullRefund: $suggestFullRefund) {
+      amountSet ${MONEY_BAG}
+      maximumRefundableSet ${MONEY_BAG}
+      subtotalSet ${MONEY_BAG}
+      totalTaxSet ${MONEY_BAG}
+      shipping { amountSet ${MONEY_BAG} maximumRefundableSet ${MONEY_BAG} }
+      refundLineItems {
+        quantity
+        lineItem { id title sku }
+        priceSet ${MONEY_BAG}
+        subtotalSet ${MONEY_BAG}
+      }
+      suggestedTransactions {
+        gateway
+        amountSet ${MONEY_BAG}
+        parentTransaction { id kind gateway }
+      }
+    }
+  }
+}`;
+
+export const calculateRefund = createShopifyTool({
+  id: "SHOPIFY_CALCULATE_REFUND",
+  description:
+    "Preview what a refund would amount to for an order (pure calculation — changes nothing). Pass line items to refund, or suggestFullRefund for the whole order.",
+  inputSchema: z.object({
+    orderId: z
+      .string()
+      .describe('Order ID — numeric or GID ("gid://shopify/Order/123")'),
+    suggestFullRefund: z
+      .boolean()
+      .optional()
+      .describe("Calculate a full refund of the remaining amount"),
+    refundLineItems: z
+      .array(
+        z.object({
+          lineItemId: z
+            .string()
+            .describe(
+              'Line item ID — numeric or GID ("gid://shopify/LineItem/123")',
+            ),
+          quantity: z.number().int().min(1).describe("Quantity to refund"),
+        }),
+      )
+      .optional()
+      .describe("Specific line items to include in the refund preview"),
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{
+      order: { suggestedRefund?: unknown } | null;
+    }>(
+      creds,
+      CALCULATE_REFUND_QUERY,
+      {
+        orderId: toGid("Order", input.orderId),
+        suggestFullRefund: input.suggestFullRefund,
+        refundLineItems: input.refundLineItems?.map((item) => ({
+          lineItemId: toGid("LineItem", item.lineItemId),
+          quantity: item.quantity,
+        })),
+      },
+      "SHOPIFY_CALCULATE_REFUND",
+    );
+    if (!data.order) {
+      throw new Error(`Order not found: ${input.orderId}`);
+    }
+    return { suggestedRefund: data.order.suggestedRefund ?? null };
+  },
+});
+
+export const LIST_RETURNS_QUERY = `
+query ListReturns($orderId: ID!, $first: Int!) {
+  order(id: $orderId) {
+    id
+    name
+    returnStatus
+    returns(first: $first) {
+      ${PAGE_INFO}
+      nodes {
+        id
+        name
+        status
+        totalQuantity
+        createdAt
+        closedAt
+        requestApprovedAt
+        returnLineItems(first: 50) {
+          nodes {
+            ... on ReturnLineItem {
+              id
+              quantity
+              processedQuantity
+              refundedQuantity
+              returnReasonNote
+              customerNote
+            }
+          }
+        }
+      }
+    }
+  }
+  returnableFulfillments(orderId: $orderId, first: 10) {
+    nodes {
+      id
+      fulfillment { id name status }
+      returnableFulfillmentLineItems(first: 50) {
+        nodes {
+          quantity
+          fulfillmentLineItem { id lineItem { title sku } }
+        }
+      }
+    }
+  }
+}`;
+
+export const listReturns = createShopifyTool({
+  id: "SHOPIFY_LIST_RETURNS",
+  description:
+    "List returns on an order plus what is still returnable (fulfilled items eligible for return).",
+  inputSchema: z.object({
+    orderId: z
+      .string()
+      .describe('Order ID — numeric or GID ("gid://shopify/Order/123")'),
+    first: z
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .optional()
+      .describe("How many returns to fetch (default 10)"),
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{
+      order: { returns?: unknown } | null;
+      returnableFulfillments: unknown;
+    }>(
+      creds,
+      LIST_RETURNS_QUERY,
+      { orderId: toGid("Order", input.orderId), first: input.first ?? 10 },
+      "SHOPIFY_LIST_RETURNS",
+    );
+    if (!data.order) {
+      throw new Error(`Order not found: ${input.orderId}`);
+    }
+    return {
+      order: data.order,
+      returnableFulfillments: flattenConnection(data.returnableFulfillments),
+    };
+  },
+});
+
+export const orderTools = [
+  listOrders,
+  getOrder,
+  listDraftOrders,
+  getDraftOrder,
+  listAbandonedCheckouts,
+  calculateRefund,
+  listReturns,
+];

--- a/shopify/server/tools/payments.ts
+++ b/shopify/server/tools/payments.ts
@@ -1,0 +1,195 @@
+/**
+ * Shopify Payments / finance tools (read-only): payouts, balance, disputes
+ * and balance transactions.
+ */
+import { z } from "zod";
+import { DEFAULT_PAGE_SIZE } from "../constants.ts";
+import { flattenConnection, shopifyGraphql } from "../lib/client.ts";
+import { MONEY, PAGE_INFO } from "../lib/gql.ts";
+import { createShopifyTool, paginationSchema } from "../lib/tool.ts";
+
+function requirePaymentsAccount<T>(account: T | null | undefined): T {
+  if (!account) {
+    throw new Error(
+      "Shopify Payments is not enabled on this store (or the token lacks the read_shopify_payments_payouts / read_shopify_payments_disputes scopes).",
+    );
+  }
+  return account;
+}
+
+export const LIST_PAYOUTS_QUERY = `
+query ListPayouts($first: Int!, $after: String) {
+  shopifyPaymentsAccount {
+    defaultCurrency
+    payouts(first: $first, after: $after) {
+      ${PAGE_INFO}
+      nodes {
+        id
+        legacyResourceId
+        issuedAt
+        status
+        transactionType
+        net ${MONEY}
+        summary {
+          chargesFee ${MONEY}
+          chargesGross ${MONEY}
+          refundsFee ${MONEY}
+          refundsFeeGross ${MONEY}
+          adjustmentsFee ${MONEY}
+          adjustmentsGross ${MONEY}
+          reservedFundsFee ${MONEY}
+          reservedFundsGross ${MONEY}
+          retriedPayoutsFee ${MONEY}
+          retriedPayoutsGross ${MONEY}
+        }
+      }
+    }
+  }
+}`;
+
+export const listPayouts = createShopifyTool({
+  id: "SHOPIFY_LIST_PAYOUTS",
+  description:
+    "List Shopify Payments payouts (bank transfers) with net amounts and fee summaries.",
+  inputSchema: z.object({ ...paginationSchema }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{
+      shopifyPaymentsAccount: {
+        defaultCurrency?: unknown;
+        payouts?: unknown;
+      } | null;
+    }>(
+      creds,
+      LIST_PAYOUTS_QUERY,
+      { first: input.first ?? DEFAULT_PAGE_SIZE, after: input.after },
+      "SHOPIFY_LIST_PAYOUTS",
+    );
+    const account = requirePaymentsAccount(data.shopifyPaymentsAccount);
+    return {
+      defaultCurrency: account.defaultCurrency,
+      payouts: flattenConnection(account.payouts),
+    };
+  },
+});
+
+export const GET_PAYMENTS_BALANCE_QUERY = `
+query GetPaymentsBalance {
+  shopifyPaymentsAccount {
+    id
+    activated
+    onboardable
+    country
+    defaultCurrency
+    balance ${MONEY}
+    payoutStatementDescriptor
+    payoutSchedule { interval weeklyAnchor monthlyAnchor }
+  }
+}`;
+
+export const getPaymentsBalance = createShopifyTool({
+  id: "SHOPIFY_GET_PAYMENTS_BALANCE",
+  description:
+    "Get the Shopify Payments account status, pending balance and payout schedule.",
+  inputSchema: z.object({}),
+  handler: async (_input, creds) => {
+    const data = await shopifyGraphql<{ shopifyPaymentsAccount: unknown }>(
+      creds,
+      GET_PAYMENTS_BALANCE_QUERY,
+      {},
+      "SHOPIFY_GET_PAYMENTS_BALANCE",
+    );
+    return { account: requirePaymentsAccount(data.shopifyPaymentsAccount) };
+  },
+});
+
+export const LIST_DISPUTES_QUERY = `
+query ListDisputes($first: Int!, $after: String) {
+  shopifyPaymentsAccount {
+    disputes(first: $first, after: $after) {
+      ${PAGE_INFO}
+      nodes {
+        id
+        legacyResourceId
+        amount ${MONEY}
+        status
+        type
+        initiatedAt
+        evidenceDueBy
+        evidenceSentOn
+        finalizedOn
+        reasonDetails { reason networkReasonCode }
+        order { id name }
+      }
+    }
+  }
+}`;
+
+export const listDisputes = createShopifyTool({
+  id: "SHOPIFY_LIST_DISPUTES",
+  description:
+    "List Shopify Payments disputes (chargebacks and inquiries) with deadlines and linked orders.",
+  inputSchema: z.object({ ...paginationSchema }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{
+      shopifyPaymentsAccount: { disputes?: unknown } | null;
+    }>(
+      creds,
+      LIST_DISPUTES_QUERY,
+      { first: input.first ?? DEFAULT_PAGE_SIZE, after: input.after },
+      "SHOPIFY_LIST_DISPUTES",
+    );
+    const account = requirePaymentsAccount(data.shopifyPaymentsAccount);
+    return { disputes: flattenConnection(account.disputes) };
+  },
+});
+
+export const LIST_BALANCE_TRANSACTIONS_QUERY = `
+query ListBalanceTransactions($first: Int!, $after: String) {
+  shopifyPaymentsAccount {
+    balanceTransactions(first: $first, after: $after) {
+      ${PAGE_INFO}
+      nodes {
+        id
+        type
+        test
+        transactionDate
+        sourceId
+        sourceType
+        sourceOrderTransactionId
+        adjustmentReason
+        amount ${MONEY}
+        fee ${MONEY}
+        net ${MONEY}
+        associatedOrder { id name }
+      }
+    }
+  }
+}`;
+
+export const listBalanceTransactions = createShopifyTool({
+  id: "SHOPIFY_LIST_BALANCE_TRANSACTIONS",
+  description:
+    "List the Shopify Payments ledger: charges, refunds, fees and payout debits.",
+  inputSchema: z.object({ ...paginationSchema }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{
+      shopifyPaymentsAccount: { balanceTransactions?: unknown } | null;
+    }>(
+      creds,
+      LIST_BALANCE_TRANSACTIONS_QUERY,
+      { first: input.first ?? DEFAULT_PAGE_SIZE, after: input.after },
+      "SHOPIFY_LIST_BALANCE_TRANSACTIONS",
+    );
+    const account = requirePaymentsAccount(data.shopifyPaymentsAccount);
+    return {
+      balanceTransactions: flattenConnection(account.balanceTransactions),
+    };
+  },
+});
+
+export const paymentTools = [
+  listPayouts,
+  getPaymentsBalance,
+  listDisputes,
+  listBalanceTransactions,
+];

--- a/shopify/server/tools/products.ts
+++ b/shopify/server/tools/products.ts
@@ -1,0 +1,418 @@
+/**
+ * Products & collections tools (read-only).
+ */
+import { z } from "zod";
+import { DEFAULT_PAGE_SIZE } from "../constants.ts";
+import { flattenConnection, shopifyGraphql, toGid } from "../lib/client.ts";
+import { MONEY, PAGE_INFO } from "../lib/gql.ts";
+import {
+  createShopifyTool,
+  paginationSchema,
+  searchQuerySchema,
+} from "../lib/tool.ts";
+
+export const LIST_PRODUCTS_QUERY = `
+query ListProducts($first: Int!, $after: String, $query: String, $sortKey: ProductSortKeys, $reverse: Boolean) {
+  products(first: $first, after: $after, query: $query, sortKey: $sortKey, reverse: $reverse) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      legacyResourceId
+      title
+      handle
+      status
+      vendor
+      productType
+      tags
+      createdAt
+      updatedAt
+      publishedAt
+      onlineStoreUrl
+      totalInventory
+      tracksInventory
+      hasOnlyDefaultVariant
+      variantsCount { count }
+      featuredMedia { preview { image { url altText } } }
+      priceRangeV2 { minVariantPrice ${MONEY} maxVariantPrice ${MONEY} }
+    }
+  }
+}`;
+
+export const listProducts = createShopifyTool({
+  id: "SHOPIFY_LIST_PRODUCTS",
+  description:
+    'List products with pagination and Shopify search-syntax filters (e.g. "status:active vendor:Nike tag:sale sku:ABC*").',
+  inputSchema: z.object({
+    ...paginationSchema,
+    query: searchQuerySchema,
+    sortKey: z
+      .enum([
+        "TITLE",
+        "PRODUCT_TYPE",
+        "VENDOR",
+        "INVENTORY_TOTAL",
+        "UPDATED_AT",
+        "CREATED_AT",
+        "PUBLISHED_AT",
+        "ID",
+        "RELEVANCE",
+      ])
+      .optional()
+      .describe("Sort key (default ID)"),
+    reverse: z.boolean().optional().describe("Reverse the sort order"),
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ products: unknown }>(
+      creds,
+      LIST_PRODUCTS_QUERY,
+      {
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+        query: input.query,
+        sortKey: input.sortKey,
+        reverse: input.reverse,
+      },
+      "SHOPIFY_LIST_PRODUCTS",
+    );
+    return { products: flattenConnection(data.products) };
+  },
+});
+
+const PRODUCT_FULL_FRAGMENT = `
+fragment ProductFull on Product {
+  id
+  legacyResourceId
+  title
+  handle
+  status
+  vendor
+  productType
+  tags
+  description
+  descriptionHtml
+  createdAt
+  updatedAt
+  publishedAt
+  onlineStoreUrl
+  onlineStorePreviewUrl
+  templateSuffix
+  isGiftCard
+  totalInventory
+  tracksInventory
+  hasOnlyDefaultVariant
+  hasOutOfStockVariants
+  category { id name fullName }
+  seo { title description }
+  priceRangeV2 { minVariantPrice ${MONEY} maxVariantPrice ${MONEY} }
+  compareAtPriceRange { minVariantCompareAtPrice ${MONEY} maxVariantCompareAtPrice ${MONEY} }
+  featuredMedia { preview { image { url altText } } }
+  options { id name position optionValues { id name } }
+  variantsCount { count }
+  mediaCount { count }
+  variants(first: 100) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      legacyResourceId
+      title
+      displayName
+      sku
+      barcode
+      price
+      compareAtPrice
+      position
+      availableForSale
+      inventoryQuantity
+      inventoryPolicy
+      taxable
+      createdAt
+      updatedAt
+      selectedOptions { name value }
+      inventoryItem { id }
+      media(first: 1) { nodes { preview { image { url altText } } } }
+    }
+  }
+  media(first: 10) { nodes { id mediaContentType preview { image { url altText } } } }
+}`;
+
+export const GET_PRODUCT_BY_ID_QUERY = `
+${PRODUCT_FULL_FRAGMENT}
+query GetProduct($id: ID!) {
+  product(id: $id) { ...ProductFull }
+}`;
+
+export const GET_PRODUCT_BY_HANDLE_QUERY = `
+${PRODUCT_FULL_FRAGMENT}
+query GetProductByHandle($handle: String!) {
+  productByIdentifier(identifier: { handle: $handle }) { ...ProductFull }
+}`;
+
+export const getProduct = createShopifyTool({
+  id: "SHOPIFY_GET_PRODUCT",
+  description:
+    "Fetch one product by ID or handle, including variants, options, media, SEO and price ranges.",
+  inputSchema: z
+    .object({
+      id: z
+        .string()
+        .optional()
+        .describe(
+          'Product ID — numeric ("123") or GID ("gid://shopify/Product/123")',
+        ),
+      handle: z.string().optional().describe("Product handle (URL slug)"),
+    })
+    .refine((v) => Boolean(v.id || v.handle), {
+      message: "Provide either id or handle",
+    }),
+  handler: async (input, creds) => {
+    const data = input.id
+      ? await shopifyGraphql<{ product: unknown }>(
+          creds,
+          GET_PRODUCT_BY_ID_QUERY,
+          { id: toGid("Product", input.id) },
+          "SHOPIFY_GET_PRODUCT",
+        )
+      : await shopifyGraphql<{ productByIdentifier: unknown }>(
+          creds,
+          GET_PRODUCT_BY_HANDLE_QUERY,
+          { handle: input.handle },
+          "SHOPIFY_GET_PRODUCT",
+        );
+    const product = "product" in data ? data.product : data.productByIdentifier;
+    if (!product) {
+      throw new Error(
+        `Product not found: ${input.id ?? input.handle}. Check the ID/handle and the token's read_products scope.`,
+      );
+    }
+    return { product };
+  },
+});
+
+export const LIST_PRODUCT_VARIANTS_QUERY = `
+query ListProductVariants($first: Int!, $after: String, $query: String) {
+  productVariants(first: $first, after: $after, query: $query) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      legacyResourceId
+      title
+      displayName
+      sku
+      barcode
+      price
+      compareAtPrice
+      position
+      availableForSale
+      inventoryQuantity
+      createdAt
+      updatedAt
+      selectedOptions { name value }
+      inventoryItem { id }
+      product { id title handle status }
+    }
+  }
+}`;
+
+export const listProductVariants = createShopifyTool({
+  id: "SHOPIFY_LIST_PRODUCT_VARIANTS",
+  description:
+    'List/search product variants across the store (price, SKU, barcode, inventory). Supports search syntax like "sku:ABC-123" or "product_id:123".',
+  inputSchema: z.object({
+    ...paginationSchema,
+    query: searchQuerySchema,
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ productVariants: unknown }>(
+      creds,
+      LIST_PRODUCT_VARIANTS_QUERY,
+      {
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+        query: input.query,
+      },
+      "SHOPIFY_LIST_PRODUCT_VARIANTS",
+    );
+    return { variants: flattenConnection(data.productVariants) };
+  },
+});
+
+export const LIST_COLLECTIONS_QUERY = `
+query ListCollections($first: Int!, $after: String, $query: String, $sortKey: CollectionSortKeys, $reverse: Boolean) {
+  collections(first: $first, after: $after, query: $query, sortKey: $sortKey, reverse: $reverse) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      legacyResourceId
+      title
+      handle
+      description
+      updatedAt
+      sortOrder
+      templateSuffix
+      productsCount { count }
+      image { url altText }
+    }
+  }
+}`;
+
+export const listCollections = createShopifyTool({
+  id: "SHOPIFY_LIST_COLLECTIONS",
+  description:
+    "List collections (manual and smart) with pagination and search filters.",
+  inputSchema: z.object({
+    ...paginationSchema,
+    query: searchQuerySchema,
+    sortKey: z
+      .enum(["TITLE", "UPDATED_AT", "ID", "RELEVANCE"])
+      .optional()
+      .describe("Sort key (default ID)"),
+    reverse: z.boolean().optional().describe("Reverse the sort order"),
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ collections: unknown }>(
+      creds,
+      LIST_COLLECTIONS_QUERY,
+      {
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+        query: input.query,
+        sortKey: input.sortKey,
+        reverse: input.reverse,
+      },
+      "SHOPIFY_LIST_COLLECTIONS",
+    );
+    return { collections: flattenConnection(data.collections) };
+  },
+});
+
+const COLLECTION_FULL_FRAGMENT = `
+fragment CollectionFull on Collection {
+  id
+  legacyResourceId
+  title
+  handle
+  description
+  descriptionHtml
+  updatedAt
+  sortOrder
+  templateSuffix
+  seo { title description }
+  image { url altText }
+  productsCount { count }
+  products(first: $productsFirst, after: $productsAfter) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      title
+      handle
+      status
+      totalInventory
+      priceRangeV2 { minVariantPrice ${MONEY} maxVariantPrice ${MONEY} }
+    }
+  }
+}`;
+
+export const GET_COLLECTION_BY_ID_QUERY = `
+${COLLECTION_FULL_FRAGMENT}
+query GetCollection($id: ID!, $productsFirst: Int!, $productsAfter: String) {
+  collection(id: $id) { ...CollectionFull }
+}`;
+
+export const GET_COLLECTION_BY_HANDLE_QUERY = `
+${COLLECTION_FULL_FRAGMENT}
+query GetCollectionByHandle($handle: String!, $productsFirst: Int!, $productsAfter: String) {
+  collectionByIdentifier(identifier: { handle: $handle }) { ...CollectionFull }
+}`;
+
+export const getCollection = createShopifyTool({
+  id: "SHOPIFY_GET_COLLECTION",
+  description:
+    "Fetch one collection by ID or handle, including a page of its products.",
+  inputSchema: z
+    .object({
+      id: z
+        .string()
+        .optional()
+        .describe(
+          'Collection ID — numeric or GID ("gid://shopify/Collection/123")',
+        ),
+      handle: z.string().optional().describe("Collection handle (URL slug)"),
+      productsFirst: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .describe("How many products to include (default 20)"),
+      productsAfter: z
+        .string()
+        .optional()
+        .describe("Pagination cursor for the products connection"),
+    })
+    .refine((v) => Boolean(v.id || v.handle), {
+      message: "Provide either id or handle",
+    }),
+  handler: async (input, creds) => {
+    const variables = {
+      productsFirst: input.productsFirst ?? DEFAULT_PAGE_SIZE,
+      productsAfter: input.productsAfter,
+    };
+    const data = input.id
+      ? await shopifyGraphql<{ collection: unknown }>(
+          creds,
+          GET_COLLECTION_BY_ID_QUERY,
+          { ...variables, id: toGid("Collection", input.id) },
+          "SHOPIFY_GET_COLLECTION",
+        )
+      : await shopifyGraphql<{ collectionByIdentifier: unknown }>(
+          creds,
+          GET_COLLECTION_BY_HANDLE_QUERY,
+          { ...variables, handle: input.handle },
+          "SHOPIFY_GET_COLLECTION",
+        );
+    const collection =
+      "collection" in data ? data.collection : data.collectionByIdentifier;
+    if (!collection) {
+      throw new Error(`Collection not found: ${input.id ?? input.handle}`);
+    }
+    return { collection };
+  },
+});
+
+export const LIST_PUBLICATIONS_QUERY = `
+query ListPublications($first: Int!, $after: String) {
+  publications(first: $first, after: $after) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      autoPublish
+      supportsFuturePublishing
+      catalog { id title status }
+    }
+  }
+}`;
+
+export const listPublications = createShopifyTool({
+  id: "SHOPIFY_LIST_PUBLICATIONS",
+  description:
+    "List publications (sales channels / catalogs such as Online Store, POS, custom apps) that products can be published to.",
+  inputSchema: z.object({ ...paginationSchema }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ publications: unknown }>(
+      creds,
+      LIST_PUBLICATIONS_QUERY,
+      { first: input.first ?? DEFAULT_PAGE_SIZE, after: input.after },
+      "SHOPIFY_LIST_PUBLICATIONS",
+    );
+    return { publications: flattenConnection(data.publications) };
+  },
+});
+
+export const productTools = [
+  listProducts,
+  getProduct,
+  listProductVariants,
+  listCollections,
+  getCollection,
+  listPublications,
+];

--- a/shopify/server/tools/store.ts
+++ b/shopify/server/tools/store.ts
@@ -1,0 +1,223 @@
+/**
+ * Store properties & localization tools (read-only): shop info, locales,
+ * translations, staff and audit events.
+ */
+import { z } from "zod";
+import { DEFAULT_PAGE_SIZE } from "../constants.ts";
+import { flattenConnection, shopifyGraphql } from "../lib/client.ts";
+import { PAGE_INFO } from "../lib/gql.ts";
+import {
+  createShopifyTool,
+  paginationSchema,
+  searchQuerySchema,
+} from "../lib/tool.ts";
+
+export const GET_SHOP_INFO_QUERY = `
+query GetShopInfo {
+  shop {
+    id
+    name
+    email
+    contactEmail
+    description
+    url
+    myshopifyDomain
+    primaryDomain { host url sslEnabled }
+    currencyCode
+    enabledPresentmentCurrencies
+    ianaTimezone
+    timezoneAbbreviation
+    weightUnit
+    unitSystem
+    taxesIncluded
+    taxShipping
+    checkoutApiSupported
+    setupRequired
+    shopOwnerName
+    createdAt
+    updatedAt
+    plan { publicDisplayName shopifyPlus partnerDevelopment }
+    billingAddress { address1 city province country zip phone }
+    shipsToCountries
+  }
+}`;
+
+export const getShopInfo = createShopifyTool({
+  id: "SHOPIFY_GET_SHOP_INFO",
+  description:
+    "Get store info: name, domains, plan, currency, timezone, contact and settings. Also works as a connection test.",
+  inputSchema: z.object({}),
+  handler: async (_input, creds) => {
+    const data = await shopifyGraphql<{ shop: unknown }>(
+      creds,
+      GET_SHOP_INFO_QUERY,
+      {},
+      "SHOPIFY_GET_SHOP_INFO",
+    );
+    return { shop: data.shop };
+  },
+});
+
+export const LIST_LOCALES_QUERY = `
+query ListLocales {
+  shopLocales {
+    locale
+    name
+    primary
+    published
+  }
+}`;
+
+export const listLocales = createShopifyTool({
+  id: "SHOPIFY_LIST_LOCALES",
+  description: "List the languages (locales) enabled on the store.",
+  inputSchema: z.object({}),
+  handler: async (_input, creds) => {
+    const data = await shopifyGraphql<{ shopLocales: unknown }>(
+      creds,
+      LIST_LOCALES_QUERY,
+      {},
+      "SHOPIFY_LIST_LOCALES",
+    );
+    return { locales: data.shopLocales };
+  },
+});
+
+export const GET_TRANSLATIONS_QUERY = `
+query GetTranslations($resourceType: TranslatableResourceType!, $locale: String!, $first: Int!, $after: String) {
+  translatableResources(resourceType: $resourceType, first: $first, after: $after) {
+    ${PAGE_INFO}
+    nodes {
+      resourceId
+      translatableContent { key value digest locale }
+      translations(locale: $locale) { key value locale outdated }
+    }
+  }
+}`;
+
+export const getTranslations = createShopifyTool({
+  id: "SHOPIFY_GET_TRANSLATIONS",
+  description:
+    "Read translatable content and its translations for a resource type (PRODUCT, COLLECTION, ONLINE_STORE_PAGE, ONLINE_STORE_ARTICLE, ONLINE_STORE_MENU, SHOP_POLICY…) in a target locale.",
+  inputSchema: z.object({
+    resourceType: z
+      .string()
+      .describe(
+        "TranslatableResourceType enum value, e.g. PRODUCT, COLLECTION, ONLINE_STORE_PAGE, ONLINE_STORE_ARTICLE, ONLINE_STORE_MENU, SHOP, SHOP_POLICY, METAOBJECT",
+      ),
+    locale: z
+      .string()
+      .describe('Target locale to read translations for, e.g. "pt-BR"'),
+    ...paginationSchema,
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ translatableResources: unknown }>(
+      creds,
+      GET_TRANSLATIONS_QUERY,
+      {
+        resourceType: input.resourceType.toUpperCase(),
+        locale: input.locale,
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+      },
+      "SHOPIFY_GET_TRANSLATIONS",
+    );
+    return {
+      translatableResources: flattenConnection(data.translatableResources),
+    };
+  },
+});
+
+export const LIST_STAFF_QUERY = `
+query ListStaff($first: Int!, $after: String) {
+  staffMembers(first: $first, after: $after) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      name
+      firstName
+      lastName
+      email
+      active
+      isShopOwner
+      accountType
+      locale
+    }
+  }
+}`;
+
+export const listStaff = createShopifyTool({
+  id: "SHOPIFY_LIST_STAFF",
+  description:
+    "List staff accounts (name, email, active, owner flag). Requires the read_users scope.",
+  inputSchema: z.object({ ...paginationSchema }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ staffMembers: unknown }>(
+      creds,
+      LIST_STAFF_QUERY,
+      { first: input.first ?? DEFAULT_PAGE_SIZE, after: input.after },
+      "SHOPIFY_LIST_STAFF",
+    );
+    return { staffMembers: flattenConnection(data.staffMembers) };
+  },
+});
+
+export const LIST_EVENTS_QUERY = `
+query ListEvents($first: Int!, $after: String, $query: String, $sortKey: EventSortKeys, $reverse: Boolean) {
+  events(first: $first, after: $after, query: $query, sortKey: $sortKey, reverse: $reverse) {
+    ${PAGE_INFO}
+    nodes {
+      id
+      createdAt
+      action
+      message
+      appTitle
+      attributeToApp
+      attributeToUser
+      criticalAlert
+      ... on BasicEvent {
+        subjectId
+        subjectType
+        secondaryMessage
+      }
+    }
+  }
+}`;
+
+export const listEvents = createShopifyTool({
+  id: "SHOPIFY_LIST_EVENTS",
+  description:
+    'List timeline/audit events across the store (product updates, order actions…). Supports filters like "subject_type:PRODUCT created_at:>=2026-07-01".',
+  inputSchema: z.object({
+    ...paginationSchema,
+    query: searchQuerySchema,
+    sortKey: z
+      .enum(["CREATED_AT", "ID"])
+      .optional()
+      .describe("Sort key (default ID)"),
+    reverse: z.boolean().optional().describe("Reverse the sort order"),
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{ events: unknown }>(
+      creds,
+      LIST_EVENTS_QUERY,
+      {
+        first: input.first ?? DEFAULT_PAGE_SIZE,
+        after: input.after,
+        query: input.query,
+        sortKey: input.sortKey,
+        reverse: input.reverse,
+      },
+      "SHOPIFY_LIST_EVENTS",
+    );
+    return { events: flattenConnection(data.events) };
+  },
+});
+
+export const storeTools = [
+  getShopInfo,
+  listLocales,
+  getTranslations,
+  listStaff,
+  listEvents,
+];

--- a/shopify/server/types/env.ts
+++ b/shopify/server/types/env.ts
@@ -1,0 +1,25 @@
+/**
+ * Environment Type Definitions
+ */
+import { type DefaultEnv } from "@decocms/runtime";
+import { z } from "zod";
+
+export const StateSchema = z.object({
+  storeDomain: z
+    .string()
+    .describe(
+      "Shopify store domain, e.g. my-store.myshopify.com (the Admin API access token goes in the connection's Authorization field)",
+    ),
+  apiVersion: z
+    .string()
+    .optional()
+    .describe("Admin GraphQL API version (default 2026-07)"),
+});
+
+export type Env = DefaultEnv<typeof StateSchema>;
+
+export interface ShopifyCredentials {
+  storeDomain: string;
+  accessToken: string;
+  apiVersion?: string;
+}

--- a/shopify/tsconfig.json
+++ b/shopify/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "types": ["bun"]
+  },
+  "include": ["server", "scripts"]
+}


### PR DESCRIPTION
## Summary

- Adds a new Shopify MCP server (`shopify/`) with read-only access to the Shopify Admin GraphQL API
- Covers products, collections, orders, draft orders, customers, inventory, fulfillment, discounts, online store content, B2B, markets, Shopify Payments, and ShopifyQL analytics
- Registered in `registry.json` with public listing and OAuth support, deployed via `deploy.json` on `kubernetes-bun`

## Test plan

- [ ] Run `bun run check` in `shopify/` to verify TypeScript types
- [ ] Run `bun run validate:queries` to validate GraphQL queries
- [ ] Run `bun test` in `shopify/` to execute unit tests
- [ ] Test connection with a valid Shopify Admin API token against a dev store

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new read-only MCP server for the Shopify Admin GraphQL API under `shopify/`, exposing tools for catalog, orders, customers, inventory, fulfillment, discounts, content, B2B/markets, Shopify Payments, and ShopifyQL analytics. Publicly registered with OAuth and wired for deployment on `kubernetes-bun`.

- **New Features**
  - Read-only server pinned to API `2026-07`; all tools are GraphQL queries (no mutations).
  - New `shopify/` workspace with `server/`, `TOOLS.md`, `README.md`, and `app.json` (connection schema).
  - Tool coverage includes products/collections, orders/drafts/returns, customers/segments, inventory, fulfillment, discounts, online store content, B2B/markets, Shopify Payments, and ShopifyQL.
  - Robust client: store domain normalization, retry with backoff, timeout, pagination helpers, and typed inputs via `zod`.
  - Dev utilities: `scripts/validate-queries.ts` to validate documents against Shopify’s schema, plus unit tests.
  - Integration: registered in `registry.json` (public, OAuth), added to root `package.json`, deploy config in `deploy.json` (entrypoint `dist/server/main.js`) for `kubernetes-bun` using `@decocms/runtime` and `@decocms/mcps-shared`.

- **Migration**
  - Create a connection using `shopify/app.json`: set `storeDomain` (e.g. my-store.myshopify.com) and place the Admin API token in the connection’s Authorization field; set `apiVersion` if you need a non-default.
  - Ensure the token has required read scopes for the tools you’ll use (e.g. `read_products`, `read_orders`, `read_customers`, `read_inventory`, `read_fulfillments`, `read_discounts`, `read_content`, `read_locales`, `read_shopify_payments_*`, `read_reports`).
  - Deploy via `deploy.json` on `kubernetes-bun` or run locally with `bun run dev`; build with `bun run build`.

<sup>Written for commit ebff24f542f5426a573975c932fe61e5084d6e78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

