### PR TITLE
added gitleaks workflow

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -1,0 +1,40 @@
+name: SAST
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: sast-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+# All third-party actions are pinned to a full commit SHA, not a tag.
+
+jobs:
+  gitleaks:
+    name: Gitleaks (secret history)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # On pull_request the action calls GET /repos/{o}/{r}/pulls/{n}/commits
+      # to scan only the PR range. Without this it 403s with
+      # "Resource not accessible by integration".
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0 # full history so rotated-but-committed secrets are caught
+
+      # gitleaks-action requires a license key for ORGANIZATION-owned repos.
+      # Free for personal accounts and public repos, where the var is unused.
+      # Get a key at https://gitleaks.io and add it as a repo/org secret
+      # named GITLEAKS_LICENSE (Settings > Secrets and variables > Actions).
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}


### PR DESCRIPTION
added gitleaks workflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions SAST workflow that runs Gitleaks on all pull requests and pushes to `main` to prevent secret leaks. The new behavior fails the check when secrets are detected, including rotated-but-committed secrets due to full-history scans.

**Rollout notes**
- Triggers on `pull_request` and `push` to `main`; 10-minute job timeout.
- Uses pinned `actions/checkout` (with `fetch-depth: 0`) and pinned `gitleaks/gitleaks-action`.
- Minimal permissions; includes `pull-requests: read` so PR-range scanning works.
- Concurrency cancels in-progress runs for the same ref.
- Required: Add a `GITLEAKS_LICENSE` secret for organization-owned repos (not needed for personal or public repos).

<sup>Written for commit 006e3cd0dddab37ef17d1523c9f27df3a9b53087. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

