### PR TITLE
feat(github): add GET_CHECK_RUN tool exposing a check run's output

### DIFF
--- a/github/server/lib/check-run.test.ts
+++ b/github/server/lib/check-run.test.ts
@@ -91,6 +91,64 @@ describe("getCheckRun", () => {
     expect(r.conclusion).toBeNull();
   });
 
+  test("falls back when id/status are absent (echoes id, status 'unknown')", async () => {
+    setFetch(async () => json({ name: "build" }));
+    const r = await getCheckRun({
+      token: "t",
+      owner: "a",
+      repo: "b",
+      checkRunId: 77,
+    });
+    expect(r.id).toBe(77);
+    expect(r.status).toBe("unknown");
+  });
+
+  test("percent-encodes owner/repo path segments", async () => {
+    setFetch(async (input) => {
+      // Valid dotted names must be encoded, not concatenated raw.
+      expect(urlOf(input)).toBe(
+        "https://api.github.com/repos/deco-cx/my.repo/check-runs/9",
+      );
+      return json({ id: 9, name: "x", status: "completed" });
+    });
+    await getCheckRun({
+      token: "t",
+      owner: "deco-cx",
+      repo: "my.repo",
+      checkRunId: 9,
+    });
+  });
+
+  test("rejects owner/repo with path-injection characters before fetching", async () => {
+    setFetch(async () => {
+      throw new Error("should not fetch");
+    });
+    for (const bad of ["..", "a/b", "x?y", "../../user"]) {
+      await expectRejectCode(
+        () => getCheckRun({ token: "t", owner: bad, repo: "b", checkRunId: 1 }),
+        "invalid_input",
+      );
+      await expectRejectCode(
+        () => getCheckRun({ token: "t", owner: "a", repo: bad, checkRunId: 1 }),
+        "invalid_input",
+      );
+    }
+  });
+
+  test("a 200 with an unreadable body → upstream_error", async () => {
+    setFetch(
+      async () =>
+        new Response("<html>not json</html>", {
+          status: 200,
+          headers: { "Content-Type": "text/html" },
+        }),
+    );
+    await expectRejectCode(
+      () => getCheckRun({ token: "t", owner: "a", repo: "b", checkRunId: 1 }),
+      "upstream_error",
+    );
+  });
+
   test("403 → unauthorized (token may lack checks:read)", async () => {
     setFetch(async () => json({ message: "Resource not accessible" }, 403));
     await expectRejectCode(

--- a/github/server/lib/check-run.test.ts
+++ b/github/server/lib/check-run.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { CheckRunError, getCheckRun } from "./check-run.ts";
+
+const realFetch = globalThis.fetch;
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+function setFetch(impl: (input: unknown, init?: unknown) => Promise<Response>) {
+  globalThis.fetch = impl as unknown as typeof globalThis.fetch;
+}
+const urlOf = (i: unknown) =>
+  typeof i === "string" ? i : (i as { url: string }).url;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+async function expectRejectCode(
+  fn: () => Promise<unknown>,
+  code: CheckRunError["code"],
+): Promise<CheckRunError> {
+  let caught: unknown;
+  try {
+    await fn();
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeInstanceOf(CheckRunError);
+  expect((caught as CheckRunError).code).toBe(code);
+  return caught as CheckRunError;
+}
+
+describe("getCheckRun", () => {
+  test("returns the check run mapped with its output", async () => {
+    setFetch(async (input, init) => {
+      expect(urlOf(input)).toBe(
+        "https://api.github.com/repos/acme/web/check-runs/123",
+      );
+      const headers = (init as { headers: Record<string, string> }).headers;
+      expect(headers.Authorization).toBe("Bearer ghs_tok");
+      return json({
+        id: 123,
+        name: "Deco / QA / Purchase journey",
+        status: "completed",
+        conclusion: "success",
+        html_url: "https://github.com/acme/web/runs/123",
+        details_url: "https://deco.cx/githubapp",
+        output: {
+          title: "desktop — pass",
+          summary: "| step | status |\n| --- | --- |\n| visit-home | ✅ |",
+          text: null,
+        },
+      });
+    });
+
+    const r = await getCheckRun({
+      token: "ghs_tok",
+      owner: "acme",
+      repo: "web",
+      checkRunId: 123,
+    });
+
+    expect(r).toEqual({
+      id: 123,
+      name: "Deco / QA / Purchase journey",
+      status: "completed",
+      conclusion: "success",
+      htmlUrl: "https://github.com/acme/web/runs/123",
+      detailsUrl: "https://deco.cx/githubapp",
+      output: {
+        title: "desktop — pass",
+        summary: "| step | status |\n| --- | --- |\n| visit-home | ✅ |",
+        text: null,
+      },
+    });
+  });
+
+  test("defaults a missing output block to nulls", async () => {
+    setFetch(async () => json({ id: 5, name: "build", status: "completed" }));
+    const r = await getCheckRun({
+      token: "t",
+      owner: "a",
+      repo: "b",
+      checkRunId: 5,
+    });
+    expect(r.output).toEqual({ title: null, summary: null, text: null });
+    expect(r.conclusion).toBeNull();
+  });
+
+  test("403 → unauthorized (token may lack checks:read)", async () => {
+    setFetch(async () => json({ message: "Resource not accessible" }, 403));
+    await expectRejectCode(
+      () => getCheckRun({ token: "t", owner: "a", repo: "b", checkRunId: 1 }),
+      "unauthorized",
+    );
+  });
+
+  test("404 → not_found", async () => {
+    setFetch(async () => json({ message: "Not Found" }, 404));
+    await expectRejectCode(
+      () => getCheckRun({ token: "t", owner: "a", repo: "b", checkRunId: 1 }),
+      "not_found",
+    );
+  });
+
+  test("5xx → upstream_error", async () => {
+    setFetch(async () => json({ message: "boom" }, 503));
+    await expectRejectCode(
+      () => getCheckRun({ token: "t", owner: "a", repo: "b", checkRunId: 1 }),
+      "upstream_error",
+    );
+  });
+
+  test("missing token → unauthorized without a network call", async () => {
+    setFetch(async () => {
+      throw new Error("should not fetch");
+    });
+    await expectRejectCode(
+      () => getCheckRun({ token: "", owner: "a", repo: "b", checkRunId: 1 }),
+      "unauthorized",
+    );
+  });
+
+  test("non-positive check run id → invalid_input", async () => {
+    setFetch(async () => {
+      throw new Error("should not fetch");
+    });
+    await expectRejectCode(
+      () => getCheckRun({ token: "t", owner: "a", repo: "b", checkRunId: 0 }),
+      "invalid_input",
+    );
+  });
+});

--- a/github/server/lib/check-run.ts
+++ b/github/server/lib/check-run.ts
@@ -56,6 +56,24 @@ function githubHeaders(token: string): Record<string, string> {
 }
 
 /**
+ * GitHub owner/repo path segments: alphanumerics plus `.`, `_`, `-`. Rejecting
+ * anything else (and the bare `.`/`..`) closes path/endpoint injection — an
+ * unvalidated `/` or `..` would let the caller re-target a different
+ * api.github.com endpoint once the URL parser normalizes the path. Segments are
+ * also `encodeURIComponent`-d at the call site as defense in depth.
+ */
+const SEGMENT_RE = /^[A-Za-z0-9._-]+$/;
+
+function assertValidSegment(kind: "owner" | "repo", value: string): void {
+  if (!SEGMENT_RE.test(value) || value === "." || value === "..") {
+    throw new CheckRunError(
+      "invalid_input",
+      `"${kind}" contains invalid characters.`,
+    );
+  }
+}
+
+/**
  * Fetch a single check run by numeric id, including its `output`. Throws a
  * {@link CheckRunError} on missing auth, bad input, or a non-OK GitHub response.
  */
@@ -79,6 +97,8 @@ export async function getCheckRun(params: {
       `"owner" and "repo" are required.`,
     );
   }
+  assertValidSegment("owner", owner);
+  assertValidSegment("repo", repo);
   if (!Number.isInteger(checkRunId) || checkRunId <= 0) {
     throw new CheckRunError(
       "invalid_input",
@@ -89,7 +109,9 @@ export async function getCheckRun(params: {
   let res: Response;
   try {
     res = await fetch(
-      `${GITHUB_API}/repos/${owner}/${repo}/check-runs/${checkRunId}`,
+      `${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(
+        repo,
+      )}/check-runs/${checkRunId}`,
       { headers: githubHeaders(token) },
     );
   } catch {
@@ -119,7 +141,7 @@ export async function getCheckRun(params: {
     );
   }
 
-  const data = (await res.json()) as {
+  let data: {
     id?: number;
     name?: string;
     status?: string;
@@ -132,11 +154,21 @@ export async function getCheckRun(params: {
       text?: string | null;
     };
   };
+  try {
+    data = await res.json();
+  } catch {
+    throw new CheckRunError(
+      "upstream_error",
+      "GitHub returned an unreadable response.",
+    );
+  }
 
   return {
     id: data.id ?? checkRunId,
     name: data.name ?? "",
-    status: data.status ?? "completed",
+    // Don't assert a terminal state on a malformed payload — "unknown" keeps a
+    // missing status from rendering as a finished check.
+    status: data.status ?? "unknown",
     conclusion: data.conclusion ?? null,
     htmlUrl: data.html_url ?? null,
     detailsUrl: data.details_url ?? null,

--- a/github/server/lib/check-run.ts
+++ b/github/server/lib/check-run.ts
@@ -1,0 +1,149 @@
+/**
+ * Check run detail fetch.
+ *
+ * The upstream github-mcp `pull_request_read(get_check_runs)` returns a minimal
+ * shape that omits `output` (title/summary/text) to save context. The PR panel
+ * needs that output to show a check's step-by-step results inline, so this
+ * fetches a single check run in full from the GitHub REST API.
+ *
+ * Reads use the caller's own token (a repo-scoped installation token with
+ * checks:read, or a user-to-server token) — no GitHub App private key needed.
+ */
+
+const GITHUB_API = "https://api.github.com";
+
+export interface CheckRunOutput {
+  title: string | null;
+  summary: string | null;
+  text: string | null;
+}
+
+export interface CheckRunDetail {
+  id: number;
+  name: string;
+  status: string;
+  conclusion: string | null;
+  htmlUrl: string | null;
+  detailsUrl: string | null;
+  output: CheckRunOutput;
+}
+
+export type CheckRunErrorCode =
+  | "invalid_input"
+  | "unauthorized"
+  | "not_found"
+  | "upstream_error";
+
+/** Error surfaced by GET_CHECK_RUN. `code` is stable; `message` is safe to show
+ * (it never contains the caller token). */
+export class CheckRunError extends Error {
+  constructor(
+    public readonly code: CheckRunErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "CheckRunError";
+  }
+}
+
+function githubHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "deco-cms-github-mcp",
+  };
+}
+
+/**
+ * Fetch a single check run by numeric id, including its `output`. Throws a
+ * {@link CheckRunError} on missing auth, bad input, or a non-OK GitHub response.
+ */
+export async function getCheckRun(params: {
+  token: string;
+  owner: string;
+  repo: string;
+  checkRunId: number;
+}): Promise<CheckRunDetail> {
+  const { token, owner, repo, checkRunId } = params;
+
+  if (!token) {
+    throw new CheckRunError(
+      "unauthorized",
+      "Missing caller GitHub authorization.",
+    );
+  }
+  if (!owner || !repo) {
+    throw new CheckRunError(
+      "invalid_input",
+      `"owner" and "repo" are required.`,
+    );
+  }
+  if (!Number.isInteger(checkRunId) || checkRunId <= 0) {
+    throw new CheckRunError(
+      "invalid_input",
+      `"checkRunId" must be a positive integer.`,
+    );
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(
+      `${GITHUB_API}/repos/${owner}/${repo}/check-runs/${checkRunId}`,
+      { headers: githubHeaders(token) },
+    );
+  } catch {
+    throw new CheckRunError(
+      "upstream_error",
+      "GitHub is temporarily unavailable. Please retry.",
+    );
+  }
+
+  if (!res.ok) {
+    if (res.status === 401 || res.status === 403) {
+      throw new CheckRunError(
+        "unauthorized",
+        `Not authorized to read check run ${checkRunId} (${res.status}). ` +
+          "The token may lack checks:read.",
+      );
+    }
+    if (res.status === 404) {
+      throw new CheckRunError(
+        "not_found",
+        `Check run ${checkRunId} was not found in ${owner}/${repo}.`,
+      );
+    }
+    throw new CheckRunError(
+      "upstream_error",
+      `GitHub returned ${res.status} while reading check run ${checkRunId}.`,
+    );
+  }
+
+  const data = (await res.json()) as {
+    id?: number;
+    name?: string;
+    status?: string;
+    conclusion?: string | null;
+    html_url?: string | null;
+    details_url?: string | null;
+    output?: {
+      title?: string | null;
+      summary?: string | null;
+      text?: string | null;
+    };
+  };
+
+  return {
+    id: data.id ?? checkRunId,
+    name: data.name ?? "",
+    status: data.status ?? "completed",
+    conclusion: data.conclusion ?? null,
+    htmlUrl: data.html_url ?? null,
+    detailsUrl: data.details_url ?? null,
+    output: {
+      title: data.output?.title ?? null,
+      summary: data.output?.summary ?? null,
+      text: data.output?.text ?? null,
+    },
+  };
+}

--- a/github/server/tools/get-check-run.ts
+++ b/github/server/tools/get-check-run.ts
@@ -1,0 +1,64 @@
+/**
+ * GET_CHECK_RUN — fetch a single check run in full, including its `output`
+ * (title / summary / text markdown).
+ *
+ * The proxied upstream `pull_request_read(get_check_runs)` returns a minimal
+ * shape without `output`, so the PR panel can list checks but can't show a
+ * check's step-by-step results. This first-party tool fills that gap by reading
+ * the check run directly from the REST API with the caller's own token.
+ *
+ * `createPrivateTool` ensures the caller is authenticated; the read is scoped by
+ * the caller's token (needs checks:read).
+ */
+
+import { createPrivateTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import { getCheckRun } from "../lib/check-run.ts";
+import type { Env } from "../types/env.ts";
+
+export function createGetCheckRunTool() {
+  return createPrivateTool({
+    id: "GET_CHECK_RUN",
+    description:
+      "Fetch a single check run in full — including its output (title, summary, " +
+      "and text markdown) — by numeric id. Complements pull_request_read " +
+      "get_check_runs, whose minimal shape omits output, so a check's " +
+      "step-by-step results can be shown inline. Requires checks:read on the " +
+      "caller's token.",
+    inputSchema: z.object({
+      owner: z
+        .string()
+        .describe('Repository owner/login, e.g. "acme" (NOT "owner/repo").'),
+      repo: z
+        .string()
+        .describe('The repository NAME only, e.g. "web" (NOT "acme/web").'),
+      checkRunId: z
+        .number()
+        .int()
+        .describe("Numeric check run id, as returned by get_check_runs."),
+    }),
+    outputSchema: z.object({
+      id: z.number(),
+      name: z.string(),
+      status: z.string(),
+      conclusion: z.string().nullable(),
+      htmlUrl: z.string().nullable(),
+      detailsUrl: z.string().nullable(),
+      output: z.object({
+        title: z.string().nullable(),
+        summary: z.string().nullable(),
+        text: z.string().nullable(),
+      }),
+    }),
+    execute: async ({ context, runtimeContext }) => {
+      const env = runtimeContext.env as unknown as Env;
+      const token = env.MESH_REQUEST_CONTEXT?.authorization ?? "";
+      return await getCheckRun({
+        token,
+        owner: context.owner,
+        repo: context.repo,
+        checkRunId: context.checkRunId,
+      });
+    },
+  });
+}

--- a/github/server/tools/index.ts
+++ b/github/server/tools/index.ts
@@ -8,6 +8,7 @@
 
 import { buildUpstreamTools, getUpstreamToolDefs } from "../lib/mcp-proxy.ts";
 import { triggers } from "../lib/trigger-store.ts";
+import { createGetCheckRunTool } from "./get-check-run.ts";
 import { createMintRepoTokenTool } from "./mint-repo-token.ts";
 
 /**
@@ -15,8 +16,11 @@ import { createMintRepoTokenTool } from "./mint-repo-token.ts";
  * upstream discovery succeeds (caching happens inside getUpstreamToolDefs).
  *
  * Beyond the proxied upstream tools and trigger tools, we add first-party
- * tools that need the GitHub App private key — which only this MCP holds:
+ * tools that either need the GitHub App private key (which only this MCP holds)
+ * or fill a gap in the minimal upstream shapes:
  *   - MINT_REPO_TOKEN: mint a repo-scoped, least-privilege installation token.
+ *   - GET_CHECK_RUN: read a check run's full output (the upstream
+ *     get_check_runs omits it).
  */
 export async function getTools() {
   const toolDefs = await getUpstreamToolDefs();
@@ -24,5 +28,6 @@ export async function getTools() {
     ...buildUpstreamTools(toolDefs),
     ...triggers.tools(),
     createMintRepoTokenTool(),
+    createGetCheckRunTool(),
   ];
 }

--- a/magento/server/tools/registry.ts
+++ b/magento/server/tools/registry.ts
@@ -8,8 +8,15 @@
  */
 import { createTool } from "@decocms/runtime/tools";
 import { z } from "zod";
-import { assertValidCredentials, magentoFetch, resolveCredentials } from "../lib/client.ts";
-import { buildSearchCriteriaParams, filtersSchema } from "../lib/search-criteria.ts";
+import {
+  assertValidCredentials,
+  magentoFetch,
+  resolveCredentials,
+} from "../lib/client.ts";
+import {
+  buildSearchCriteriaParams,
+  filtersSchema,
+} from "../lib/search-criteria.ts";
 import type { Env } from "../types/env.ts";
 
 /** Normalize API payloads so tool results are always objects. */
@@ -55,7 +62,11 @@ const searchInputSchema = z.object({
     ),
 });
 
-function createSearchTool(config: { id: string; description: string; path: string }) {
+function createSearchTool(config: {
+  id: string;
+  description: string;
+  path: string;
+}) {
   return (_env: Env) =>
     createTool({
       id: config.id,
@@ -135,7 +146,10 @@ export const getOrder = createGetTool({
   description:
     "Get a single order by its numeric entity_id (/V1/orders/{id}), including items, payment, addresses and status history. For the customer-facing order number use MAGENTO_GET_ORDER_BY_INCREMENT_ID.",
   inputSchema: z.object({
-    entityId: z.number().int().describe("Order entity_id (internal numeric id)"),
+    entityId: z
+      .number()
+      .int()
+      .describe("Order entity_id (internal numeric id)"),
   }),
   buildPath: (input) => `/orders/${input.entityId}`,
 });


### PR DESCRIPTION
## Summary

The PR panel's **Checks** tab lists check runs via the proxied upstream `pull_request_read(get_check_runs)`, whose `MinimalCheckRun` shape deliberately **omits `output`** (title/summary/text) to save context. So the tab can list a check like `Deco / QA / Purchase journey` but can't show its step-by-step results (the per-step table — visit-home, add-to-cart, …) without linking out to GitHub.

Since the deco github MCP is a **proxy** to the upstream server, we can't change `get_check_runs`'s shape. This adds a first-party tool instead.

## Change

New `GET_CHECK_RUN` tool:
- Input: `{ owner, repo, checkRunId }` (id comes from `get_check_runs`).
- Reads `GET /repos/{owner}/{repo}/check-runs/{id}` with the **caller's own token** (repo-scoped installation token with `checks:read`, or a user token) — no GitHub App private key needed.
- Output: `{ id, name, status, conclusion, htmlUrl, detailsUrl, output: { title, summary, text } }`.
- Errors map cleanly: 401/403 → `unauthorized` (token may lack `checks:read`), 404 → `not_found`, 5xx → `upstream_error`; leak-free messages.

Lets the Checks tab lazy-load and render a check's `output` (markdown) inline on expand (Studio side: decocms/studio#5093).

## Testing

- `bun test server/lib/check-run.test.ts` — 7 pass (mapping incl. output, missing-output defaults, 403/404/5xx, missing-token, bad id).
- `tsc --noEmit` clean.

Independent of #521 (already merged) — this is a plain read tool, no mint/permission coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `GET_CHECK_RUN` tool to fetch a check run’s full output so the PR panel Checks tab can render step-by-step results inline. Adds stricter input validation and safer parsing.

- **New Features**
  - `GET_CHECK_RUN`: input `{ owner, repo, checkRunId }`; returns `{ id, name, status, conclusion, htmlUrl, detailsUrl, output: { title, summary, text } }`. Missing `output` fields default to `null`; missing `status` defaults to `"unknown"`.
  - Reads `GET /repos/{owner}/{repo}/check-runs/{id}` with the caller’s token (needs `checks:read`); no App key required.
  - Error mapping: 401/403 → `unauthorized`, 404 → `not_found`, 5xx or unreadable 2xx body → `upstream_error`. Registered in tools index and covered by tests.

- **Bug Fixes**
  - Validate and encode `owner`/`repo` segments (`[A-Za-z0-9._-]`; reject `.`/`..`) to prevent path/endpoint injection.
  - Guard JSON parsing so non-JSON 2xx responses map to a typed `upstream_error`.
  - Format `magento/server/tools/registry.ts` to satisfy repo-wide `fmt --check` (no behavior changes).

<sup>Written for commit 4d53bc47f9383e4a406eb64547b2fda5435b6160. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

