### PR TITLE
fix(allowlist): remove systems.entia/entity-verification, deleted from the official MCP Registry

### DIFF
--- a/registry/server/lib/allowlist.ts
+++ b/registry/server/lib/allowlist.ts
@@ -5810,7 +5810,6 @@ export const ALLOWED_SERVERS: string[] = [
   "support.supp/mcp-server",
   "sv.mcp/el-salvador",
   "sv.prometheus/mcp",
-  "systems.entia/entity-verification",
   "tax.zip/ziptax",
   "team.jogo/mcp",
   "tech.agentbazaar/marketplace",


### PR DESCRIPTION
Maintainer of the ENTIA MCP server here.

`registry/server/lib/allowlist.ts` allowlists two namespaces for us. One of them, `systems.entia/entity-verification`, was a duplicate publication and was **deleted from the official MCP Registry today** — all of its versions are gone and it no longer appears in the registry API. Anything resolving through it now points at nothing.

This PR removes that single line. `io.github.entia-systems-core/entity-verification` is our canonical entry (v4.4.0, status `active`) and is left untouched.

Evidence:

```
curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=entia"
-> io.github.entia-systems-core/entity-verification 4.4.0 active
   "11.3M entities, 10 countries, 12 tools. EU VAT (VIES), BORME, GLEIF, KYB. Free: 100 req/month."
   (no systems.entia/entity-verification entry in the response)
```

The live server behind the canonical entry: endpoint `https://mcp.entia.systems/mcp`, 12 tools via `tools/list`, `get_platform_stats` -> `{"total_entities": 11330392, "countries_active": 10}`.

The file header says it is generated by `scripts/generate-allowlist.ts`, so regenerating would also drop the dead namespace; I patched the committed file directly rather than guess at your generation environment. I left the `Total servers: 5887` header comment alone for the same reason — happy to adjust it, or to close this in favour of a regeneration run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove deleted MCP server `systems.entia/entity-verification` from the allowlist so it matches the official registry and avoids dangling entries. Previously we allowed both `systems.entia/entity-verification` and the canonical `io.github.entia-systems-core/entity-verification`; now only the canonical entry remains. This has no runtime effect because the removed entry no longer resolves.

**Impact and review notes**
- Single-line removal in `registry/server/lib/allowlist.ts`; a regenerated allowlist would make the same change.
- No rollout or config changes required.
- If any client still references `systems.entia/entity-verification`, switch to `io.github.entia-systems-core/entity-verification`.

<sup>Written for commit 0cb8972cba48817bfb42125c3f172d2e983d711b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

