### PR TITLE
fix(shopify): drop "shopify" token from OAuth URLs

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -3059,7 +3059,7 @@
       "remotes": [
         {
           "type": "HTTP",
-          "url": "https://sites-shopify.deco.site/mcp",
+          "url": "https://mcp-commerce-store.deco.site/mcp",
           "name": "shopify",
           "title": "Shopify",
           "description": "MCP for the Shopify Admin GraphQL API — read products, collections, orders, draft orders, customers, inventory, fulfillment, discounts, online store content, B2B, markets, Shopify Payments and ShopifyQL analytics, plus edit theme files (Liquid & assets)."

--- a/shopify/app.json
+++ b/shopify/app.json
@@ -4,7 +4,7 @@
   "friendlyName": "Shopify",
   "connection": {
     "type": "HTTP",
-    "url": "https://sites-shopify.deco.site/mcp"
+    "url": "https://mcp-commerce-store.deco.site/mcp"
   },
   "description": "MCP for the Shopify Admin GraphQL API — read products, collections, orders, draft orders, customers, inventory, fulfillment, discounts, online store content, B2B, markets, Shopify Payments and ShopifyQL analytics, plus edit theme files (Liquid & assets).",
   "icon": "https://github.com/shopify.png",

--- a/shopify/server/lib/oauth.test.ts
+++ b/shopify/server/lib/oauth.test.ts
@@ -13,7 +13,7 @@ import {
 } from "./token.ts";
 import { createHmac } from "node:crypto";
 
-const SELF = "https://sites-shopify.deco.site";
+const SELF = "https://mcp-commerce-store.deco.site";
 const MESH = "https://api.decocms.com";
 const SECRET = "oauth-test-secret";
 const CLIENT_ID = "test-client-id";
@@ -58,7 +58,7 @@ describe("authorizationUrl", () => {
   test("defaults to the prod domain (not localhost) when SELF_URL is unset", () => {
     delete process.env.SELF_URL;
     const url = new URL(shopifyOAuth.authorizationUrl(CALLBACK));
-    expect(url.origin).toBe("https://sites-shopify.deco.site");
+    expect(url.origin).toBe("https://mcp-commerce-store.deco.site");
   });
 });
 
@@ -167,7 +167,7 @@ describe("GET /oauth/custom", () => {
   });
 });
 
-describe("GET /oauth/shopify/callback", () => {
+describe("GET /oauth/store/callback", () => {
   function callbackUrl(overrides: Record<string, string> = {}): string {
     const state = signState({ cb: CALLBACK }, SECRET);
     const base: Record<string, string> = {

--- a/shopify/server/lib/oauth.ts
+++ b/shopify/server/lib/oauth.ts
@@ -13,7 +13,7 @@
  *   2. `/oauth/custom` renders a form; on submit it 302s to Shopify's
  *      `/admin/oauth/authorize` with `redirect_uri` pointing back at us and the
  *      mesh callback URL signed into `state`.
- *   3. Shopify → `/oauth/shopify/callback?code&shop&state&hmac`. We verify the
+ *   3. Shopify → `/oauth/store/callback?code&shop&state&hmac`. We verify the
  *      HMAC + state, exchange the code for an *expiring* offline token, seal the
  *      `{shop, access, refresh, expiresIn}` grant into an encrypted blob, and
  *      302 back to the mesh callback with it as `code`.
@@ -41,7 +41,9 @@ import {
 } from "./token.ts";
 
 export const OAUTH_CONNECT_PATH = "/oauth/custom";
-export const OAUTH_CALLBACK_PATH = "/oauth/shopify/callback";
+// Kept free of the "shopify" token (Shopify forbids it in app URLs) and distinct
+// from `/oauth/callback`, which the runtime mounts on this same origin.
+export const OAUTH_CALLBACK_PATH = "/oauth/store/callback";
 
 /**
  * Scopes requested during the grant. Almost all are read scopes; `write_themes`
@@ -82,7 +84,7 @@ export function getScopes(): string {
 
 /** This MCP's own public origin. Deployed at a fixed domain, so we default to
  * it; override with SELF_URL for local dev (e.g. http://localhost:8001). */
-const DEFAULT_SELF_URL = "https://sites-shopify.deco.site";
+const DEFAULT_SELF_URL = "https://mcp-commerce-store.deco.site";
 
 interface OAuthEnv {
   clientId: string;
@@ -374,7 +376,7 @@ function handleConnect(url: URL, env: OAuthEnv): Response {
   return Response.redirect(authorize.toString(), 302);
 }
 
-/** GET /oauth/shopify/callback — validate Shopify's redirect, exchange the code
+/** GET /oauth/store/callback — validate Shopify's redirect, exchange the code
  * for an expiring offline token, seal the grant, and bounce back to the mesh
  * callback. */
 async function handleCallback(url: URL, env: OAuthEnv): Promise<Response> {


### PR DESCRIPTION
## Why

Shopify forbids the word **"shopify"** in an app's URLs (callback + host). The Shopify MCP's OAuth flow used it in both:

- callback path `…/oauth/shopify/callback`
- host `sites-shopify.deco.site`

## What

- **Callback path:** `/oauth/shopify/callback` → `/oauth/store/callback`
  - Not `/oauth/callback` — that path is where the runtime mounts its own OAuth callback on this same origin, so it would collide.
- **Host:** `sites-shopify.deco.site` → `mcp-commerce-store.deco.site`
  - `app.json` `connection.url` + `DEFAULT_SELF_URL` in `oauth.ts`.
- Tests updated — **22 pass**.

The connect page (`/oauth/custom`) was already clean.

## Follow-ups (external, not in this PR)

- [ ] **Infra:** point `mcp-commerce-store.deco.site` at the service. The platform's automatic domain is `sites-<site>.deco.site`, so this host needs a custom-domain mapping (the `deploy.json` `site` field is left as `shopify` — it's just the internal deploy identity and isn't merchant-facing).
- [ ] **Shopify Partners:** register `https://mcp-commerce-store.deco.site/oauth/store/callback` in the app's redirect allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes "shopify" from public OAuth URLs to comply with Shopify’s URL policy. Callback path changes from /oauth/shopify/callback to /oauth/store/callback, and the default public origin changes from https://sites-shopify.deco.site to https://mcp-commerce-store.deco.site; `app.json` and `registry.json` now point to the new host.

- Rollout
  - Map mcp-commerce-store.deco.site to the service.
  - Add https://mcp-commerce-store.deco.site/oauth/store/callback to the Shopify app’s redirect allowlist.

<sup>Written for commit 8fff1eb2762084f94d354501b832ec0abcadf2da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

