### PR TITLE
feat(vtex): add Sales Performance analytics tools (cards, trend, table)

### DIFF
--- a/vtex/server/tools/custom/sales-performance.test.ts
+++ b/vtex/server/tools/custom/sales-performance.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildSalesPerformanceCardsUrl,
+  buildSalesPerformanceTableUrl,
+  buildSalesPerformanceTrendUrl,
+  DEFAULT_SALES_PERFORMANCE_METRICS,
+  mapMetricsToParams,
+} from "./sales-performance.ts";
+
+const dates = {
+  startDate: "2026-08-11T03:00:00.000Z",
+  endDate: "2026-08-18T02:59:59.000Z",
+  compareStartDate: "2026-08-04T03:00:00.000Z",
+  compareEndDate: "2026-08-11T02:59:59.000Z",
+};
+
+describe("mapMetricsToParams", () => {
+  test("maps an ordered list to metric1..metricN", () => {
+    expect(mapMetricsToParams(["capturedRevenue", "capturedOrders"])).toEqual({
+      metric1: "capturedRevenue",
+      metric2: "capturedOrders",
+    });
+  });
+});
+
+describe("buildSalesPerformanceCardsUrl", () => {
+  test("matches admin dashboard query shape without encoded colons", () => {
+    const url = buildSalesPerformanceCardsUrl("torratorra", {
+      currency: "BRL",
+      ...dates,
+      metrics: DEFAULT_SALES_PERFORMANCE_METRICS,
+    });
+
+    expect(url).toBe(
+      "https://torratorra.myvtex.com/api/analytics/consumption/sp-cards?an=torratorra&currency=BRL&startDate=2026-08-11T03:00:00.000Z&endDate=2026-08-18T02:59:59.000Z&compareStartDate=2026-08-04T03:00:00.000Z&compareEndDate=2026-08-11T02:59:59.000Z&metric1=capturedRevenue&metric2=capturedOrders&metric3=capturedAverageTicket&metric4=itemsPerOrder&metric5=averageSellingPrice",
+    );
+    expect(url).not.toContain("%3A");
+  });
+});
+
+describe("buildSalesPerformanceTrendUrl", () => {
+  test("includes single metric, agg and timezone", () => {
+    const url = buildSalesPerformanceTrendUrl("torratorra", {
+      currency: "BRL",
+      metric: "capturedRevenue",
+      agg: "day",
+      timezone: "-03:00",
+      ...dates,
+    });
+
+    expect(url).toBe(
+      "https://torratorra.myvtex.com/api/analytics/consumption/sp-graphic?an=torratorra&currency=BRL&metric1=capturedRevenue&agg=day&timezone=-03:00&startDate=2026-08-11T03:00:00.000Z&endDate=2026-08-18T02:59:59.000Z&compareStartDate=2026-08-04T03:00:00.000Z&compareEndDate=2026-08-11T02:59:59.000Z",
+    );
+    expect(url).not.toContain("%3A");
+  });
+});
+
+describe("buildSalesPerformanceTableUrl", () => {
+  test("matches the shared endpoint query shape", () => {
+    const url = buildSalesPerformanceTableUrl("torratorra", {
+      currency: "BRL",
+      groupBy: "productName",
+      metrics: DEFAULT_SALES_PERFORMANCE_METRICS,
+      sortBy: "capturedRevenue",
+      sortOrientation: "DESC",
+      sortType: "percentage",
+      itemsPerPage: 10,
+      startIndex: 0,
+      ...dates,
+    });
+
+    expect(url).toBe(
+      "https://torratorra.myvtex.com/api/analytics/consumption/sp-item-detail-table?an=torratorra&currency=BRL&sortBy=capturedRevenue&sortOrientation=DESC&sortType=percentage&itemsPerPage=10&groupByDim=productName&startDate=2026-08-11T03:00:00.000Z&endDate=2026-08-18T02:59:59.000Z&compareStartDate=2026-08-04T03:00:00.000Z&compareEndDate=2026-08-11T02:59:59.000Z&metric1=capturedRevenue&metric2=capturedOrders&metric3=capturedAverageTicket&metric4=itemsPerOrder&metric5=averageSellingPrice&startIndex=0",
+    );
+    expect(url).not.toContain("%3A");
+  });
+});

