### PR TITLE
docs(shopify): document Protected Customer Data requirement

### DIFF
--- a/shopify/README.md
+++ b/shopify/README.md
@@ -40,6 +40,33 @@ The OAuth flow needs a **public Shopify Partner app**; its `SHOPIFY_CLIENT_ID`,
 `SHOPIFY_CLIENT_SECRET` and `SHOPIFY_TOKEN_SECRET` are provided as deploy secrets — see
 [`.github/workflows/SECRETS.md`](../.github/workflows/SECRETS.md).
 
+### Protected customer data (required for the customer tools)
+
+The `read_customers` scope alone is **not** enough to read the `Customer` object. Shopify
+gates all customer data behind a separate, app-level approval called
+[**Protected Customer Data**](https://shopify.dev/docs/apps/launch/protected-customer-data),
+independent of OAuth scopes. Without it, any customer tool
+(`SHOPIFY_LIST_CUSTOMERS`, customer lookups, segments, order→customer joins, …) fails with:
+
+> `This app is not approved to access the Customer object. See
+> https://shopify.dev/docs/apps/launch/protected-customer-data …`
+
+To enable it, in the **Partner Dashboard**:
+
+1. Apps → *your app* → **API access**.
+2. Find **Protected customer data access** → **Request access**.
+3. Grant the levels you need:
+   - **Protected customer data** (level 1) — required for _any_ `Customer` access.
+   - **Protected customer fields** (level 2) — PII: name, email, phone, address.
+4. Complete the data-protection questionnaire (how you use, store, encrypt and retain the
+   data). Public/distributed apps are reviewed by Shopify; custom/dev apps are usually
+   granted immediately.
+5. Save, then **reconnect the MCP** (re-run OAuth) if the error persists — the protected-data
+   consent sometimes only takes effect on the next grant.
+
+If you don't need customer data, drop `read_customers` from `SHOPIFY_SCOPES` and the rest of
+the toolset works unaffected.
+
 ### Local development
 
 For local dev you can skip OAuth and pass a raw Admin API token via env vars:


### PR DESCRIPTION
Follow-up to #526.

Using the customer tools (`SHOPIFY_LIST_CUSTOMERS`, lookups, segments, order→customer joins) fails with:

> `This app is not approved to access the Customer object. See https://shopify.dev/docs/apps/launch/protected-customer-data …`

even with the `read_customers` scope granted. That's Shopify's **Protected Customer Data** gate — a separate, app-level approval independent of OAuth scopes. It's a Partner-dashboard configuration, not a code issue (the MCP already surfaces the error with a clear hint).

Adds a README section covering:
- what the gate is and the exact error,
- the Partner Dashboard steps to grant it (level 1 protected data + level 2 PII fields, questionnaire, reconnect),
- the option to drop `read_customers` from `SHOPIFY_SCOPES` if customer data isn't needed.

Docs-only — no code or `registry.json` change (the registry `readme` comes from `mesh_description`, not `README.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add README guidance for Shopify’s Protected Customer Data so customer tools work and the “not approved to access the Customer object” error is avoided. Also notes how to remove `read_customers` if customer data isn’t needed.

- **Migration**
  - Partner Dashboard → Apps → your app → API access → request “Protected customer data” (level 1) and, if needed, “Protected customer fields” (level 2).
  - Complete the questionnaire, then re-run OAuth to reconnect.
  - If not using customer data, remove `read_customers` from `SHOPIFY_SCOPES`.

<sup>Written for commit 63be6e8d9cde97d4f6032bc5484262d8f23a325c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

