### PR TITLE
fix(vtex): surface curated param descriptions to the agent

### DIFF
--- a/vtex/server/lib/param-descriptions.ts
+++ b/vtex/server/lib/param-descriptions.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+/**
+ * Curated parameter descriptions, applied on top of each tool's input schema.
+ *
+ * Why this exists: the generated Zod schemas are produced with
+ * `metadata: false` (see `openapi-ts.config.ts`), so NO field description
+ * reaches the tool `inputSchema` — i.e. the JSON Schema the agent/LLM sees.
+ * The agent therefore gets bare `f_RnB: string` with no hint of what it means
+ * or what value format it expects.
+ *
+ * Rather than re-enabling metadata globally (which inflates the server bundle
+ * by ~1.6 MB and would pull in unrelated upstream schema drift on regen), we
+ * curate descriptions for the params where the omission actually hurts:
+ * VTEX jargon (`RnB`), non-obvious value formats (date ranges), or closed
+ * value sets (status). These are richer than VTEX's raw OpenAPI text on
+ * purpose — e.g. `f_RnB` explains the coupon → promotion-id lookup that the
+ * raw "rates and benefits" wording omits.
+ *
+ * Keyed by tool id → field name. Adding coverage = one line here.
+ */
+export const PARAM_DESCRIPTIONS: Record<string, Record<string, string>> = {
+  VTEX_LIST_ORDERS: {
+    f_RnB:
+      "Filter orders by promotion (VTEX 'rates and benefits' / RnB). The value " +
+      "is the promotion's identifier — NOT the coupon code. To count sales for " +
+      "a coupon (e.g. 'FICA10') or a promotion name (e.g. 'Pop retenção DECO'), " +
+      "first resolve its promotion id using the promotions tools, then pass that " +
+      "id here.",
+    f_creationDate:
+      "Filter by order creation date. Format: " +
+      "`creationDate:[<from> TO <to>]` using UTC timestamps, e.g. " +
+      "`creationDate:[2026-07-25T00:00:00.000Z TO 2026-07-27T23:59:59.999Z]`.",
+    f_invoicedDate:
+      "Filter by invoiced date. Format: `invoicedDate:[<from> TO <to>]` using " +
+      "UTC timestamps, e.g. " +
+      "`invoicedDate:[2026-07-25T00:00:00.000Z TO 2026-07-27T23:59:59.999Z]`.",
+    f_status:
+      "Filter by order status. Valid values: " +
+      "waiting-for-sellers-confirmation, payment-pending, payment-approved, " +
+      "ready-for-handling, handling, invoiced, canceled.",
+    q:
+      "Full-text search over order id, client email, client document and " +
+      "client name. The `+` character is not allowed.",
+  },
+};
+
+/**
+ * Return a copy of `schema` with curated `.describe()` metadata applied to any
+ * field listed for `toolId`. Fields with no override, and tools with no entry,
+ * are returned unchanged. Missing fields in the map are ignored (safe if the
+ * generated schema changes shape).
+ */
+export function applyParamDescriptions(
+  toolId: string,
+  schema: z.ZodObject<any>,
+): z.ZodObject<any> {
+  const overrides = PARAM_DESCRIPTIONS[toolId];
+  if (!overrides) return schema;
+
+  const shape = schema.shape as Record<string, z.ZodTypeAny>;
+  const next: Record<string, z.ZodTypeAny> = { ...shape };
+  for (const [field, description] of Object.entries(overrides)) {
+    if (next[field]) next[field] = next[field].describe(description);
+  }
+  return z.object(next);
+}

--- a/vtex/server/lib/tool-adapter.ts
+++ b/vtex/server/lib/tool-adapter.ts
@@ -10,6 +10,7 @@ import {
   createVtexClient,
   resolveCredentials,
 } from "./client-factory.ts";
