### PR TITLE
fix(shopify): accept the OAuth callback on the MCP's own origin

### DIFF
--- a/shopify/server/lib/oauth.test.ts
+++ b/shopify/server/lib/oauth.test.ts
@@ -74,6 +74,16 @@ describe("GET /oauth/custom", () => {
     expect(await res!.text()).toContain("Connect your Shopify store");
   });
 
+  test("accepts a callback on the MCP's own origin (runtime mounts it there)", async () => {
+    const selfCallback = `${SELF}/oauth/callback?state=abc`;
+    const res = await handleOAuthRoute(
+      new Request(
+        `${SELF}${OAUTH_CONNECT_PATH}?callback_url=${encodeURIComponent(selfCallback)}`,
+      ),
+    );
+    expect(res?.status).toBe(200);
+  });
+
   test("rejects an off-origin callback URL", async () => {
     const res = await handleOAuthRoute(
       new Request(

--- a/shopify/server/lib/oauth.ts
+++ b/shopify/server/lib/oauth.ts
@@ -110,19 +110,27 @@ const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
 
 /**
  * Guard against open-redirect / code theft: only ever hand the OAuth code back
- * to the mesh's origin. The mesh callback lives under decocms.com; loopback is
- * allowed over http for local dev (RFC 8252 §7.3), everything else must be
- * https. Same model as the GitHub MCP's redirect allowlist.
+ * to a trusted origin. The runtime mounts its OAuth callback on this MCP's own
+ * origin, so that's the primary allowed origin; we also accept decocms.com
+ * (the mesh) and loopback over http for local dev (RFC 8252 §7.3). Same spirit
+ * as the GitHub MCP's redirect allowlist.
  *
  * MESH_URL is an optional operator-controlled override: set it to allow a
  * self-hosted mesh origin (e.g. a local deco studio on a custom host).
  */
-function isAllowedCallback(callbackUrl: string): boolean {
+function isAllowedCallback(callbackUrl: string, selfUrl: string): boolean {
   let url: URL;
   try {
     url = new URL(callbackUrl);
   } catch {
     return false;
+  }
+
+  // Primary case: the runtime's OAuth callback lives on our own origin.
+  try {
+    if (url.origin === new URL(selfUrl).origin) return true;
+  } catch {
+    // ignore a malformed selfUrl and fall through
   }
 
   // Explicit override for a self-hosted / local mesh (trusted, operator-set).
@@ -217,7 +225,7 @@ function connectForm(callbackUrl: string): Response {
  * into Shopify's authorize endpoint. */
 function handleConnect(url: URL, env: OAuthEnv): Response {
   const callbackUrl = url.searchParams.get("callback_url");
-  if (!callbackUrl || !isAllowedCallback(callbackUrl)) {
+  if (!callbackUrl || !isAllowedCallback(callbackUrl, env.selfUrl)) {
     return htmlResponse("Invalid or missing callback URL.", 400);
   }
 
@@ -254,7 +262,7 @@ async function handleCallback(url: URL, env: OAuthEnv): Promise<Response> {
     params.get("state") ?? "",
     env.tokenSecret,
   );
-  if (!state?.cb || !isAllowedCallback(state.cb)) {
+  if (!state?.cb || !isAllowedCallback(state.cb, env.selfUrl)) {
     return htmlResponse("Invalid OAuth state.", 400);
   }
 


### PR DESCRIPTION
Follow-up to #528. The `SELF_URL`/`MESH_URL` fix merged, but a third fix was left out and the flow still errors with **"Invalid or missing callback URL"** in prod.

## Cause
The runtime mounts its `/oauth/callback` on **this MCP's own origin**, so the `callback_url` handed to `authorizationUrl` is:

```
https://sites-shopify.deco.site/oauth/callback?state=…
```

i.e. on `sites-shopify.deco.site`, **not** `decocms.com`. The callback allowlist from #528 only accepted `decocms.com` (+ loopback + `MESH_URL`), so it rejected the real callback.

## Fix
Accept the **`SELF_URL` origin** as the primary allowed callback origin (that's where the runtime mounts `/oauth/callback`), keeping `decocms.com`, loopback and the optional `MESH_URL` override.

## Tests
`bun test` — oauth suite **17 pass**, incl. a new case: a callback on the MCP's own origin is accepted. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept OAuth callbacks on this MCP’s own origin (`SELF_URL`) so the Shopify OAuth flow no longer fails with “Invalid or missing callback URL.” The allowlist still includes `decocms.com`, loopback, and optional `MESH_URL`.

- **Bug Fixes**
  - Updated `isAllowedCallback` to trust the `SELF_URL` origin and wired `env.selfUrl` through connect/callback handlers.
  - Added a test to accept self-origin callbacks; OAuth test suite passes.

<sup>Written for commit 7b61ef40ad9f2c0458f4280054841080eedddf4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

