### PR TITLE
fix(shopify): switch OAuth to expiring offline tokens

### DIFF
--- a/shopify/README.md
+++ b/shopify/README.md
@@ -16,8 +16,9 @@ Connecting is a one-click **OAuth** flow — no manual token copying:
 1. In the connection UI, start the OAuth flow. You'll land on a page asking for your
    store's `my-store.myshopify.com` domain.
 2. Shopify shows the standard authorization screen listing the requested **read scopes**.
-   Approve it and you're connected — the MCP stores a read-only **offline access token**
-   (it never expires, so there's no refresh).
+   Approve it and you're connected — the MCP stores a read-only **expiring offline access
+   token** (~1h) plus a rotating **refresh token** (~90d). The connection refreshes itself
+   automatically; you only re-run OAuth if the refresh token lapses or you revoke the app.
 
 There's no connection config to fill in. The Admin API version defaults to `2026-07`;
 override it per deployment with the `SHOPIFY_API_VERSION` env var.
@@ -93,17 +94,24 @@ bumping the API version.
 
 ## Auth notes
 
-OAuth (authorization code grant, offline token). Shopify's authorize endpoint is
-per-store, but the runtime's `authorizationUrl(callbackUrl)` hook doesn't know which store
+OAuth (authorization code grant, **expiring** offline token). Shopify's authorize endpoint
+is per-store, but the runtime's `authorizationUrl(callbackUrl)` hook doesn't know which store
 the user wants. So (like the WhatsApp MCP) the hook points at our own `/oauth/custom` page,
 which asks for the shop domain and then drives the real Shopify grant. See the flow diagram
 in [`server/lib/oauth.ts`](./server/lib/oauth.ts).
 
-The Shopify access token is sealed (AES-256-GCM, keyed by `SHOPIFY_TOKEN_SECRET`) together
-with the shop domain into the connection's access token, so both travel back through the
-browser redirect without exposing the raw token, and every tool call carries the store it
-belongs to — no separate Store Domain config field. Legacy connections that used a raw
-Admin API token plus a `storeDomain` state field still work.
+Shopify no longer issues non-expiring offline tokens — the Admin API rejects them with a
+`403` (`Non-expiring access tokens are no longer accepted`). The code exchange therefore
+sends `expiring=1`, which yields a ~1h access token plus a ~90d rotating refresh token. Both
+are sealed (AES-256-GCM, keyed by `SHOPIFY_TOKEN_SECRET`) together with the shop domain, so
+they travel back through the browser redirect without exposing the raw tokens and every tool
+call carries the store it belongs to — no separate Store Domain config field. When the access
+token expires, the client re-hits the runtime `/token` endpoint with
+`grant_type=refresh_token`; the MCP's `refreshToken` hook rotates it against Shopify and
+returns a freshly sealed pair. A Shopify `4xx` on refresh (rotated-out or lapsed token, app
+uninstalled) surfaces as `invalid_grant` so the client knows to reconnect; a `5xx`/network
+error is treated as transient. Legacy connections that used a raw Admin API token plus a
+`storeDomain` state field still work.
 
 A raw admin token in the `Authorization` header (no OAuth) is still accepted as a fallback,
 which is what the local-dev env vars use.

--- a/shopify/server/lib/oauth.test.ts
+++ b/shopify/server/lib/oauth.test.ts
@@ -181,34 +181,63 @@ describe("GET /oauth/shopify/callback", () => {
     return `${SELF}${OAUTH_CALLBACK_PATH}?${params.toString()}`;
   }
 
-  test("exchanges the code and bounces a sealed credential to the mesh", async () => {
-    let exchangeBody: unknown;
+  test("exchanges the code for an expiring token and seals the grant", async () => {
+    let exchangeBody: Record<string, string> | undefined;
     globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
       expect(String(input)).toBe(
         "https://my-store.myshopify.com/admin/oauth/access_token",
       );
-      exchangeBody = JSON.parse(String(init?.body));
-      return Response.json({ access_token: "shpat_offline" });
+      expect(init?.headers).toMatchObject({
+        "Content-Type": "application/x-www-form-urlencoded",
+      });
+      exchangeBody = Object.fromEntries(
+        new URLSearchParams(String(init?.body)),
+      );
+      return Response.json({
+        access_token: "shpat_access",
+        refresh_token: "shprt_refresh",
+        expires_in: 3600,
+        refresh_token_expires_in: 7776000,
+      });
     }) as typeof fetch;
 
     const res = await handleOAuthRoute(new Request(callbackUrl()));
     expect(res?.status).toBe(302);
+    // `expiring=1` is what makes Shopify issue a rotating offline token.
     expect(exchangeBody).toEqual({
       client_id: CLIENT_ID,
       client_secret: CLIENT_SECRET,
       code: "shopify-auth-code",
+      expiring: "1",
     });
 
     const dest = new URL(res!.headers.get("Location")!);
     expect(dest.origin).toBe(MESH);
     expect(dest.searchParams.get("state")).toBe("mesh-state");
-    const sealed = dest.searchParams.get("code")!;
+    // The `code` carries the whole grant (access + refresh + lifetime).
+    const grant = dest.searchParams.get("code")!;
     expect(
-      decryptCredential<{ shop: string; token: string }>(sealed, SECRET),
+      decryptCredential<{
+        shop: string;
+        access: string;
+        refresh: string;
+        expiresIn: number;
+      }>(grant, SECRET),
     ).toEqual({
       shop: "my-store.myshopify.com",
-      token: "shpat_offline",
+      access: "shpat_access",
+      refresh: "shprt_refresh",
+      expiresIn: 3600,
     });
+  });
+
+  test("fails when Shopify omits the refresh token", async () => {
+    globalThis.fetch = (async () =>
+      Response.json({
+        access_token: "shpat_access",
+      })) as unknown as typeof fetch;
+    const res = await handleOAuthRoute(new Request(callbackUrl()));
+    expect(res?.status).toBe(502);
   });
 
   test("rejects a bad Shopify HMAC", async () => {
@@ -227,20 +256,106 @@ describe("GET /oauth/shopify/callback", () => {
 });
 
 describe("exchangeCode", () => {
-  test("validates and echoes the sealed credential as the access token", async () => {
-    // A sealed credential minted by the callback is passed back as `code`.
-    const sealed = encryptCredential(
-      { shop: "s.myshopify.com", token: "shpat_x" },
+  test("splits the sealed grant into access + refresh tokens", async () => {
+    // A sealed grant minted by the callback is passed back as `code`.
+    const grant = encryptCredential(
+      {
+        shop: "s.myshopify.com",
+        access: "shpat_x",
+        refresh: "shprt_y",
+        expiresIn: 3600,
+      },
       SECRET,
     );
-    const result = await shopifyOAuth.exchangeCode({ code: sealed });
-    expect(result).toEqual({ access_token: sealed, token_type: "Bearer" });
+    const result = await shopifyOAuth.exchangeCode({ code: grant });
+    expect(result.token_type).toBe("Bearer");
+    expect(result.expires_in).toBe(3600);
+    expect(
+      decryptCredential<{ shop: string; token: string }>(
+        result.access_token,
+        SECRET,
+      ),
+    ).toEqual({ shop: "s.myshopify.com", token: "shpat_x" });
+    expect(
+      decryptCredential<{ shop: string; refreshToken: string }>(
+        result.refresh_token!,
+        SECRET,
+      ),
+    ).toEqual({ shop: "s.myshopify.com", refreshToken: "shprt_y" });
   });
 
   test("throws on a tampered code", async () => {
     await expect(
       shopifyOAuth.exchangeCode({ code: "not-a-real-credential" }),
     ).rejects.toThrow(/Invalid or tampered/);
+  });
+});
+
+describe("refreshToken", () => {
+  function sealedRefresh(shop = "my-store.myshopify.com", token = "shprt_old") {
+    return encryptCredential({ shop, refreshToken: token }, SECRET);
+  }
+
+  test("rotates the token against the store's endpoint", async () => {
+    let body: Record<string, string> | undefined;
+    globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+      expect(String(input)).toBe(
+        "https://my-store.myshopify.com/admin/oauth/access_token",
+      );
+      body = Object.fromEntries(new URLSearchParams(String(init?.body)));
+      return Response.json({
+        access_token: "shpat_new",
+        refresh_token: "shprt_new",
+        expires_in: 3600,
+      });
+    }) as typeof fetch;
+
+    const result = await shopifyOAuth.refreshToken(sealedRefresh());
+    expect(body).toEqual({
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+      grant_type: "refresh_token",
+      refresh_token: "shprt_old",
+    });
+    expect(result.expires_in).toBe(3600);
+    expect(
+      decryptCredential<{ shop: string; token: string }>(
+        result.access_token,
+        SECRET,
+      ),
+    ).toEqual({ shop: "my-store.myshopify.com", token: "shpat_new" });
+    expect(
+      decryptCredential<{ shop: string; refreshToken: string }>(
+        result.refresh_token!,
+        SECRET,
+      ),
+    ).toEqual({ shop: "my-store.myshopify.com", refreshToken: "shprt_new" });
+  });
+
+  test("maps a tampered refresh token to invalid_grant", async () => {
+    await expect(
+      shopifyOAuth.refreshToken("not-a-real-token"),
+    ).rejects.toMatchObject({ error: "invalid_grant" });
+  });
+
+  test("maps a Shopify 4xx to invalid_grant (client must reconnect)", async () => {
+    globalThis.fetch = (async () =>
+      new Response("invalid_grant", {
+        status: 400,
+      })) as unknown as typeof fetch;
+    await expect(
+      shopifyOAuth.refreshToken(sealedRefresh()),
+    ).rejects.toMatchObject({ error: "invalid_grant" });
+  });
+
+  test("treats a Shopify 5xx as transient (plain error → 500)", async () => {
+    globalThis.fetch = (async () =>
+      new Response("boom", { status: 503 })) as unknown as typeof fetch;
+    const err = await shopifyOAuth
+      .refreshToken(sealedRefresh())
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.error).toBeUndefined();
   });
 });
 

--- a/shopify/server/lib/oauth.ts
+++ b/shopify/server/lib/oauth.ts
@@ -14,19 +14,27 @@
  *      `/admin/oauth/authorize` with `redirect_uri` pointing back at us and the
  *      mesh callback URL signed into `state`.
  *   3. Shopify → `/oauth/shopify/callback?code&shop&state&hmac`. We verify the
- *      HMAC + state, exchange the code for an offline token, seal `{shop, token}`
- *      into an encrypted credential, and 302 back to the mesh callback with it
- *      as `code`.
- *   4. runtime → `exchangeCode({ code })` → we validate and return the sealed
- *      credential as the connection's `access_token`.
+ *      HMAC + state, exchange the code for an *expiring* offline token, seal the
+ *      `{shop, access, refresh, expiresIn}` grant into an encrypted blob, and
+ *      302 back to the mesh callback with it as `code`.
+ *   4. runtime → `exchangeCode({ code })` → we open the grant and hand the
+ *      runtime a sealed access token (`{shop, token}`), a sealed refresh token
+ *      (`{shop, refreshToken}`) and `expires_in`.
+ *   5. When the access token expires, the client re-hits the runtime `/token`
+ *      endpoint with `grant_type=refresh_token`; the runtime calls our
+ *      `refreshToken`, which rotates the token against Shopify's per-store
+ *      endpoint and hands back a freshly sealed access/refresh pair.
  *
- * The token never expires (offline grant), so there's no `refreshToken`.
+ * Shopify no longer issues non-expiring offline tokens (the Admin API rejects
+ * them with a 403), so the grant requests `expiring=1`: a ~1h access token plus
+ * a ~90d rotating refresh token.
  */
+import { OAuthInvalidGrantError } from "@decocms/runtime";
 import { normalizeStoreDomain } from "./client.ts";
 import {
   decryptCredential,
   encryptCredential,
-  type SealedCredential,
+  type SealedRefresh,
   signState,
   verifyShopifyHmac,
   verifyState,
@@ -152,6 +160,45 @@ function isAllowedCallback(callbackUrl: string, selfUrl: string): boolean {
   );
 }
 
+// ── Shopify token endpoint ────────────────────────────────────────────────────
+
+/**
+ * The offline grant sealed into the OAuth `code` handed back to the runtime.
+ * Carries everything `exchangeCode` needs to mint the connection's tokens: the
+ * runtime only forwards `code` (extra query params are dropped), so the access
+ * token, refresh token and lifetime all have to ride inside it.
+ */
+interface SealedGrant {
+  shop: string;
+  access: string;
+  refresh: string;
+  expiresIn?: number;
+}
+
+/** Shopify's expiring-offline-token response (`/admin/oauth/access_token`). */
+interface ShopifyTokenResponse {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  refresh_token_expires_in?: number;
+  scope?: string;
+}
+
+/** POST to a store's `/admin/oauth/access_token` with form-encoded params. */
+function postTokenEndpoint(
+  shop: string,
+  params: Record<string, string>,
+): Promise<Response> {
+  return fetch(`https://${shop}/admin/oauth/access_token`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    },
+    body: new URLSearchParams(params).toString(),
+  });
+}
+
 // ── Runtime oauth hook ────────────────────────────────────────────────────────
 
 export const shopifyOAuth = {
@@ -165,13 +212,81 @@ export const shopifyOAuth = {
   },
   exchangeCode: async ({ code }: { code: string }) => {
     const env = getOAuthEnv();
-    const sealed = decryptCredential<SealedCredential>(code, env.tokenSecret);
-    if (!sealed?.shop || !sealed?.token) {
+    const grant = decryptCredential<SealedGrant>(code, env.tokenSecret);
+    if (!grant?.shop || !grant?.access || !grant?.refresh) {
       throw new Error("Invalid or tampered Shopify authorization code");
     }
-    // `code` is already the sealed credential minted in the callback — it
-    // becomes the connection's long-lived (offline) access token verbatim.
-    return { access_token: code, token_type: "Bearer" };
+    // Split the grant into the two credentials the runtime hands to the client:
+    // the sealed access token (used verbatim as the Admin API token) and the
+    // sealed refresh token (replayed to `refreshToken` when it expires).
+    return {
+      access_token: encryptCredential(
+        { shop: grant.shop, token: grant.access },
+        env.tokenSecret,
+      ),
+      token_type: "Bearer",
+      refresh_token: encryptCredential(
+        { shop: grant.shop, refreshToken: grant.refresh },
+        env.tokenSecret,
+      ),
+      expires_in: grant.expiresIn,
+    };
+  },
+  refreshToken: async (refreshToken: string) => {
+    const env = getOAuthEnv();
+    const sealed = decryptCredential<SealedRefresh>(
+      refreshToken,
+      env.tokenSecret,
+    );
+    if (!sealed?.shop || !sealed?.refreshToken) {
+      // A garbage/tampered refresh token is unrecoverable — force a reconnect.
+      throw new OAuthInvalidGrantError(
+        "invalid_grant",
+        "Invalid or tampered Shopify refresh token",
+      );
+    }
+
+    const response = await postTokenEndpoint(sealed.shop, {
+      client_id: env.clientId,
+      client_secret: env.clientSecret,
+      grant_type: "refresh_token",
+      refresh_token: sealed.refreshToken,
+    });
+
+    // 4xx means the grant is gone (refresh token rotated out, app uninstalled,
+    // 90-day refresh expiry) → invalid_grant so the client knows to reconnect.
+    // 5xx/network are transient → plain Error surfaces as a 500 and the client
+    // retries later without dropping the connection.
+    if (!response.ok) {
+      const detail = (await response.text()).slice(0, 300);
+      if (response.status >= 400 && response.status < 500) {
+        throw new OAuthInvalidGrantError(
+          "invalid_grant",
+          `Shopify refused the refresh token (${response.status}): ${detail}`,
+        );
+      }
+      throw new Error(
+        `Shopify token refresh failed (${response.status}): ${detail}`,
+      );
+    }
+
+    const body = (await response.json()) as ShopifyTokenResponse;
+    if (!body.access_token || !body.refresh_token) {
+      throw new Error("Shopify refresh did not return the expected tokens");
+    }
+
+    return {
+      access_token: encryptCredential(
+        { shop: sealed.shop, token: body.access_token },
+        env.tokenSecret,
+      ),
+      token_type: "Bearer",
+      refresh_token: encryptCredential(
+        { shop: sealed.shop, refreshToken: body.refresh_token },
+        env.tokenSecret,
+      ),
+      expires_in: body.expires_in,
+    };
   },
 };
 
@@ -249,12 +364,14 @@ function handleConnect(url: URL, env: OAuthEnv): Response {
     new URL(OAUTH_CALLBACK_PATH, env.selfUrl).toString(),
   );
   authorize.searchParams.set("state", state);
-  // No `grant_options[]=per-user` → offline (non-expiring) access token.
+  // No `grant_options[]=per-user` → offline access token (the `expiring=1` opt-in
+  // that makes it a rotating token is sent later, at the code-exchange step).
   return Response.redirect(authorize.toString(), 302);
 }
 
 /** GET /oauth/shopify/callback — validate Shopify's redirect, exchange the code
- * for an offline token, seal it, and bounce back to the mesh callback. */
+ * for an expiring offline token, seal the grant, and bounce back to the mesh
+ * callback. */
 async function handleCallback(url: URL, env: OAuthEnv): Promise<Response> {
   const params = url.searchParams;
 
@@ -276,21 +393,14 @@ async function handleCallback(url: URL, env: OAuthEnv): Promise<Response> {
     return htmlResponse("Missing shop or authorization code.", 400);
   }
 
-  const tokenResponse = await fetch(
-    `https://${shop}/admin/oauth/access_token`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
-      body: JSON.stringify({
-        client_id: env.clientId,
-        client_secret: env.clientSecret,
-        code,
-      }),
-    },
-  );
+  // `expiring=1` opts into an expiring offline token (~1h access + ~90d rotating
+  // refresh). Shopify rejects non-expiring tokens on the Admin API with a 403.
+  const tokenResponse = await postTokenEndpoint(shop, {
+    client_id: env.clientId,
+    client_secret: env.clientSecret,
+    code,
+    expiring: "1",
+  });
 
   if (!tokenResponse.ok) {
     const detail = (await tokenResponse.text()).slice(0, 300);
@@ -300,19 +410,26 @@ async function handleCallback(url: URL, env: OAuthEnv): Promise<Response> {
     );
   }
 
-  const { access_token: accessToken } = (await tokenResponse.json()) as {
-    access_token?: string;
-  };
-  if (!accessToken) {
-    return htmlResponse("Shopify did not return an access token.", 502);
+  const {
+    access_token: accessToken,
+    refresh_token: refreshToken,
+    expires_in: expiresIn,
+  } = (await tokenResponse.json()) as ShopifyTokenResponse;
+  if (!accessToken || !refreshToken) {
+    return htmlResponse(
+      "Shopify did not return an expiring offline token (access + refresh).",
+      502,
+    );
   }
 
-  const sealed = encryptCredential(
-    { shop, token: accessToken },
+  // Seal the whole grant into the `code` — the runtime forwards only `code` to
+  // `exchangeCode`, so the refresh token and lifetime have to travel inside it.
+  const sealedGrant = encryptCredential(
+    { shop, access: accessToken, refresh: refreshToken, expiresIn },
     env.tokenSecret,
   );
   const dest = new URL(state.cb);
-  dest.searchParams.set("code", sealed);
+  dest.searchParams.set("code", sealedGrant);
   return Response.redirect(dest.toString(), 302);
 }
 

--- a/shopify/server/lib/token.ts
+++ b/shopify/server/lib/token.ts
@@ -33,6 +33,16 @@ export interface SealedCredential {
   token: string;
 }
 
+/**
+ * The `{ shop, refreshToken }` pair sealed into an OAuth connection's refresh
+ * token. Expiring offline tokens rotate, so we need the shop to hit the
+ * per-store refresh endpoint when the client asks for a new access token.
+ */
+export interface SealedRefresh {
+  shop: string;
+  refreshToken: string;
+}
+
 /** The shared secret used to seal/open credentials and sign state. */
 export function getTokenSecret(): string {
   return process.env.SHOPIFY_TOKEN_SECRET || "";


### PR DESCRIPTION
## Problem

Shopify's Admin API now **rejects non-expiring offline tokens** with a `403`:

> `[API] Non-expiring access tokens are no longer accepted for the Admin API. Start using expiring offline tokens…`

The OAuth flow (added in #526) minted exactly that kind of token — the code exchange never opted into expiring tokens, and the flow assumed the token *"never expires, so there's no refresh."* Every tool call on such a connection now fails.

## Fix

Switch the flow to Shopify's [expiring offline tokens](https://shopify.dev/docs/apps/build/authentication-authorization/access-tokens/offline-access-tokens) (~1h access token + ~90d rotating refresh token), which is now mandatory.

- **Code exchange** (`/oauth/shopify/callback`) now POSTs form-encoded with `expiring=1` and reads back `access_token` + `refresh_token` + `expires_in`. The full grant is sealed (AES-GCM) into the OAuth `code`, since the runtime forwards only `code` to `exchangeCode`.
- **`exchangeCode`** splits the grant into a sealed access token (used verbatim as the Admin API token — `resolveCredentials` is unchanged) and a sealed refresh token, and returns `expires_in`.
- **New `refreshToken` hook** — the runtime already supports the `refresh_token` grant. When the access token expires, the client hits the runtime `/token` endpoint and this hook rotates the token against Shopify's per-store endpoint, returning a freshly sealed pair. A Shopify `4xx` (rotated-out/lapsed token, app uninstalled) maps to `OAuthInvalidGrantError` → `invalid_grant` so the client reconnects; `5xx`/network stays transient.

Legacy raw-token / env-var paths are untouched.

## ⚠️ Requires reconnect

This fixes tokens minted **from now on**. Existing connections still hold a non-expiring token that can't be upgraded in place — **after deploy, existing Shopify connections must re-run OAuth (reconnect)** to obtain an expiring token.

## Verification

- `bun test` → **59 pass, 0 fail** (covers the expiring exchange, missing-refresh-token failure, the grant split, and all three refresh outcomes: success / `invalid_grant` / transient)
- `oxlint` + `oxfmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Shopify OAuth to expiring offline tokens to restore Admin API access and adds token refresh support. Existing Shopify connections must reconnect.

- **Bug Fixes**
  - Code exchange now sends `expiring=1` (form-encoded) and reads `access_token`, `refresh_token`, and `expires_in`.
  - `exchangeCode` returns a sealed access token, a sealed refresh token, and `expires_in`.
  - New `refreshToken` hook rotates tokens against the store endpoint; Shopify 4xx → `invalid_grant` (reconnect), 5xx/network → transient error.

- **Migration**
  - Deploy, then reconnect existing Shopify connections to mint expiring tokens.
  - Legacy raw-token/env-var paths remain unchanged.

<sup>Written for commit f0925751b79d03cd50c1e7d29dbf114bbea0d909. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

