### PR TITLE
fix(vtex): correct sales-performance metrics param description (all-5-or-none)

### DIFF
--- a/vtex/server/tools/custom/sales-performance.ts
+++ b/vtex/server/tools/custom/sales-performance.ts
@@ -82,8 +82,14 @@ const salesMetricsListSchema = z
   .max(5)
   .default([...DEFAULT_SALES_PERFORMANCE_METRICS])
   .describe(
-    "Metrics to return, 1-5 (mapped to metric1..metric5). Endpoints expect at least two. Values: revenue/orders/items/averageTicket in captured|approved|invoiced|canceled variants, plus itemsPerOrder, packagesPerOrder, averageSellingPrice, averageShippingPrice.",
+    "Metrics to return, mapped to metric1..metric5. WARNING: despite the declared 1-5 item schema, the underlying endpoint only accepts EITHER the parameter fully omitted (returns all 5 defaults) OR all 5 metrics supplied explicitly — partial arrays (1-4 items) return HTTP 422; all 5 columns are always returned regardless. Values: revenue/orders/items/averageTicket in captured|approved|invoiced|canceled variants, plus itemsPerOrder, packagesPerOrder, averageSellingPrice, averageShippingPrice.",
   );
+
+// Table-specific variant: same all-5-or-none constraint, plus guidance to use
+// `sortBy` (not a partial `metrics` array) when ranking by a single metric.
+const salesTableMetricsListSchema = salesMetricsListSchema.describe(
+  "Metrics to return, mapped to metric1..metric5. WARNING: despite the declared 1-5 item schema, the underlying endpoint only accepts EITHER the parameter fully omitted (returns all 5 defaults) OR all 5 metrics supplied explicitly — partial arrays (1-4 items) return HTTP 422. To rank/sort by a specific metric, omit the `metrics` param entirely and use `sortBy` instead; all 5 columns are always returned regardless. Values: revenue/orders/items/averageTicket in captured|approved|invoiced|canceled variants, plus itemsPerOrder, packagesPerOrder, averageSellingPrice, averageShippingPrice.",
+);
 
 const salesAggSchema = z
   .enum(["hour", "day", "week", "month"])
@@ -269,7 +275,7 @@ export const getSalesPerformanceTable = (_env: Env) =>
         .enum(SALES_PERFORMANCE_GROUP_BY)
         .default("productName")
         .describe("Dimension to group and rank rows by"),
-      metrics: salesMetricsListSchema,
+      metrics: salesTableMetricsListSchema,
       sortBy: salesMetricSchema
         .default("capturedRevenue")
         .describe("Metric to sort rows by (should be one of `metrics`)"),


### PR DESCRIPTION
## What

Fixes the misleading `metrics` parameter description on the VTEX Sales Performance analytics tools.

The description claimed the endpoint *"expects at least two"* metrics. In reality the underlying analytics endpoint (`sp-cards` / `sp-item-detail-table`) only accepts the `metrics` param **fully omitted** (returns all 5 defaults) **or all 5 supplied explicitly** — any partial array of 1–4 items returns **HTTP 422**. The old wording led agents to send partial arrays and hit 422s.

## Changes

- Corrected `salesMetricsListSchema.describe(...)` (shared by `VTEX_GET_SALES_PERFORMANCE_CARDS` and `VTEX_GET_SALES_PERFORMANCE_TABLE`) to document the all-5-or-none constraint and the 422 behavior.
- Added a table-specific variant `salesTableMetricsListSchema` that also tells the agent to omit `metrics` and use `sortBy` when ranking by a single metric — `sortBy` only exists on the table tool, so that guidance is scoped to it and kept off the cards tool.

Description-only change (plus the schema alias wiring); no runtime behavior change.

## Notes / follow-ups

- The 422 / all-5-or-none behavior comes from a live report, not endpoint verification here. If confirmed, a stronger follow-up would be to **enforce** it in the schema (reject partial arrays at validation) rather than only warn in the description.
- Assumed `sp-cards` shares the same `metric1..metricN` constraint as the table (same param encoding + backend); if cards tolerates partial arrays, the shared warning can be narrowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies VTEX Sales Performance metrics parameter to reflect the endpoint’s all-5-or-none behavior and prevent 422 errors from partial arrays. Previously documented “at least two” is replaced with: omit `metrics` for defaults or provide all five; partial arrays return 422. Adds table-specific guidance to use `sortBy` for single-metric ranking. No runtime behavior change.

- Updated `salesMetricsListSchema.describe(...)` used by `VTEX_GET_SALES_PERFORMANCE_CARDS` and `VTEX_GET_SALES_PERFORMANCE_TABLE`.
- Added `salesTableMetricsListSchema` with `sortBy` guidance and wired it into the table tool; cards remain on the shared schema.
- Validation logic is unchanged; this is a description-only update to reduce agent misconfiguration.

<sup>Written for commit ddb01848e9f84b8fe2de9a6bd7845713d48586c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/mcps/pull/547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