--- a/vtex/server/tools/custom/sales-performance.ts
+++ b/vtex/server/tools/custom/sales-performance.ts
@@ -1,0 +1,323 @@
+import { createTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import type { Env } from "../../types/env.ts";
+import {
+  analyticsCompareEndDateSchema,
+  analyticsCompareStartDateSchema,
+  analyticsCurrencySchema,
+  analyticsEndDateSchema,
+  analyticsStartDateSchema,
+  analyticsTimezoneSchema,
+  buildAnalyticsConsumptionUrl,
+  fetchAnalyticsConsumption,
+} from "./analytics-consumption.ts";
+import { resolveAnalyticsDateRange } from "./orders-oms.ts";
+
+/**
+ * Reverse-engineered from the admin "Performance de vendas" (Sales Performance)
+ * dashboard. All three endpoints live under
+ * `/api/analytics/consumption/{path}` and use the same VtexId session auth as
+ * the home-analytics tools. See `.context/sales-performance-api-spec.md`.
+ */
+
+/** Valid `metricN` values accepted by the sales-performance endpoints. */
+export const SALES_PERFORMANCE_METRICS = [
+  "capturedRevenue",
+  "approvedRevenue",
+  "invoicedRevenue",
+  "canceledRevenue",
+  "capturedOrders",
+  "approvedOrders",
+  "invoicedOrders",
+  "canceledOrders",
+  "capturedItems",
+  "approvedItems",
+  "invoicedItems",
+  "canceledItems",
+  "capturedAverageTicket",
+  "approvedAverageTicket",
+  "invoicedAverageTicket",
+  "canceledAverageTicket",
+  "itemsPerOrder",
+  "packagesPerOrder",
+  "averageSellingPrice",
+  "averageShippingPrice",
+] as const;
+
+/** Valid `groupByDim` values for the item detail table. */
+export const SALES_PERFORMANCE_GROUP_BY = [
+  "productName",
+  "category",
+  "brand",
+  "marketplaceName",
+  "deliveryMethod",
+  "shippingOption",
+  "destinationCity",
+  "destinationState",
+  "sellerName",
+  "paymentMethod",
+  "ownershipProduct",
+  "campaign",
+  "coupon",
+  "tradePolicy",
+  "promotion",
+  "utmCampaign",
+  "utmSource",
+] as const;
+
+/** The five metrics the dashboard shows by default. */
+export const DEFAULT_SALES_PERFORMANCE_METRICS = [
+  "capturedRevenue",
+  "capturedOrders",
+  "capturedAverageTicket",
+  "itemsPerOrder",
+  "averageSellingPrice",
+] as const;
+
+const salesMetricSchema = z.enum(SALES_PERFORMANCE_METRICS);
+
+const salesMetricsListSchema = z
+  .array(salesMetricSchema)
+  .min(1)
+  .max(5)
+  .default([...DEFAULT_SALES_PERFORMANCE_METRICS])
+  .describe(
+    "Metrics to return, 1-5 (mapped to metric1..metric5). Endpoints expect at least two. Values: revenue/orders/items/averageTicket in captured|approved|invoiced|canceled variants, plus itemsPerOrder, packagesPerOrder, averageSellingPrice, averageShippingPrice.",
+  );
+
+const salesAggSchema = z
+  .enum(["hour", "day", "week", "month"])
+  .default("day")
+  .describe("Time bucket granularity for the trend chart");
+
+/** Map an ordered metric list to `metric1`..`metricN` query params. */
+export function mapMetricsToParams(
+  metrics: readonly string[],
+): Record<string, string> {
+  return metrics.reduce<Record<string, string>>((acc, metric, index) => {
+    acc[`metric${index + 1}`] = metric;
+    return acc;
+  }, {});
+}
+
+export function buildSalesPerformanceCardsUrl(
+  accountName: string,
+  params: {
+    currency: string;
+    startDate: string;
+    endDate: string;
+    compareStartDate: string;
+    compareEndDate: string;
+    metrics: readonly string[];
+  },
+): string {
+  return buildAnalyticsConsumptionUrl(accountName, "sp-cards", {
+    an: accountName,
+    currency: params.currency,
+    startDate: params.startDate,
+    endDate: params.endDate,
+    compareStartDate: params.compareStartDate,
+    compareEndDate: params.compareEndDate,
+    ...mapMetricsToParams(params.metrics),
+  });
+}
+
+export function buildSalesPerformanceTrendUrl(
+  accountName: string,
+  params: {
+    currency: string;
+    metric: string;
+    agg: string;
+    timezone: string;
+    startDate: string;
+    endDate: string;
+    compareStartDate: string;
+    compareEndDate: string;
+  },
+): string {
+  return buildAnalyticsConsumptionUrl(accountName, "sp-graphic", {
+    an: accountName,
+    currency: params.currency,
+    metric1: params.metric,
+    agg: params.agg,
+    timezone: params.timezone,
+    startDate: params.startDate,
+    endDate: params.endDate,
+    compareStartDate: params.compareStartDate,
+    compareEndDate: params.compareEndDate,
+  });
+}
+
+export function buildSalesPerformanceTableUrl(
+  accountName: string,
+  params: {
+    currency: string;
+    groupBy: string;
+    metrics: readonly string[];
+    sortBy: string;
+    sortOrientation: string;
+    sortType: string;
+    itemsPerPage: number;
+    startIndex: number;
+    startDate: string;
+    endDate: string;
+    compareStartDate: string;
+    compareEndDate: string;
+  },
+): string {
+  return buildAnalyticsConsumptionUrl(accountName, "sp-item-detail-table", {
+    an: accountName,
+    currency: params.currency,
+    sortBy: params.sortBy,
+    sortOrientation: params.sortOrientation,
+    sortType: params.sortType,
+    itemsPerPage: params.itemsPerPage,
+    groupByDim: params.groupBy,
+    startDate: params.startDate,
+    endDate: params.endDate,
+    compareStartDate: params.compareStartDate,
+    compareEndDate: params.compareEndDate,
+    ...mapMetricsToParams(params.metrics),
+    startIndex: params.startIndex,
+  });
+}
+
+export const getSalesPerformanceSummary = (_env: Env) =>
+  createTool({
+    id: "VTEX_GET_SALES_PERFORMANCE_SUMMARY",
+    description:
+      "Get the admin Sales Performance (Performance de vendas) KPI summary cards — reference window vs a comparison window — for revenue, orders, items, average ticket, etc. Internal analytics service (App Key/Token are exchanged for a session token under the hood). Defaults to today through now in BRL with the previous-day compare window.",
+    annotations: { readOnlyHint: true },
+    inputSchema: z.object({
+      startDate: analyticsStartDateSchema,
+      endDate: analyticsEndDateSchema,
+      compareStartDate: analyticsCompareStartDateSchema,
+      compareEndDate: analyticsCompareEndDateSchema,
+      currency: analyticsCurrencySchema,
+      metrics: salesMetricsListSchema,
+      timezone: analyticsTimezoneSchema,
+    }),
+    execute: async ({ context, runtimeContext }) => {
+      const env = runtimeContext.env as Env;
+      const { accountName, appKey, appToken } = env.MESH_REQUEST_CONTEXT.state;
+      const range = resolveAnalyticsDateRange(context);
+
+      return fetchAnalyticsConsumption(
+        { accountName, appKey, appToken },
+        "sp-cards",
+        {
+          an: accountName,
+          currency: context.currency,
+          ...range,
+          ...mapMetricsToParams(context.metrics),
+        },
+      );
+    },
+  });
+
+export const getSalesPerformanceTrend = (_env: Env) =>
+  createTool({
+    id: "VTEX_GET_SALES_PERFORMANCE_TREND",
+    description:
+      "Get the admin Sales Performance (Performance de vendas) time-series trend for a single metric, with reference and comparison series bucketed by hour/day/week/month. Internal analytics service (App Key/Token are exchanged for a session token under the hood). Defaults to today through now in BRL with daily buckets and the previous-day compare window.",
+    annotations: { readOnlyHint: true },
+    inputSchema: z.object({
+      startDate: analyticsStartDateSchema,
+      endDate: analyticsEndDateSchema,
+      compareStartDate: analyticsCompareStartDateSchema,
+      compareEndDate: analyticsCompareEndDateSchema,
+      currency: analyticsCurrencySchema,
+      metric: salesMetricSchema
+        .default("capturedRevenue")
+        .describe("The single metric to plot over time"),
+      agg: salesAggSchema,
+      timezone: analyticsTimezoneSchema,
+    }),
+    execute: async ({ context, runtimeContext }) => {
+      const env = runtimeContext.env as Env;
+      const { accountName, appKey, appToken } = env.MESH_REQUEST_CONTEXT.state;
+      const range = resolveAnalyticsDateRange(context);
+
+      return fetchAnalyticsConsumption(
+        { accountName, appKey, appToken },
+        "sp-graphic",
+        {
+          an: accountName,
+          currency: context.currency,
+          metric1: context.metric,
+          agg: context.agg,
+          timezone: context.timezone,
+          ...range,
+        },
+      );
+    },
+  });
+
+export const getSalesPerformanceTable = (_env: Env) =>
+  createTool({
+    id: "VTEX_GET_SALES_PERFORMANCE_TABLE",
+    description:
+      "Get the admin Sales Performance (Performance de vendas) detail table — sales metrics broken down and ranked by a dimension (product/SKU, category, brand, seller, payment method, UTM, coupon, etc.), reference window vs a comparison window. The first row is always the aggregate 'total'. Supports sorting and pagination. Internal analytics service (App Key/Token are exchanged for a session token under the hood). Defaults to today through now in BRL grouped by product, sorted by captured revenue.",
+    annotations: { readOnlyHint: true },
+    inputSchema: z.object({
+      startDate: analyticsStartDateSchema,
+      endDate: analyticsEndDateSchema,
+      compareStartDate: analyticsCompareStartDateSchema,
+      compareEndDate: analyticsCompareEndDateSchema,
+      currency: analyticsCurrencySchema,
+      groupBy: z
+        .enum(SALES_PERFORMANCE_GROUP_BY)
+        .default("productName")
+        .describe("Dimension to group and rank rows by"),
+      metrics: salesMetricsListSchema,
+      sortBy: salesMetricSchema
+        .default("capturedRevenue")
+        .describe("Metric to sort rows by (should be one of `metrics`)"),
+      sortOrientation: z
+        .enum(["DESC", "ASC"])
+        .default("DESC")
+        .describe("Sort direction"),
+      sortType: z
+        .enum(["percentage", "variation"])
+        .default("percentage")
+        .describe(
+          "Sort by percentage share (percentage) or by absolute variation vs the compare window (variation)",
+        ),
+      itemsPerPage: z
+        .number()
+        .int()
+        .min(1)
+        .max(250)
+        .default(10)
+        .describe("Rows per page"),
+      startIndex: z
+        .number()
+        .int()
+        .min(0)
+        .default(0)
+        .describe("0-based pagination offset"),
+      timezone: analyticsTimezoneSchema,
+    }),
+    execute: async ({ context, runtimeContext }) => {
+      const env = runtimeContext.env as Env;
+      const { accountName, appKey, appToken } = env.MESH_REQUEST_CONTEXT.state;
+      const range = resolveAnalyticsDateRange(context);
+
+      return fetchAnalyticsConsumption(
+        { accountName, appKey, appToken },
+        "sp-item-detail-table",
+        {
+          an: accountName,
+          currency: context.currency,
+          sortBy: context.sortBy,
+          sortOrientation: context.sortOrientation,
+          sortType: context.sortType,
+          itemsPerPage: context.itemsPerPage,
+          groupByDim: context.groupBy,
+          ...range,
+          ...mapMetricsToParams(context.metrics),
+          startIndex: context.startIndex,
+        },
+      );
+    },
+  });

--- a/vtex/server/tools/index.ts
+++ b/vtex/server/tools/index.ts
@@ -92,6 +92,11 @@ import {
   getHomeTopProducts,
   getHomeTopViewedProducts,
 } from "./custom/home-analytics.ts";
+import {
+  getSalesPerformanceSummary,
+  getSalesPerformanceTable,
+  getSalesPerformanceTrend,
+} from "./custom/sales-performance.ts";
 
 // ── Tool registry factories (env: Env) => Tool ────────────────────────────────
 const registryFactories = [
@@ -186,6 +191,10 @@ const customFactories = [
   getHomeMetricsSummary,
   getHomeTopViewedProducts,
   getHomeTopProducts,
+  // Sales Performance dashboard: KPI cards, trend chart, detail table (internal analytics)
+  getSalesPerformanceSummary,
+  getSalesPerformanceTrend,
+  getSalesPerformanceTable,
 ];
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## What

Adds three read-only MCP tools that wrap the VTEX admin **"Performance de vendas" (Sales Performance)** dashboard, under `/api/analytics/consumption/`:

| Tool | Endpoint | Returns |
|------|----------|---------|
| `VTEX_GET_SALES_PERFORMANCE_SUMMARY` | `sp-cards` | KPI summary cards (reference vs compare window) |
| `VTEX_GET_SALES_PERFORMANCE_TREND` | `sp-graphic` | single-metric time series (hour/day/week/month) |
| `VTEX_GET_SALES_PERFORMANCE_TABLE` | `sp-item-detail-table` | metrics broken down & ranked by a dimension |

`sp-item-detail-table` is the endpoint originally requested. The other two round out the same dashboard and reuse the same helpers.

## How

Follows the existing `custom/home-analytics.ts` pattern and reuses `fetchAnalyticsConsumption` / `resolveAnalyticsDateRange` (VtexId session-token auth, literal query strings so ISO colons aren't encoded). Registered in `server/tools/index.ts`.

## Payload possibilities (reverse-engineered live from the dashboard)

- **20 metric values** (`metric1`..`metric5`): `capturedRevenue`, `approvedRevenue`, `invoicedRevenue`, `canceledRevenue`, `captured/approved/invoiced/canceledOrders`, `…Items`, `…AverageTicket`, `itemsPerOrder`, `packagesPerOrder`, `averageSellingPrice`, `averageShippingPrice`.
- **17 `groupByDim` dimensions**: `productName` (default), `category`, `brand`, `marketplaceName`, `deliveryMethod`, `shippingOption`, `destinationCity`, `destinationState`, `sellerName`, `paymentMethod`, `ownershipProduct`, `campaign`, `coupon`, `tradePolicy`, `promotion`, `utmCampaign`, `utmSource`.
- **`sortType`**: `percentage` | `variation` (the UI "Representativa" toggle is client-side only, not an API value).
- **`sortOrientation`**: `DESC` | `ASC`; plus `itemsPerPage` / `startIndex` pagination.
- The dashboard's three "%" metrics (approved-orders %, invoiced-orders %, order breakage %) are computed client-side and are **not** valid API params (return 500) — deliberately excluded from the enum.

Full spec captured in `.context/sales-performance-api-spec.md` (gitignored).

## Test

- `bun test server/tools/custom/sales-performance.test.ts` → 4 pass (URL-shape assertions, incl. no `%3A` encoding).
- `bun test server/tools/custom/` → 35 pass.
- `bun run check` → no new type errors from these files (pre-existing errors are inside the `@decocms/runtime` dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three read-only VTEX analytics tools that expose the admin Sales Performance dashboard (KPI cards, single-metric trend, ranked breakdown table). This enables programmatic access via the existing analytics session flow without changing existing tools.

- Review notes
  - Tools → endpoints: VTEX_GET_SALES_PERFORMANCE_SUMMARY → sp-cards, VTEX_GET_SALES_PERFORMANCE_TREND → sp-graphic, VTEX_GET_SALES_PERFORMANCE_TABLE → sp-item-detail-table.
  - Reuses `fetchAnalyticsConsumption`, `resolveAnalyticsDateRange`, and the shared URL builder; timestamps stay literal (no encoded colons). Auth uses VtexId session from App Key/Token.
  - Input schemas enumerate 20 metrics and 17 groupBy dimensions; trend supports `hour|day|week|month`; table supports `sortType` (percentage|variation), `sortOrientation`, and pagination.
  - Registered in `vtex/server/tools/index.ts`. Tests assert URL shape and metric mapping (`bun test` passes).
  - No breaking changes or migrations. Consumers can call the new tool IDs directly.

<sup>Written for commit 719441924459a192524dde9e116453cb09880ad7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