+import { applyParamDescriptions } from "./param-descriptions.ts";
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Schema introspection helpers
@@ -295,7 +296,13 @@ export interface ToolFromOperationConfig {
  * `createTool` definition that the MCP runtime can register.
  */
 export function createToolFromOperation(config: ToolFromOperationConfig) {
-  const flatInput = flattenRequestSchema(config.requestSchema);
+  // Generated schemas carry no field descriptions (metadata: false), so layer
+  // curated ones onto the flattened input before it becomes the agent-facing
+  // inputSchema.
+  const flatInput = applyParamDescriptions(
+    config.id,
+    flattenRequestSchema(config.requestSchema),
+  );
 
   // The factory's `env` is captured ONCE when the runtime resolves tool
   // registrations on the first request, then cached for the process lifetime

--- a/vtex/server/tools/registry.test.ts
+++ b/vtex/server/tools/registry.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect, mock } from "bun:test";
-import { createToolFromOperation } from "../lib/tool-adapter.ts";
+import { z } from "zod";
+import {
+  createToolFromOperation,
+  flattenRequestSchema,
+} from "../lib/tool-adapter.ts";
+import { applyParamDescriptions } from "../lib/param-descriptions.ts";
 
 // ── Zod schemas ────────────────────────────────────────────────────────────────
 import * as catalogZod from "../generated/catalog/zod.gen.ts";
@@ -1137,6 +1142,40 @@ describe("VTEX_LIST_ORDERS", () => {
     await expect(
       tool.execute({ runtimeContext: mockRuntimeContext, context: {} }),
     ).rejects.toThrow();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Curated param descriptions
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("param descriptions", () => {
+  test("VTEX_LIST_ORDERS: curated descriptions reach the agent-facing JSON Schema", () => {
+    const flat = applyParamDescriptions(
+      "VTEX_LIST_ORDERS",
+      flattenRequestSchema(ordersZod.zListOrdersData as any),
+    );
+    const json: any = z.toJSONSchema(flat, {
+      io: "input",
+      unrepresentable: "any",
+    });
+
+    // f_RnB must explain the coupon → promotion-id lookup (the reported gap).
+    expect(json.properties?.f_RnB?.description).toMatch(/promotion id/i);
+    expect(json.properties?.f_RnB?.description).toMatch(/coupon/i);
+    // Value-format hints for date filters.
+    expect(json.properties?.f_creationDate?.description).toMatch(
+      /creationDate:\[/,
+    );
+    // Overriding a field must not make it required.
+    expect((json.required ?? []).includes("f_RnB")).toBe(false);
+  });
+
+  test("tools without curated overrides are returned unchanged", () => {
+    const schema = flattenRequestSchema(
+      catalogZod.zGetApiCatalogPvtBrandByBrandIdData as any,
+    );
+    expect(applyParamDescriptions("VTEX_GET_BRAND", schema)).toBe(schema);
   });
 });
 


### PR DESCRIPTION
## Problem

An agent using the VTEX MCP couldn't figure out it needed `f_RnB` to count sales for a coupon/promotion (e.g. `FICA10` / "Pop retenção DECO"). Root cause: the agent gets **no description at all** for that parameter.

The generated Zod schemas are produced with `metadata: false` in `openapi-ts.config.ts` (comment: *"descriptions are not read at runtime"*). That's inaccurate for an MCP — the input schema **is** read at runtime: it becomes the JSON Schema sent to the LLM. With metadata off, **every** `f_` filter on **every** VTEX tool reaches the agent as a bare `f_RnB: string`, with no meaning and no value format. The rich JSDoc in `types.gen.ts` never leaves compile time.

## Why not just flip `metadata: true`?

Measured it:

| | bundle | notes |
|---|---|---|
| baseline (`metadata: false`) | 4.70 MB | |
| `metadata: true` (regen) | 6.05 MB | **+1.57 MB / +35%** |

Regenerating also can't be isolated: `download-schemas` pulls current upstream, which drifts (~10k lines across 72 files), renames an operation (`postApiAuthenticator` → `postApiAuthenticatorV1`StorefrontUsers) that breaks a `registry.ts` reference, and adds new modules. That's a separate "sync schemas" concern, not this fix.

## This PR

Layer **curated** descriptions onto the flattened input schema in the tool adapter (`applyParamDescriptions`), keyed by tool id → field. Covers the `VTEX_LIST_ORDERS` params where the omission actually hurts, written richer than the raw OpenAPI text:

- **`f_RnB`** — explains it takes the *promotion id, not the coupon code*, and that you resolve `FICA10` / a promotion name via the promotions tools first.
- **`f_creationDate` / `f_invoicedDate`** — the `creationDate:[<from> TO <to>]` UTC range format.
- **`f_status`** — the closed set of valid statuses.
- **`q`** — what full-text search matches.

Adding coverage later = one line in `param-descriptions.ts`.

## Impact

- Bundle unchanged: **4.70 MB** (+1.5 KB for the new module).
- `f_RnB` and the other curated params now carry descriptions in the agent-facing JSON Schema (verified end-to-end via `z.toJSONSchema`).
- No upstream schema drift, no generated-code changes.

## Tests

`bun test server/tools/registry.test.ts` → 53 pass. New regression tests assert the curated descriptions reach the JSON Schema, that overriding a field keeps it optional, and that tools without overrides are returned unchanged.

## Follow-up (out of scope)

Whether to do a full `metadata: true` regen for blanket coverage is a separate decision — it needs the +1.57 MB bundle accepted and the upstream drift / renamed export handled deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes curated parameter descriptions to the agent so VTEX filters like `f_RnB`, date ranges, status, and `q` are clear and usable. Fixes the missing metadata that blocked counting sales by coupon/promotion, without increasing the bundle size.

- **Bug Fixes**
  - Layer curated descriptions onto tool input schemas via `applyParamDescriptions`.
  - Covers `VTEX_LIST_ORDERS`: `f_RnB` (promotion id, not coupon), `f_creationDate`/`f_invoicedDate` range format, valid `f_status` values, and what `q` searches.
  - Tests verify descriptions in the agent-facing JSON Schema and that fields remain optional.
  - No schema regen; bundle stays ~4.70 MB (+~1.5 KB).

<sup>Written for commit b55084a5a01aa5319966a58268414bf10c952521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

