### PR TITLE
fix(shopify): request read_online_store_navigation scope for menus

### DIFF
--- a/shopify/README.md
+++ b/shopify/README.md
@@ -29,8 +29,9 @@ override it per deployment with the `SHOPIFY_API_VERSION` env var.
 
 Default scopes requested: `read_products`, `read_orders`, `read_customers`,
 `read_inventory`, `read_fulfillments`, `read_locations`, `read_discounts`, `read_content`,
-`read_themes`, `write_themes`, `read_locales`, `read_translations`, `read_marketing_events`,
-`read_markets`, `read_reports`. Override with the `SHOPIFY_SCOPES` env var
+`read_online_store_navigation`, `read_themes`, `write_themes`, `read_locales`,
+`read_translations`, `read_marketing_events`, `read_markets`, `read_reports`.
+Override with the `SHOPIFY_SCOPES` env var
 (comma-separated) to add or trim — e.g. drop `write_themes` for a strictly read-only
 deployment (the two theme-write tools then fail with an ACCESS_DENIED hint).
 

--- a/shopify/server/lib/oauth.ts
+++ b/shopify/server/lib/oauth.ts
@@ -65,6 +65,7 @@ export const DEFAULT_SCOPES = [
   "read_locations",
   "read_discounts",
   "read_content",
+  "read_online_store_navigation",
   "read_themes",
   "write_themes",
   "read_locales",


### PR DESCRIPTION
## What

Adds `read_online_store_navigation` to the Shopify MCP's `DEFAULT_SCOPES`.

## Why

`SHOPIFY_LIST_MENUS` wraps the Admin API `menus` query, which requires the **`read_online_store_navigation`** scope — not `read_content`. That scope was missing from the default OAuth grant, so listing menus failed with `ACCESS_DENIED` on connected stores.

## How

- Added `read_online_store_navigation` to `DEFAULT_SCOPES` in `server/lib/oauth.ts`.
- Updated the default-scopes list in `README.md` to match.

## Note

The scope is requested at OAuth time, so existing connections must **reconnect** (re-run OAuth) after this deploys to pick up the new scope. New connections get it automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Request the `read_online_store_navigation` OAuth scope by default so `SHOPIFY_LIST_MENUS` can call the Admin `menus` query. Fixes ACCESS_DENIED errors and updates the README to list the new scope.

- **Migration**
  - Existing Shopify connections must reconnect (redo OAuth) to grant the new scope. New connections get it automatically.

<sup>Written for commit b6c9704642dd249c6a4d0b9bed3a69fc5a6c4354. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

