### PR TITLE
feat(shopify): add theme-file write tools (edit Liquid & assets)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -3021,13 +3021,13 @@
   {
     "id": "deco/shopify",
     "title": "Shopify",
-    "description": "Read-only MCP for the Shopify Admin GraphQL API — products, collections, orders, draft orders, customers, inventory, fulfillment, discounts, online store content, B2B, markets, Shopify Payments and ShopifyQL analytics.",
+    "description": "MCP for the Shopify Admin GraphQL API — read products, collections, orders, draft orders, customers, inventory, fulfillment, discounts, online store content, B2B, markets, Shopify Payments and ShopifyQL analytics, plus edit theme files (Liquid & assets).",
     "is_public": true,
     "_meta": {
       "mcp.mesh": {
         "verified": false,
         "friendly_name": "Shopify",
-        "short_description": "Read-only access to Shopify stores: catalog, orders, customers, inventory and analytics.",
+        "short_description": "Read Shopify catalog, orders, customers, inventory and analytics — and edit theme files.",
         "owner": "deco",
         "has_remote": true,
         "has_oauth": false,
@@ -3044,13 +3044,13 @@
         "categories": [
           "E-commerce"
         ],
-        "readme": "The Shopify MCP gives AI agents read-only access to a Shopify store through the Admin GraphQL API. It can browse and search products, variants and collections, inspect orders (including draft orders, abandoned checkouts, returns, refund previews and fulfillment status), look up customers and segments, check inventory levels per location, review discounts and marketing activities, read online store content (pages, blogs, articles, menus, redirects and theme files), and pull financial data from Shopify Payments (payouts, balance, disputes). It also supports ShopifyQL analytics queries where available. Because every tool is a GraphQL query — never a mutation — the MCP can never modify store data. Connect via OAuth: authorize the app against your store's myshopify.com domain and it obtains a read-only offline Admin API token automatically."
+        "readme": "The Shopify MCP gives AI agents access to a Shopify store through the Admin GraphQL API. It can browse and search products, variants and collections, inspect orders (including draft orders, abandoned checkouts, returns, refund previews and fulfillment status), look up customers and segments, check inventory levels per location, review discounts and marketing activities, read online store content (pages, blogs, articles, menus, redirects and theme files), and pull financial data from Shopify Payments (payouts, balance, disputes). It also supports ShopifyQL analytics queries where available. Almost every tool is a read-only GraphQL query; the only mutations are theme-file editing — create, overwrite or delete Liquid templates and theme assets (requires the write_themes scope). Connect via OAuth: authorize the app against your store's myshopify.com domain and it obtains an offline Admin API token automatically."
       }
     },
     "server": {
       "name": "shopify",
       "title": "Shopify",
-      "description": "Read-only MCP for the Shopify Admin GraphQL API — products, collections, orders, draft orders, customers, inventory, fulfillment, discounts, online store content, B2B, markets, Shopify Payments and ShopifyQL analytics.",
+      "description": "MCP for the Shopify Admin GraphQL API — read products, collections, orders, draft orders, customers, inventory, fulfillment, discounts, online store content, B2B, markets, Shopify Payments and ShopifyQL analytics, plus edit theme files (Liquid & assets).",
       "icons": [
         {
           "src": "https://github.com/shopify.png"
@@ -3062,7 +3062,7 @@
           "url": "https://sites-shopify.deco.site/mcp",
           "name": "shopify",
           "title": "Shopify",
-          "description": "Read-only MCP for the Shopify Admin GraphQL API — products, collections, orders, draft orders, customers, inventory, fulfillment, discounts, online store content, B2B, markets, Shopify Payments and ShopifyQL analytics."
+          "description": "MCP for the Shopify Admin GraphQL API — read products, collections, orders, draft orders, customers, inventory, fulfillment, discounts, online store content, B2B, markets, Shopify Payments and ShopifyQL analytics, plus edit theme files (Liquid & assets)."
         }
       ]
     }

--- a/shopify/README.md
+++ b/shopify/README.md
@@ -1,13 +1,16 @@
 # Shopify MCP
 
-Read-only MCP for the **Shopify Admin GraphQL API** (pinned to `2026-07`). Every tool is a
-GraphQL query — never a mutation — so the MCP can never modify store data.
+MCP for the **Shopify Admin GraphQL API** (pinned to `2026-07`). Almost every tool is a
+read-only GraphQL query; the sole exception is theme-file editing — two mutations
+(`SHOPIFY_UPDATE_THEME_FILES`, `SHOPIFY_DELETE_THEME_FILES`) that create, overwrite or delete
+Liquid templates and theme assets. Nothing else can modify store data.
 
-45 tools across 11 domains: products & collections, orders (drafts, abandoned checkouts,
+47 tools across 11 domains: products & collections, orders (drafts, abandoned checkouts,
 returns, refund previews), fulfillment & locations, inventory, customers & segments,
 discounts & marketing, online store content (pages, blogs, articles, menus, redirects,
-themes), store properties & localization, B2B companies & markets, Shopify Payments,
-and ShopifyQL analytics. See [TOOLS.md](./TOOLS.md) for the full catalog and scope map.
+themes — read **and** write), store properties & localization, B2B companies & markets,
+Shopify Payments, and ShopifyQL analytics. See [TOOLS.md](./TOOLS.md) for the full catalog
+and scope map.
 
 ## Setup
 
@@ -15,19 +18,21 @@ Connecting is a one-click **OAuth** flow — no manual token copying:
 
 1. In the connection UI, start the OAuth flow. You'll land on a page asking for your
    store's `my-store.myshopify.com` domain.
-2. Shopify shows the standard authorization screen listing the requested **read scopes**.
-   Approve it and you're connected — the MCP stores a read-only **expiring offline access
-   token** (~1h) plus a rotating **refresh token** (~90d). The connection refreshes itself
-   automatically; you only re-run OAuth if the refresh token lapses or you revoke the app.
+2. Shopify shows the standard authorization screen listing the requested scopes (all read,
+   plus **`write_themes`** for theme editing). Approve it and you're connected — the MCP
+   stores an **expiring offline access token** (~1h) plus a rotating **refresh token** (~90d).
+   The connection refreshes itself automatically; you only re-run OAuth if the refresh token
+   lapses or you revoke the app.
 
 There's no connection config to fill in. The Admin API version defaults to `2026-07`;
 override it per deployment with the `SHOPIFY_API_VERSION` env var.
 
 Default scopes requested: `read_products`, `read_orders`, `read_customers`,
 `read_inventory`, `read_fulfillments`, `read_locations`, `read_discounts`, `read_content`,
-`read_themes`, `read_locales`, `read_translations`, `read_marketing_events`,
+`read_themes`, `write_themes`, `read_locales`, `read_translations`, `read_marketing_events`,
 `read_markets`, `read_reports`. Override with the `SHOPIFY_SCOPES` env var
-(comma-separated) to add or trim.
+(comma-separated) to add or trim — e.g. drop `write_themes` for a strictly read-only
+deployment (the two theme-write tools then fail with an ACCESS_DENIED hint).
 
 Some scopes are **plan/entitlement-gated** and are left out of the default because Shopify
 rejects the whole authorize request (`missing_shopify_permission`) if the store can't grant

--- a/shopify/TOOLS.md
+++ b/shopify/TOOLS.md
@@ -1,8 +1,9 @@
-# Shopify MCP — Tool Selection (read-only)
+# Shopify MCP — Tool Selection
 
-Final tool list for the new `shopify` MCP. **Decision: the MCP is read-only** — every tool
-wraps a query against the **Shopify Admin GraphQL API** (version `2026-07`, current stable).
-No mutations, so the MCP can never modify store data.
+Final tool list for the `shopify` MCP. **The MCP is read-only except for theme-file editing.**
+Every tool wraps the **Shopify Admin GraphQL API** (version `2026-07`, current stable): all are
+queries apart from two theme-file mutations (`SHOPIFY_UPDATE_THEME_FILES`,
+`SHOPIFY_DELETE_THEME_FILES`). No other tool can modify store data.
 
 All tools below are selected (`[x]`). The `Tier` column just indicates expected usage:
 **core** = day-1 essentials, **rec** = common, **opt** = niche but harmless to include.
@@ -22,9 +23,10 @@ All tools below are selected (`[x]`). The `Tier` column just indicates expected 
 
 ## Selection at a glance
 
-~40 read-only tools across 11 domains: products & collections, orders (incl. drafts,
+47 tools across 11 domains: products & collections, orders (incl. drafts,
 returns, abandoned checkouts), fulfillment, inventory, customers, discounts, online store
-content, store properties, B2B, markets, and Shopify Payments.
+content (incl. theme-file read + write), store properties, B2B, markets, and Shopify Payments.
+All are read-only queries except the two theme-file write tools.
 
 Excluded by decision (2026-07-14): gift cards, metafields/metaobjects, files, webhooks.
 
@@ -99,7 +101,7 @@ Scopes: `read_discounts`, `read_marketing_events`
 
 ## 7. Online Store Content
 
-Scopes: `read_content`, `read_online_store_navigation`, `read_themes`
+Scopes: `read_content`, `read_online_store_navigation`, `read_themes`, `write_themes` (for the theme-write tools)
 
 | Pick | Tool | GraphQL op | What it does | Tier |
 |---|---|---|---|---|
@@ -110,6 +112,8 @@ Scopes: `read_content`, `read_online_store_navigation`, `read_themes`
 | [x] | `SHOPIFY_LIST_REDIRECTS` | `urlRedirects` | URL redirects | opt |
 | [x] | `SHOPIFY_LIST_THEMES` | `themes` | Installed themes + roles (main, unpublished…) | opt |
 | [x] | `SHOPIFY_GET_THEME_FILES` | `theme.files` | Read theme files (liquid, JSON templates) | opt |
+| [x] | `SHOPIFY_UPDATE_THEME_FILES` | `themeFilesUpsert` | **Write:** create/overwrite theme files (Liquid, JSON, assets) — full replace per file | rec |
+| [x] | `SHOPIFY_DELETE_THEME_FILES` | `themeFilesDelete` | **Write:** delete theme files by filename | opt |
 
 ## 8. Store Properties & Localization
 
@@ -157,7 +161,7 @@ Scopes: `read_reports`
 
 | Surface | Why excluded |
 |---|---|
-| **All mutations** | MCP is read-only by decision — no create/update/delete of any resource |
+| **All mutations except theme-file editing** | MCP is read-only apart from `themeFilesUpsert`/`themeFilesDelete` — no other create/update/delete of any resource |
 | **Gift cards, metafields/metaobjects, files, webhooks** | Cut from scope by decision (2026-07-14) |
 | **Bulk operations** (`bulkOperationRunQuery`) | Read-only in effect, but implemented as mutations and add async/polling complexity; revisit if large exports become a need |
 | **Raw GraphQL passthrough** (`SHOPIFY_RUN_GRAPHQL`) | Can't guarantee read-only — a passthrough would accept mutations. Could add later as a query-only variant that rejects mutation documents |
@@ -167,6 +171,11 @@ Scopes: `read_reports`
 
 ## Decisions
 
+0. **Theme-file writes:** the MCP is read-only *except* for editing theme files
+   (`SHOPIFY_UPDATE_THEME_FILES` / `SHOPIFY_DELETE_THEME_FILES`), added so agents can modify
+   Liquid/theme code. These require the `write_themes` scope (in `DEFAULT_SCOPES`; drop it via
+   `SHOPIFY_SCOPES` for a strictly read-only deployment). Upsert fully replaces each file — no
+   partial patch — so callers read the current file first. All other write surfaces stay out.
 1. **Store domain configuration:** Magento approach — the Admin API access token goes in the
    connection-level Authorization (Bearer) field, and `storeDomain` is a required field in the
    connection `configSchema` (with `SHOPIFY_STORE_DOMAIN` / `SHOPIFY_ACCESS_TOKEN` env fallbacks

--- a/shopify/app.json
+++ b/shopify/app.json
@@ -6,14 +6,14 @@
     "type": "HTTP",
     "url": "https://sites-shopify.deco.site/mcp"
   },
-  "description": "Read-only MCP for the Shopify Admin GraphQL API — products, collections, orders, draft orders, customers, inventory, fulfillment, discounts, online store content, B2B, markets, Shopify Payments and ShopifyQL analytics.",
+  "description": "MCP for the Shopify Admin GraphQL API — read products, collections, orders, draft orders, customers, inventory, fulfillment, discounts, online store content, B2B, markets, Shopify Payments and ShopifyQL analytics, plus edit theme files (Liquid & assets).",
   "icon": "https://github.com/shopify.png",
   "unlisted": false,
   "metadata": {
     "categories": ["E-commerce"],
     "official": false,
     "tags": ["shopify", "ecommerce", "orders", "products", "customers", "inventory", "analytics", "api"],
-    "short_description": "Read-only access to Shopify stores: catalog, orders, customers, inventory and analytics.",
-    "mesh_description": "The Shopify MCP gives AI agents read-only access to a Shopify store through the Admin GraphQL API. It can browse and search products, variants and collections, inspect orders (including draft orders, abandoned checkouts, returns, refund previews and fulfillment status), look up customers and segments, check inventory levels per location, review discounts and marketing activities, read online store content (pages, blogs, articles, menus, redirects and theme files), and pull financial data from Shopify Payments (payouts, balance, disputes). It also supports ShopifyQL analytics queries where available. Because every tool is a GraphQL query — never a mutation — the MCP can never modify store data. Connect via OAuth: authorize the app against your store's myshopify.com domain and it obtains a read-only offline Admin API token automatically."
+    "short_description": "Read Shopify catalog, orders, customers, inventory and analytics — and edit theme files.",
+    "mesh_description": "The Shopify MCP gives AI agents access to a Shopify store through the Admin GraphQL API. It can browse and search products, variants and collections, inspect orders (including draft orders, abandoned checkouts, returns, refund previews and fulfillment status), look up customers and segments, check inventory levels per location, review discounts and marketing activities, read online store content (pages, blogs, articles, menus, redirects and theme files), and pull financial data from Shopify Payments (payouts, balance, disputes). It also supports ShopifyQL analytics queries where available. Almost every tool is a read-only GraphQL query; the only mutations are theme-file editing — create, overwrite or delete Liquid templates and theme assets (requires the write_themes scope). Connect via OAuth: authorize the app against your store's myshopify.com domain and it obtains an offline Admin API token automatically."
   }
 }

--- a/shopify/scripts/validate-queries.ts
+++ b/shopify/scripts/validate-queries.ts
@@ -17,6 +17,7 @@ import * as orders from "../server/tools/orders.ts";
 import * as payments from "../server/tools/payments.ts";
 import * as products from "../server/tools/products.ts";
 import * as store from "../server/tools/store.ts";
+import * as themes from "../server/tools/themes.ts";
 import { DEFAULT_API_VERSION } from "../server/constants.ts";
 
 const version =
@@ -112,6 +113,19 @@ const SAMPLES: Record<string, Record<string, unknown>> = {
   LIST_DISPUTES_QUERY: { first: 1 },
   LIST_BALANCE_TRANSACTIONS_QUERY: { first: 1 },
   RUN_SHOPIFYQL_QUERY: { query: "FROM sales SHOW total_sales SINCE -7d" },
+  UPDATE_THEME_FILES_MUTATION: {
+    themeId: GID.theme,
+    files: [
+      {
+        filename: "snippets/sample.liquid",
+        body: { type: "TEXT", value: "hello" },
+      },
+    ],
+  },
+  DELETE_THEME_FILES_MUTATION: {
+    themeId: GID.theme,
+    files: ["snippets/sample.liquid"],
+  },
 };
 
 const modules = {
@@ -126,6 +140,7 @@ const modules = {
   b2b,
   payments,
   analytics,
+  themes,
 };
 
 interface Doc {
@@ -137,7 +152,10 @@ interface Doc {
 const docs: Doc[] = [];
 for (const [moduleName, mod] of Object.entries(modules)) {
   for (const [exportName, value] of Object.entries(mod)) {
-    if (exportName.endsWith("_QUERY") && typeof value === "string") {
+    if (
+      (exportName.endsWith("_QUERY") || exportName.endsWith("_MUTATION")) &&
+      typeof value === "string"
+    ) {
       docs.push({ name: exportName, module: moduleName, query: value });
     }
   }

--- a/shopify/server/lib/oauth.ts
+++ b/shopify/server/lib/oauth.ts
@@ -44,14 +44,17 @@ export const OAUTH_CONNECT_PATH = "/oauth/custom";
 export const OAUTH_CALLBACK_PATH = "/oauth/shopify/callback";
 
 /**
- * Read scopes requested during the grant. Kept to what a standard store can
- * grant — Shopify rejects the whole authorize request (missing_shopify_permission)
- * if the app asks for a scope the store isn't entitled to.
+ * Scopes requested during the grant. Almost all are read scopes; `write_themes`
+ * backs the two theme-file write tools (SHOPIFY_UPDATE_THEME_FILES /
+ * SHOPIFY_DELETE_THEME_FILES). Kept to what a standard store can grant — Shopify
+ * rejects the whole authorize request (missing_shopify_permission) if the app
+ * asks for a scope the store isn't entitled to.
  *
  * Deliberately excluded from the default because they're plan/entitlement-gated:
  *   - read_users, read_companies         → Shopify Plus only
  *   - read_shopify_payments_payouts/…    → require Shopify Payments
- * Add them (or trim further) per deployment via the SHOPIFY_SCOPES env var.
+ * Add them (or trim further) per deployment via the SHOPIFY_SCOPES env var —
+ * e.g. drop `write_themes` for a strictly read-only deployment.
  */
 export const DEFAULT_SCOPES = [
   "read_products",
@@ -63,6 +66,7 @@ export const DEFAULT_SCOPES = [
   "read_discounts",
   "read_content",
   "read_themes",
+  "write_themes",
   "read_locales",
   "read_translations",
   "read_marketing_events",
@@ -325,7 +329,7 @@ function connectForm(callbackUrl: string): Response {
 <body>
   <form class="card" method="GET" action="${OAUTH_CONNECT_PATH}">
     <h1>Connect your Shopify store</h1>
-    <p>Enter your store's <code>.myshopify.com</code> domain to authorize read-only access.</p>
+    <p>Enter your store's <code>.myshopify.com</code> domain to authorize access.</p>
     <label for="shop">Store domain</label>
     <input id="shop" name="shop" placeholder="my-store.myshopify.com"
       autocomplete="off" autofocus required />

--- a/shopify/server/lib/tool.ts
+++ b/shopify/server/lib/tool.ts
@@ -1,6 +1,7 @@
 /**
- * Factory for read-only Shopify tools: resolves credentials from the mesh
- * request context, validates them, and delegates to the handler.
+ * Factory for Shopify tools: resolves credentials from the mesh request
+ * context, validates them, and delegates to the handler. Read tools are the
+ * default (`readOnlyHint: true`); pass `annotations` to declare a write tool.
  */
 import { createTool } from "@decocms/runtime/tools";
 import { z } from "zod";
@@ -11,12 +12,22 @@ import {
   resolveCredentials,
 } from "./client.ts";
 
+/** MCP tool annotations (hints for clients about a tool's side effects). */
+export interface ToolAnnotations {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
 export function createShopifyTool<
   TSchema extends z.ZodObject<z.ZodRawShape>,
 >(config: {
   id: string;
   description: string;
   inputSchema: TSchema;
+  /** Defaults to a read-only tool; override for write/mutation tools. */
+  annotations?: ToolAnnotations;
   handler: (
     input: z.infer<TSchema>,
     creds: ResolvedCredentials,
@@ -27,7 +38,7 @@ export function createShopifyTool<
       id: config.id,
       description: config.description,
       inputSchema: config.inputSchema,
-      annotations: { readOnlyHint: true },
+      annotations: config.annotations ?? { readOnlyHint: true },
       execute: async ({ context, runtimeContext }) => {
         const env = runtimeContext.env as Env;
         const creds = resolveCredentials(env.MESH_REQUEST_CONTEXT);

--- a/shopify/server/main.ts
+++ b/shopify/server/main.ts
@@ -1,9 +1,10 @@
 /**
  * Shopify MCP
  *
- * Read-only MCP for the Shopify Admin GraphQL API — products, collections,
+ * Mostly-read MCP for the Shopify Admin GraphQL API — products, collections,
  * orders, customers, inventory, fulfillment, discounts, online store content,
- * B2B, markets, Shopify Payments and ShopifyQL analytics.
+ * B2B, markets, Shopify Payments and ShopifyQL analytics. The only mutations
+ * are the theme-file write tools (create/update/delete Liquid & theme assets).
  */
 import { serve } from "@decocms/mcps-shared/serve";
 import { withRuntime } from "@decocms/runtime";

--- a/shopify/server/tools/index.ts
+++ b/shopify/server/tools/index.ts
@@ -1,5 +1,7 @@
 /**
- * Central export point for all Shopify tools (all read-only).
+ * Central export point for all Shopify tools. Every tool is a read-only query
+ * except the theme-file write tools (themeWriteTools), which are the MCP's only
+ * mutations.
  */
 import { analyticsTools } from "./analytics.ts";
 import { b2bTools } from "./b2b.ts";
@@ -12,6 +14,7 @@ import { orderTools } from "./orders.ts";
 import { paymentTools } from "./payments.ts";
 import { productTools } from "./products.ts";
 import { storeTools } from "./store.ts";
+import { themeWriteTools } from "./themes.ts";
 
 export const tools = [
   ...productTools,
@@ -25,4 +28,5 @@ export const tools = [
   ...b2bTools,
   ...paymentTools,
   ...analyticsTools,
+  ...themeWriteTools,
 ];

--- a/shopify/server/tools/themes.ts
+++ b/shopify/server/tools/themes.ts
@@ -1,0 +1,186 @@
+/**
+ * Online store theme *write* tools: create/update and delete theme files
+ * (Liquid templates, JSON settings, section/asset files).
+ *
+ * These are the only mutations in this MCP. Every other tool is a read-only
+ * query — see tools/index.ts. Writing theme files requires the `write_themes`
+ * scope; a token with only `read_themes` fails with an ACCESS_DENIED hint.
+ */
+import { z } from "zod";
+import { shopifyGraphql, toGid } from "../lib/client.ts";
+import { createShopifyTool } from "../lib/tool.ts";
+
+/** Shape of Shopify's `userErrors` on the theme-file mutations. */
+interface ThemeFilesUserError {
+  filename?: string | null;
+  code?: string | null;
+  message: string;
+}
+
+/**
+ * Theme-file mutations report business errors in `userErrors` (not the
+ * top-level GraphQL `errors` that shopifyGraphql already throws on), so they'd
+ * otherwise pass silently. Throw a descriptive error when any are present.
+ */
+function assertNoUserErrors(
+  errors: ThemeFilesUserError[] | undefined,
+  toolId: string,
+): void {
+  if (!errors?.length) return;
+  const detail = errors
+    .map((e) => {
+      const where = e.filename ? `${e.filename}: ` : "";
+      const code = e.code ? ` (${e.code})` : "";
+      return `${where}${e.message}${code}`;
+    })
+    .join("; ");
+  throw new Error(
+    `Shopify rejected the theme file change [tool=${toolId}]: ${detail}`,
+  );
+}
+
+export const UPDATE_THEME_FILES_MUTATION = `
+mutation UpdateThemeFiles($themeId: ID!, $files: [OnlineStoreThemeFilesUpsertFileInput!]!) {
+  themeFilesUpsert(themeId: $themeId, files: $files) {
+    upsertedThemeFiles {
+      filename
+    }
+    userErrors {
+      filename
+      code
+      message
+    }
+  }
+}`;
+
+export const updateThemeFiles = createShopifyTool({
+  id: "SHOPIFY_UPDATE_THEME_FILES",
+  description:
+    "Create or overwrite theme files (Liquid, JSON settings, assets) on a theme. " +
+    "Each file is fully replaced by the content you provide — there is no partial patch, " +
+    "so read the current file first (SHOPIFY_GET_THEME_FILES) and send the complete new body. " +
+    "Editing the live (MAIN) theme changes the storefront immediately; prefer an UNPUBLISHED " +
+    "theme when testing. Requires the write_themes scope.",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+  },
+  inputSchema: z.object({
+    themeId: z
+      .string()
+      .describe(
+        'Theme ID — numeric or GID ("gid://shopify/OnlineStoreTheme/123"). Use SHOPIFY_LIST_THEMES to find it.',
+      ),
+    files: z
+      .array(
+        z.object({
+          filename: z
+            .string()
+            .describe(
+              'Theme-relative path, e.g. "sections/header.liquid" or "templates/product.json".',
+            ),
+          content: z
+            .string()
+            .describe(
+              "Full new content of the file (text). For binary assets, set encoding to BASE64.",
+            ),
+          encoding: z
+            .enum(["TEXT", "BASE64"])
+            .optional()
+            .describe("How content is encoded (default TEXT)."),
+        }),
+      )
+      .min(1)
+      .describe("Files to create or overwrite (each fully replaced)."),
+  }),
+  handler: async (input, creds) => {
+    const files = input.files.map((f) => ({
+      filename: f.filename,
+      body: { type: f.encoding ?? "TEXT", value: f.content },
+    }));
+    const data = await shopifyGraphql<{
+      themeFilesUpsert: {
+        upsertedThemeFiles: { filename: string }[] | null;
+        userErrors: ThemeFilesUserError[];
+      } | null;
+    }>(
+      creds,
+      UPDATE_THEME_FILES_MUTATION,
+      { themeId: toGid("OnlineStoreTheme", input.themeId), files },
+      "SHOPIFY_UPDATE_THEME_FILES",
+    );
+    assertNoUserErrors(
+      data.themeFilesUpsert?.userErrors,
+      "SHOPIFY_UPDATE_THEME_FILES",
+    );
+    return {
+      upsertedFiles: data.themeFilesUpsert?.upsertedThemeFiles ?? [],
+    };
+  },
+});
+
+export const DELETE_THEME_FILES_MUTATION = `
+mutation DeleteThemeFiles($themeId: ID!, $files: [String!]!) {
+  themeFilesDelete(themeId: $themeId, files: $files) {
+    deletedThemeFiles {
+      filename
+    }
+    userErrors {
+      filename
+      code
+      message
+    }
+  }
+}`;
+
+export const deleteThemeFiles = createShopifyTool({
+  id: "SHOPIFY_DELETE_THEME_FILES",
+  description:
+    "Delete files from a theme by exact filename. Deleting a file the theme " +
+    "depends on can break the storefront — prefer an UNPUBLISHED theme when " +
+    "unsure. Requires the write_themes scope.",
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
+  },
+  inputSchema: z.object({
+    themeId: z
+      .string()
+      .describe(
+        'Theme ID — numeric or GID ("gid://shopify/OnlineStoreTheme/123").',
+      ),
+    filenames: z
+      .array(z.string())
+      .min(1)
+      .describe(
+        'Exact theme-relative paths to delete, e.g. ["sections/custom.liquid"].',
+      ),
+  }),
+  handler: async (input, creds) => {
+    const data = await shopifyGraphql<{
+      themeFilesDelete: {
+        deletedThemeFiles: { filename: string }[] | null;
+        userErrors: ThemeFilesUserError[];
+      } | null;
+    }>(
+      creds,
+      DELETE_THEME_FILES_MUTATION,
+      {
+        themeId: toGid("OnlineStoreTheme", input.themeId),
+        files: input.filenames,
+      },
+      "SHOPIFY_DELETE_THEME_FILES",
+    );
+    assertNoUserErrors(
+      data.themeFilesDelete?.userErrors,
+      "SHOPIFY_DELETE_THEME_FILES",
+    );
+    return {
+      deletedFiles: data.themeFilesDelete?.deletedThemeFiles ?? [],
+    };
+  },
+});
+
+export const themeWriteTools = [updateThemeFiles, deleteThemeFiles];


### PR DESCRIPTION
## What

Adds the first (and only) mutations to the Shopify MCP — editing Online Store **theme files** (Liquid templates, JSON settings, section/asset files):

| Tool | GraphQL op | What it does |
|---|---|---|
| `SHOPIFY_UPDATE_THEME_FILES` | `themeFilesUpsert` | Create/overwrite theme files — **full replace per file**, no partial patch |
| `SHOPIFY_DELETE_THEME_FILES` | `themeFilesDelete` | Delete theme files by filename |

Every other tool remains a read-only query. These two are the only write surface.

## Why

The MCP was intentionally read-only, so agents could inspect a store but never edit theme/Liquid code. This PR opens exactly that one door — theme editing — while keeping the rest read-only.

## How

- **`createShopifyTool`** now takes an optional `annotations` arg so write tools declare `readOnlyHint: false` / `destructiveHint: true` (reads still default to read-only).
- **`write_themes`** added to `DEFAULT_SCOPES`. Drop it via `SHOPIFY_SCOPES` for a strictly read-only deployment — the two tools then fail with an `ACCESS_DENIED` hint.
- Mutation **`userErrors`** are surfaced as thrown errors (they don't appear in the top-level GraphQL `errors` that the client already handles).
- **`validate-queries`** now also checks `*_MUTATION` documents. Both new mutations validate clean against the live `2026-07` schema.
- Docs updated to reflect "read-only **except** theme-file editing": `README.md`, `app.json`, `TOOLS.md`, and code comments.

## Verification

- `bun run validate:queries` → **53/53 ok, 0 failures** (incl. both new mutations)
- `bun test` → **59 pass, 0 fail**
- `bun run check` → no errors in shopify source (2 pre-existing errors live inside `@decocms/runtime`, unrelated)

## Notes / follow-ups

- Editing the live (MAIN) theme changes the storefront immediately; tool descriptions steer callers toward an UNPUBLISHED theme when testing.
- Not included (could be follow-ups): `themeFilesCopy`, `themeCreate`/`themePublish`/`themeDelete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the first write surface to the Shopify MCP: theme-file editing. New tools let you create/overwrite and delete Liquid, JSON, and asset files; everything else remains read-only.

- **New Features**
  - Added `SHOPIFY_UPDATE_THEME_FILES` (GraphQL `themeFilesUpsert`) and `SHOPIFY_DELETE_THEME_FILES` (`themeFilesDelete`) for full-file replace and deletes.
  - Surfaced mutation `userErrors` as thrown errors with clear filenames/messages.
  - `createShopifyTool` now supports `annotations` to mark write tools (`readOnlyHint: false`, `destructiveHint: true`).
  - `validate-queries` checks `*_MUTATION` docs; both mutations validate against `2026-07`.
  - Docs, app metadata, and `registry.json` updated to note “read-only except theme-file editing.”

- **Migration**
  - OAuth now requests `write_themes`. Re-authorize to use the new tools if your token lacks this scope.
  - To stay read-only, drop `write_themes` via `SHOPIFY_SCOPES`; the two write tools will return ACCESS_DENIED.

<sup>Written for commit 914b5e4b0ef28f6ec69001700989d0253a4a0167. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

