### PR TITLE
refactor(shopify): hardcode Admin API version (OAuth-only config)

### DIFF
--- a/shopify/server/lib/client.test.ts
+++ b/shopify/server/lib/client.test.ts
@@ -16,7 +16,6 @@ afterEach(() => {
   globalThis.fetch = originalFetch;
   delete process.env.SHOPIFY_STORE_DOMAIN;
   delete process.env.SHOPIFY_ACCESS_TOKEN;
-  delete process.env.SHOPIFY_API_VERSION;
   delete process.env.SHOPIFY_TOKEN_SECRET;
 });
 
@@ -79,7 +78,6 @@ describe("resolveCredentials", () => {
     });
     expect(creds.accessToken).toBe("shpat_abc123");
     expect(creds.storeDomain).toBe("my-store.myshopify.com");
-    expect(creds.apiVersion).toBe("2026-07");
     expect(creds.sources).toEqual({
       storeDomain: "state",
       accessToken: "authorization",
@@ -125,14 +123,6 @@ describe("resolveCredentials", () => {
     expect(creds.accessToken).toBe("");
     expect(creds.sources.accessToken).toBe("missing");
   });
-
-  test("respects apiVersion from state", () => {
-    const creds = resolveCredentials({
-      authorization: "Bearer t",
-      state: { storeDomain: "s", apiVersion: "2026-04" },
-    });
-    expect(creds.apiVersion).toBe("2026-04");
-  });
 });
 
 describe("assertValidCredentials", () => {
@@ -157,7 +147,6 @@ describe("buildGraphqlUrl", () => {
       buildGraphqlUrl({
         storeDomain: "my-store.myshopify.com",
         accessToken: "t",
-        apiVersion: "2026-07",
       }),
     ).toBe("https://my-store.myshopify.com/admin/api/2026-07/graphql.json");
   });
@@ -199,7 +188,6 @@ describe("flattenConnection", () => {
 const CREDS = {
   storeDomain: "my-store.myshopify.com",
   accessToken: "shpat_test",
-  apiVersion: "2026-07",
 };
 
 function mockFetch(

--- a/shopify/server/lib/client.ts
+++ b/shopify/server/lib/client.ts
@@ -37,7 +37,7 @@ export interface ResolvedCredentials extends ShopifyCredentials {
 
 export interface MeshRequestContext {
   authorization?: string | null;
-  state?: { storeDomain?: string; apiVersion?: string };
+  state?: { storeDomain?: string };
 }
 
 /**
@@ -57,8 +57,6 @@ export function resolveCredentials(
   ctx: MeshRequestContext | undefined,
 ): ResolvedCredentials {
   const state = ctx?.state ?? {};
-  const apiVersion =
-    state.apiVersion || process.env.SHOPIFY_API_VERSION || DEFAULT_API_VERSION;
 
   const rawAuth = ctx?.authorization
     ? ctx.authorization.replace(/^Bearer\s+/i, "").trim()
@@ -74,7 +72,6 @@ export function resolveCredentials(
       return {
         storeDomain: normalizeStoreDomain(sealed.shop),
         accessToken: sealed.token,
-        apiVersion,
         sources: { storeDomain: "oauth", accessToken: "oauth" },
       };
     }
@@ -104,7 +101,6 @@ export function resolveCredentials(
       ? normalizeStoreDomain(storeDomain.value)
       : "",
     accessToken: accessToken.value,
-    apiVersion,
     sources: {
       storeDomain: storeDomain.source,
       accessToken: accessToken.source,
@@ -130,8 +126,7 @@ export function assertValidCredentials(
 }
 
 export function buildGraphqlUrl(creds: ShopifyCredentials): string {
-  const version = creds.apiVersion || DEFAULT_API_VERSION;
-  return `https://${creds.storeDomain}/admin/api/${version}/graphql.json`;
+  return `https://${creds.storeDomain}/admin/api/${DEFAULT_API_VERSION}/graphql.json`;
 }
 
 interface GraphqlError {

--- a/shopify/server/types/env.ts
+++ b/shopify/server/types/env.ts
@@ -5,8 +5,7 @@ import { type DefaultEnv } from "@decocms/runtime";
 import { z } from "zod";
 
 // No connection config — auth is OAuth and the store comes from the token.
-// The Admin API version defaults to DEFAULT_API_VERSION; override per deploy
-// with the SHOPIFY_API_VERSION env var (see resolveCredentials).
+// The Admin API version is hardcoded (see DEFAULT_API_VERSION in constants.ts).
 export const StateSchema = z.object({});
 
 export type Env = DefaultEnv<typeof StateSchema>;
@@ -14,5 +13,4 @@ export type Env = DefaultEnv<typeof StateSchema>;
 export interface ShopifyCredentials {
   storeDomain: string;
   accessToken: string;
-  apiVersion?: string;
 }


### PR DESCRIPTION
## What

The Shopify connection form is already OAuth-only — `StateSchema` was reduced to `z.object({})` in #526, so there's no fillable domain/token/version field anymore (token comes from the OAuth `Authorization` header).

This PR removes the last piece of runtime-variable config: the Admin API **version is now hardcoded** to `DEFAULT_API_VERSION` (`2026-07`) instead of being resolved from `state.apiVersion` or the `SHOPIFY_API_VERSION` env var.

## Changes

- `server/types/env.ts` — drop `apiVersion` from `ShopifyCredentials`; update comment.
- `server/lib/client.ts` — remove the `state.apiVersion || SHOPIFY_API_VERSION || …` resolution and the `apiVersion` field on `MeshRequestContext.state` / resolved creds; `buildGraphqlUrl` uses `DEFAULT_API_VERSION` directly.
- `server/lib/client.test.ts` — drop the `apiVersion` cases/assertions.

## Notes

- Kept the local-dev env fallbacks (`SHOPIFY_STORE_DOMAIN` / `SHOPIFY_ACCESS_TOKEN`) and the legacy raw-token path — these aren't part of the connection schema and don't appear in the UI.
- All 58 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardcodes the Shopify Admin API version to `DEFAULT_API_VERSION` (`2026-07`) for the OAuth-only connection. Previously the version could be set via connection state or the `SHOPIFY_API_VERSION` env var; overrides are no longer supported to reduce config surface and prevent version drift.

- Remove any use of `apiVersion` in `ShopifyCredentials`, `MeshRequestContext.state`, and downstream consumers; the GraphQL URL builder always uses `DEFAULT_API_VERSION`.
- Stop setting `SHOPIFY_API_VERSION`; it has no effect.
- No changes to the UI or OAuth flow; local dev fallbacks (`SHOPIFY_STORE_DOMAIN`, `SHOPIFY_ACCESS_TOKEN`) remain.

<sup>Written for commit 33ea3117f17591f187333d052962503f3f7fccda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

