### PR TITLE
feat(wake): add Wake Commerce Storefront MCP (V1, read-only)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1157,6 +1157,20 @@
         "typescript": "^5.7.2",
       },
     },
+    "wake": {
+      "name": "wake",
+      "version": "1.0.0",
+      "dependencies": {
+        "@decocms/runtime": "^1.6.2",
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@decocms/mcps-shared": "1.0.0",
+        "@modelcontextprotocol/sdk": "^1.25.1",
+        "deco-cli": "^0.28.0",
+        "typescript": "^5.7.2",
+      },
+    },
     "whatsapp": {
       "name": "whatsappagent",
       "version": "1.0.0",
@@ -3724,6 +3738,8 @@
 
     "vtex-docs": ["vtex-docs@workspace:vtex-docs"],
 
+    "wake": ["wake@workspace:wake"],
+
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
 
     "weak-lru-cache": ["weak-lru-cache@1.0.0", "", {}, "sha512-135bPugHHIJLNx20guHgk4etZAbd7nou34NQfdKkJPgMuC3Oqn4cT6f7ORVvnud9oEyXJVJXPcTFsUvttGm5xg=="],
@@ -4576,6 +4592,12 @@
 
     "vtex-docs/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
+    "wake/@decocms/runtime": ["@decocms/runtime@1.6.5", "", { "dependencies": { "@ai-sdk/provider": "^3.0.10", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.29.0", "jose": "^6.0.11", "zod": "^4.0.0" }, "peerDependencies": { "ai": ">=6.0.0" } }, "sha512-r6O4z+ISJpBnhDw4x1K8IYNqfQ+xdwSjNcg6vDqU42I6x82H8snfAg/E6u9WfcMClap7sXxMAdKuDcEMxPq55A=="],
+
+    "wake/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "wake/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
     "whatsapp-management/@decocms/bindings": ["@decocms/bindings@1.4.9", "", { "dependencies": { "@decocms/mcp-utils": "^1.0.5", "@modelcontextprotocol/sdk": "1.29.0", "@tanstack/react-router": "1.169.2", "react": "^19.2.6", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-NvhuHsKL0YpSUaAZqEe0PAzF41/JJSi+H0X7HpMBScOVpALcGqAC+DaJvcKeo3aRXXW7z6du0oCdkhLf2A6Vjw=="],
 
     "whatsapp-management/@decocms/runtime": ["@decocms/runtime@1.1.3", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0", "@cloudflare/workers-types": "^4.20250617.0", "@decocms/bindings": "^1.0.7", "@modelcontextprotocol/sdk": "1.25.1", "hono": "^4.10.7", "jose": "^6.0.11", "zod": "^4.0.0" } }, "sha512-pj6OccmpWulMjyOt9FHTNX41xHk800uzhmoYK/xq9h1f+DfDBMqyOZnt70Zmwrab7dMDO2w3VQD+NlgFKtrw1w=="],
@@ -5195,6 +5217,10 @@
     "vtex/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 
     "vtex/vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "wake/@decocms/runtime/@decocms/bindings": ["@decocms/bindings@1.4.9", "", { "dependencies": { "@decocms/mcp-utils": "^1.0.5", "@modelcontextprotocol/sdk": "1.29.0", "@tanstack/react-router": "1.169.2", "react": "^19.2.6", "zod": "^4.0.0", "zod-from-json-schema": "^0.5.2" } }, "sha512-NvhuHsKL0YpSUaAZqEe0PAzF41/JJSi+H0X7HpMBScOVpALcGqAC+DaJvcKeo3aRXXW7z6du0oCdkhLf2A6Vjw=="],
+
+    "wake/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 
     "whatsapp-management/@decocms/bindings/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
@@ -6030,6 +6056,8 @@
 
     "vtex/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
+    "wake/@decocms/runtime/@decocms/bindings/@tanstack/react-router": ["@tanstack/react-router@1.169.2", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.169.2", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-OJM7Kguc7ERnweaNRWsyWgIKcl3z23rD1B4jaxjzd9RGdnzpt2HfrWa9rggbT0Hfzhfo4D2ZmsfoTme035tniQ=="],
+
     "whatsapp-management/@decocms/bindings/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 
     "whatsapp-management/@decocms/bindings/@tanstack/react-router/@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
@@ -6645,6 +6673,10 @@
     "vtex-docs/@decocms/runtime/@decocms/bindings/@tanstack/react-router/@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
 
     "vtex-docs/@decocms/runtime/@decocms/bindings/@tanstack/react-router/@tanstack/router-core": ["@tanstack/router-core@1.169.2", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-5sm0DJF1A7Mz+9gy4Gz/lLovNailK3yot4vYvz9MkBUPw26uLnhQiR8hSCYxucjE0wD6Mdlc5l+Z0/XTlZ7xHw=="],
+
+    "wake/@decocms/runtime/@decocms/bindings/@tanstack/react-router/@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
+
+    "wake/@decocms/runtime/@decocms/bindings/@tanstack/react-router/@tanstack/router-core": ["@tanstack/router-core@1.169.2", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.4", "seroval-plugins": "^1.5.4" } }, "sha512-5sm0DJF1A7Mz+9gy4Gz/lLovNailK3yot4vYvz9MkBUPw26uLnhQiR8hSCYxucjE0wD6Mdlc5l+Z0/XTlZ7xHw=="],
 
     "whatsapp-management/deco-cli/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 

--- a/deploy.json
+++ b/deploy.json
@@ -511,5 +511,14 @@
       "shopify/**",
       "shared/**"
     ]
+  },
+  "wake": {
+    "site": "wake",
+    "entrypoint": "./dist/server/main.js",
+    "platformName": "kubernetes-bun",
+    "watch": [
+      "wake/**",
+      "shared/**"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "virtual-try-on",
     "vtex",
     "vtex-docs",
+    "wake",
     "whatsapp",
     "whatsapp-management",
     "whisper",

--- a/registry.json
+++ b/registry.json
@@ -3404,6 +3404,54 @@
     }
   },
   {
+    "id": "deco/wake",
+    "title": "Wake Commerce",
+    "description": "Read-only access to the Wake Commerce Storefront API — product search, catalog navigation, product detail, recommendations and shipping quotes.",
+    "is_public": true,
+    "_meta": {
+      "mcp.mesh": {
+        "verified": false,
+        "friendly_name": "Wake Commerce",
+        "short_description": "Search and browse a Wake Commerce storefront catalog.",
+        "owner": "deco",
+        "has_remote": true,
+        "has_oauth": false,
+        "tags": [
+          "wake",
+          "fbits",
+          "ecommerce",
+          "storefront",
+          "catalog",
+          "search",
+          "products"
+        ],
+        "categories": [
+          "E-commerce"
+        ],
+        "readme": "The Wake Commerce MCP exposes read-only access to the Wake (fbits) Storefront GraphQL API, letting AI agents explore an e-commerce catalog. **Key Features** — Full-text product **search** with facet aggregations and price ranges; explicit product **listing** by id, sku, ean, category, brand, price and attributes; rich product **detail** with variants, prices and reviews; search-as-you-type **autocomplete**; product **recommendations**; **hotsite** (category / landing page) resolution; variant **options**; **buy lists** (kits); **shipping quotes** by postal code; and store metadata. **Authentication** — Configure your Wake Storefront API token (sent as the TCS-Access-Token header). Perfect for building shopping assistants, catalog explorers and storefront automations on top of Wake Commerce."
+      }
+    },
+    "server": {
+      "name": "wake",
+      "title": "Wake Commerce",
+      "description": "Read-only access to the Wake Commerce Storefront API — product search, catalog navigation, product detail, recommendations and shipping quotes.",
+      "icons": [
+        {
+          "src": "https://raw.githubusercontent.com/deco-cx/apps/main/wake/logo.png"
+        }
+      ],
+      "remotes": [
+        {
+          "type": "HTTP",
+          "url": "https://sites-wake.deco.site/mcp",
+          "name": "wake",
+          "title": "Wake Commerce",
+          "description": "Read-only access to the Wake Commerce Storefront API — product search, catalog navigation, product detail, recommendations and shipping quotes."
+        }
+      ]
+    }
+  },
+  {
     "id": "deco/whatsapp-agent",
     "title": "Deco WhatsApp Agent",
     "description": "Talk to your Mesh Agents via WhatsApp",

--- a/registry.json
+++ b/registry.json
@@ -3404,54 +3404,6 @@
     }
   },
   {
-    "id": "deco/wake",
-    "title": "Wake Commerce",
-    "description": "Read-only access to the Wake Commerce Storefront API — product search, catalog navigation, product detail, recommendations and shipping quotes.",
-    "is_public": true,
-    "_meta": {
-      "mcp.mesh": {
-        "verified": false,
-        "friendly_name": "Wake Commerce",
-        "short_description": "Search and browse a Wake Commerce storefront catalog.",
-        "owner": "deco",
-        "has_remote": true,
-        "has_oauth": false,
-        "tags": [
-          "wake",
-          "fbits",
-          "ecommerce",
-          "storefront",
-          "catalog",
-          "search",
-          "products"
-        ],
-        "categories": [
-          "E-commerce"
-        ],
-        "readme": "The Wake Commerce MCP exposes read-only access to the Wake (fbits) Storefront GraphQL API, letting AI agents explore an e-commerce catalog. **Key Features** — Full-text product **search** with facet aggregations and price ranges; explicit product **listing** by id, sku, ean, category, brand, price and attributes; rich product **detail** with variants, prices and reviews; search-as-you-type **autocomplete**; product **recommendations**; **hotsite** (category / landing page) resolution; variant **options**; **buy lists** (kits); **shipping quotes** by postal code; and store metadata. **Authentication** — Configure your Wake Storefront API token (sent as the TCS-Access-Token header). Perfect for building shopping assistants, catalog explorers and storefront automations on top of Wake Commerce."
-      }
-    },
-    "server": {
-      "name": "wake",
-      "title": "Wake Commerce",
-      "description": "Read-only access to the Wake Commerce Storefront API — product search, catalog navigation, product detail, recommendations and shipping quotes.",
-      "icons": [
-        {
-          "src": "https://raw.githubusercontent.com/deco-cx/apps/main/wake/logo.png"
-        }
-      ],
-      "remotes": [
-        {
-          "type": "HTTP",
-          "url": "https://sites-wake.deco.site/mcp",
-          "name": "wake",
-          "title": "Wake Commerce",
-          "description": "Read-only access to the Wake Commerce Storefront API — product search, catalog navigation, product detail, recommendations and shipping quotes."
-        }
-      ]
-    }
-  },
-  {
     "id": "deco/whatsapp-agent",
     "title": "Deco WhatsApp Agent",
     "description": "Talk to your Mesh Agents via WhatsApp",

--- a/wake/.env.example
+++ b/wake/.env.example
@@ -1,0 +1,3 @@
+# Shared secret that guards the MCP endpoint (withAuth). Generate with:
+#   openssl rand -hex 32
+AUTH_TOKEN=

--- a/wake/.gitignore
+++ b/wake/.gitignore
@@ -1,0 +1,4 @@
+.dev.vars
+.env
+dist/
+node_modules/

--- a/wake/README.md
+++ b/wake/README.md
@@ -1,17 +1,21 @@
 # Wake Commerce MCP
 
-Read-only access to the [Wake Commerce](https://wake.tech/) (fbits) **Storefront
-GraphQL API** for AI agents — product search, catalog navigation, product
-detail, recommendations and shipping quotes.
+Read-only access to [Wake Commerce](https://wake.tech/) (fbits) for AI agents:
 
-This is **V1**: storefront reads only. Cart, wishlist, customer and Admin (REST)
-operations are intentionally out of scope for now.
+- **Storefront GraphQL API** — product search, catalog navigation, product
+  detail, recommendations and shipping quotes.
+- **Admin REST API** — store-level orders for analysis and reporting (admin,
+  not per-shopper).
+
+Cart, wishlist and customer/session operations are intentionally out of scope
+for now.
 
 ## Configuration
 
 | Field | Required | Description |
 | --- | --- | --- |
-| `storefrontToken` | ✅ | Wake Storefront API token, sent as the `TCS-Access-Token` header. [How to create one](https://wakecommerce.readme.io/docs/storefront-api-criacao-e-autenticacao-do-token). |
+| `storefrontToken` | ✅ | Wake Storefront API token, sent as the `TCS-Access-Token` header. Powers all catalog/product tools. [How to create one](https://wakecommerce.readme.io/docs/storefront-api-criacao-e-autenticacao-do-token). |
+| `apiToken` | — | Wake Admin API token, sent as `Authorization: Basic <token>` for `api.fbits.net`. Required only for the admin order tools. |
 | `account` | — | Wake account name (e.g. `erploja2`). Reference only. |
 
 The MCP endpoint itself is protected by `withAuth`, which reads the `AUTH_TOKEN`
@@ -19,8 +23,11 @@ environment variable at startup (generate with `openssl rand -hex 32`).
 
 The Storefront API is a single fixed endpoint
 (`https://storefront-api.fbits.net/graphql`); the token identifies the store.
+The Admin API is served from `https://api.fbits.net`.
 
 ## Tools
+
+### Storefront (catalog) — requires `storefrontToken`
 
 | Tool | Description |
 | --- | --- |
@@ -35,6 +42,15 @@ The Storefront API is a single fixed endpoint
 | `WAKE_SHOP_INFO` | Storefront metadata (name, URLs, checkout URLs). |
 | `WAKE_RESOLVE_URL` | Resolve a storefront URL path to its route kind. |
 | `WAKE_SHIPPING_QUOTES` | Shipping options (price, deadline) for a variant to a CEP. |
+
+### Admin (orders / analytics) — requires `apiToken`
+
+| Tool | Description |
+| --- | --- |
+| `WAKE_LIST_ORDERS` | List store orders by date range, status, payment method, customer or SKU; paginated. |
+| `WAKE_GET_ORDER` | Full detail of a single order by id. |
+| `WAKE_GET_ORDER_STATUS_HISTORY` | Status change history (timeline) of an order. |
+| `WAKE_LIST_ORDER_STATUSES` | All order statuses configured in the store (to map ids before filtering). |
 
 ## Development
 

--- a/wake/README.md
+++ b/wake/README.md
@@ -1,0 +1,51 @@
+# Wake Commerce MCP
+
+Read-only access to the [Wake Commerce](https://wake.tech/) (fbits) **Storefront
+GraphQL API** for AI agents — product search, catalog navigation, product
+detail, recommendations and shipping quotes.
+
+This is **V1**: storefront reads only. Cart, wishlist, customer and Admin (REST)
+operations are intentionally out of scope for now.
+
+## Configuration
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `storefrontToken` | ✅ | Wake Storefront API token, sent as the `TCS-Access-Token` header. [How to create one](https://wakecommerce.readme.io/docs/storefront-api-criacao-e-autenticacao-do-token). |
+| `account` | — | Wake account name (e.g. `erploja2`). Reference only. |
+
+The MCP endpoint itself is protected by `withAuth`, which reads the `AUTH_TOKEN`
+environment variable at startup (generate with `openssl rand -hex 32`).
+
+The Storefront API is a single fixed endpoint
+(`https://storefront-api.fbits.net/graphql`); the token identifies the store.
+
+## Tools
+
+| Tool | Description |
+| --- | --- |
+| `WAKE_SEARCH_PRODUCTS` | Full-text catalog search with facet aggregations and price ranges. |
+| `WAKE_LIST_PRODUCTS` | List products by explicit filters (id, sku, ean, category, brand, price, attributes); cursor-paginated. |
+| `WAKE_GET_PRODUCT` | Full product detail: variants, attribute selections, prices, reviews, SEO. |
+| `WAKE_AUTOCOMPLETE` | Search-as-you-type suggestions plus matching products. |
+| `WAKE_PRODUCT_RECOMMENDATIONS` | Products recommended for a given product. |
+| `WAKE_GET_HOTSITE` | Resolve a category / landing page by URL or id, with its products. |
+| `WAKE_PRODUCT_OPTIONS` | Selectable attributes (color, size, …) and their variants. |
+| `WAKE_GET_BUYLIST` | Buy list (kit / combo) by id, with component products. |
+| `WAKE_SHOP_INFO` | Storefront metadata (name, URLs, checkout URLs). |
+| `WAKE_RESOLVE_URL` | Resolve a storefront URL path to its route kind. |
+| `WAKE_SHIPPING_QUOTES` | Shipping options (price, deadline) for a variant to a CEP. |
+
+## Development
+
+```bash
+bun install          # from the monorepo root
+cd wake
+bun run dev          # hot-reload dev server
+bun run check        # type-check
+bun run build        # build server bundle
+```
+
+The GraphQL fragments and queries are mirrored from the production-proven
+[deco.cx Wake app](https://github.com/deco-cx/apps/tree/main/wake) so they stay
+valid against the live Storefront API.

--- a/wake/app.json
+++ b/wake/app.json
@@ -1,0 +1,19 @@
+{
+  "scopeName": "deco",
+  "name": "wake",
+  "friendlyName": "Wake Commerce",
+  "connection": {
+    "type": "HTTP",
+    "url": "https://sites-wake.deco.site/mcp"
+  },
+  "description": "Read-only access to the Wake Commerce Storefront API — product search, catalog navigation, product detail, recommendations and shipping quotes.",
+  "icon": "https://raw.githubusercontent.com/deco-cx/apps/main/wake/logo.png",
+  "unlisted": false,
+  "metadata": {
+    "categories": ["E-commerce", "Developer Tools"],
+    "official": false,
+    "tags": ["wake", "fbits", "ecommerce", "storefront", "catalog", "search", "products"],
+    "short_description": "Search and browse a Wake Commerce storefront catalog.",
+    "mesh_description": "The Wake Commerce MCP exposes read-only access to the Wake (fbits) Storefront GraphQL API, letting AI agents explore an e-commerce catalog. **Key Features** — Full-text product **search** with facet aggregations and price ranges; explicit product **listing** by id, sku, ean, category, brand, price and attributes; rich product **detail** with variants, prices and reviews; search-as-you-type **autocomplete**; product **recommendations**; **hotsite** (category / landing page) resolution; variant **options**; **buy lists** (kits); **shipping quotes** by postal code; and store metadata. **Authentication** — Configure your Wake Storefront API token (sent as the TCS-Access-Token header). Perfect for building shopping assistants, catalog explorers and storefront automations on top of Wake Commerce."
+  }
+}

--- a/wake/app.json
+++ b/wake/app.json
@@ -8,7 +8,7 @@
   },
   "description": "Read-only access to the Wake Commerce Storefront API — product search, catalog navigation, product detail, recommendations and shipping quotes.",
   "icon": "https://raw.githubusercontent.com/deco-cx/apps/main/wake/logo.png",
-  "unlisted": false,
+  "unlisted": true,
   "metadata": {
     "categories": ["E-commerce", "Developer Tools"],
     "official": false,

--- a/wake/app.json
+++ b/wake/app.json
@@ -6,14 +6,14 @@
     "type": "HTTP",
     "url": "https://sites-wake.deco.site/mcp"
   },
-  "description": "Read-only access to the Wake Commerce Storefront API — product search, catalog navigation, product detail, recommendations and shipping quotes.",
+  "description": "Read-only access to Wake Commerce — Storefront catalog (search, product detail, recommendations, shipping) plus Admin orders for analytics.",
   "icon": "https://raw.githubusercontent.com/deco-cx/apps/main/wake/logo.png",
   "unlisted": true,
   "metadata": {
     "categories": ["E-commerce", "Developer Tools"],
     "official": false,
-    "tags": ["wake", "fbits", "ecommerce", "storefront", "catalog", "search", "products"],
-    "short_description": "Search and browse a Wake Commerce storefront catalog.",
-    "mesh_description": "The Wake Commerce MCP exposes read-only access to the Wake (fbits) Storefront GraphQL API, letting AI agents explore an e-commerce catalog. **Key Features** — Full-text product **search** with facet aggregations and price ranges; explicit product **listing** by id, sku, ean, category, brand, price and attributes; rich product **detail** with variants, prices and reviews; search-as-you-type **autocomplete**; product **recommendations**; **hotsite** (category / landing page) resolution; variant **options**; **buy lists** (kits); **shipping quotes** by postal code; and store metadata. **Authentication** — Configure your Wake Storefront API token (sent as the TCS-Access-Token header). Perfect for building shopping assistants, catalog explorers and storefront automations on top of Wake Commerce."
+    "tags": ["wake", "fbits", "ecommerce", "storefront", "catalog", "search", "products", "orders", "analytics"],
+    "short_description": "Search a Wake storefront catalog and analyze store orders.",
+    "mesh_description": "The Wake Commerce MCP exposes read-only access to Wake (fbits) for AI agents. **Storefront (catalog)** — full-text product **search** with facet aggregations and price ranges; explicit product **listing** by id, sku, ean, category, brand, price and attributes; rich product **detail** with variants, prices and reviews; **autocomplete**; product **recommendations**; **hotsite** (category / landing page) resolution; variant **options**; **buy lists** (kits); **shipping quotes**; and store metadata. **Admin (orders / analytics)** — list store **orders** by date range, status, payment method, customer or SKU; fetch order **detail** and **status history**; and list configured **order statuses**. **Authentication** — Storefront token (TCS-Access-Token header) for catalog tools; Admin API token (Basic auth) for order tools. Perfect for shopping assistants, catalog explorers and sales/order analytics on top of Wake Commerce."
   }
 }

--- a/wake/package.json
+++ b/wake/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "wake",
+  "version": "1.0.0",
+  "description": "MCP for the Wake Commerce Storefront API — product search, catalog, and shipping.",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun run --hot server/main.ts",
+    "check": "tsc --noEmit",
+    "build:server": "NODE_ENV=production bun build server/main.ts --target=bun --outfile=dist/server/main.js",
+    "build": "bun run build:server"
+  },
+  "dependencies": {
+    "@decocms/runtime": "^1.6.2",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@decocms/mcps-shared": "1.0.0",
+    "@modelcontextprotocol/sdk": "^1.25.1",
+    "deco-cli": "^0.28.0",
+    "typescript": "^5.7.2"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  }
+}

--- a/wake/server/lib/admin.ts
+++ b/wake/server/lib/admin.ts
@@ -1,0 +1,80 @@
+/**
+ * Wake Admin REST client (api.fbits.net).
+ *
+ * Authenticates with the Admin API token as an HTTP Basic credential
+ * (`Authorization: Basic <token>`). Used by the admin/analytics tools (orders).
+ */
+import type { Env } from "../types/env.ts";
+
+const ADMIN_BASE = "https://api.fbits.net";
+const REQUEST_TIMEOUT_MS = 30_000;
+
+export interface AdminClient {
+  get<T = unknown>(path: string, query?: Record<string, unknown>): Promise<T>;
+}
+
+/** Reads the Admin API token from the per-request configuration state. */
+export function getApiToken(env: Env): string {
+  const token = env.MESH_REQUEST_CONTEXT?.state?.apiToken;
+  if (!token) {
+    throw new Error(
+      "Wake apiToken is not configured. It is required for admin tools (orders/analytics) and is sent as the `Authorization: Basic <token>` header for api.fbits.net.",
+    );
+  }
+  return token;
+}
+
+function buildQueryString(query: Record<string, unknown>): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null || value === "") continue;
+    params.set(key, String(value));
+  }
+  const encoded = params.toString();
+  return encoded ? `?${encoded}` : "";
+}
+
+export function createAdminClient(env: Env): AdminClient {
+  const token = getApiToken(env);
+
+  return {
+    async get<T = unknown>(
+      path: string,
+      query: Record<string, unknown> = {},
+    ): Promise<T> {
+      const url = `${ADMIN_BASE}${path}${buildQueryString(query)}`;
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+      let response: Response;
+      try {
+        response = await fetch(url, {
+          method: "GET",
+          headers: {
+            Accept: "application/json",
+            Authorization: `Basic ${token}`,
+          },
+          signal: controller.signal,
+        });
+      } catch (error) {
+        if ((error as { name?: string })?.name === "AbortError") {
+          throw new Error(
+            `Wake Admin API request timed out after ${REQUEST_TIMEOUT_MS}ms.`,
+          );
+        }
+        throw error;
+      } finally {
+        clearTimeout(timeout);
+      }
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => "");
+        throw new Error(
+          `Wake Admin API HTTP ${response.status} ${response.statusText}: ${body.slice(0, 500)}`,
+        );
+      }
+
+      return (await response.json()) as T;
+    },
+  };
+}

--- a/wake/server/lib/constants.ts
+++ b/wake/server/lib/constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared enum constants mirrored from the Wake Storefront GraphQL schema.
+ */
+
+/** ProductSortKeys — sort keys for product listing (`products`, `hotsite`). */
+export const PRODUCT_SORT_KEYS = [
+  "NAME",
+  "SALES",
+  "PRICE",
+  "DISCOUNT",
+  "RANDOM",
+  "RELEASE_DATE",
+  "STOCK",
+] as const;
+
+/** ProductSearchSortKeys — sort keys for full-text `search`, adds RELEVANCE. */
+export const SEARCH_SORT_KEYS = ["RELEVANCE", ...PRODUCT_SORT_KEYS] as const;

--- a/wake/server/lib/queries.ts
+++ b/wake/server/lib/queries.ts
@@ -1,0 +1,455 @@
+/**
+ * Wake Storefront GraphQL — fragments and read queries.
+ *
+ * Fragments and selections are mirrored from the production-proven deco.cx Wake
+ * app (deco-cx/apps/wake) so they stay valid against the live Storefront API at
+ * https://storefront-api.fbits.net/graphql.
+ *
+ * V1 exposes read-only storefront operations only.
+ */
+
+// ── Fragments ────────────────────────────────────────────────────────────────
+
+const PRODUCT = /* GraphQL */ `
+fragment Product on Product {
+  mainVariant
+  productName
+  productId
+  alias
+  attributes { id type value name }
+  productCategories { id name url hierarchy main googleCategories }
+  informations { title value type }
+  available
+  averageRating
+  condition
+  createdAt
+  ean
+  id
+  images { url fileName print }
+  minimumOrderQuantity
+  prices {
+    bestInstallment { discount displayName fees name number value }
+    discountPercentage
+    discounted
+    installmentPlans {
+      displayName
+      installments { discount fees number value }
+      name
+    }
+    listPrice
+    multiplicationFactor
+    price
+    priceTables { discountPercentage id listPrice price }
+    wholesalePrices { price quantity }
+  }
+  productBrand { fullUrlLogo logoUrl name alias }
+  productVariantId
+  seller { name }
+  parentId
+  sku
+  numberOfVotes
+  stock
+  variantName
+  variantStock
+  collection
+  urlVideo
+  similarProducts { alias image imageUrl name }
+  promotions { content disclosureType id fullStampUrl stamp title }
+}
+`;
+
+const PRODUCT_VARIANT = /* GraphQL */ `
+fragment ProductVariant on ProductVariant {
+  aggregatedStock
+  alias
+  available
+  attributes { attributeId displayType id name type value }
+  ean
+  id
+  images { fileName mini order print url }
+  productId
+  productVariantId
+  productVariantName
+  sku
+  stock
+  prices {
+    discountPercentage
+    discounted
+    installmentPlans {
+      displayName
+      name
+      installments { discount fees number value }
+    }
+    listPrice
+    multiplicationFactor
+    price
+    priceTables { discountPercentage id listPrice price }
+    wholesalePrices { price quantity }
+    bestInstallment { discount displayName fees name number value }
+  }
+  offers {
+    name
+    prices {
+      installmentPlans {
+        displayName
+        installments { discount fees number value }
+      }
+      listPrice
+      price
+    }
+    productVariantId
+  }
+  promotions { content disclosureType id fullStampUrl stamp title }
+}
+`;
+
+const SINGLE_PRODUCT_PART = /* GraphQL */ `
+fragment SingleProductPart on SingleProduct {
+  mainVariant
+  productName
+  productId
+  alias
+  collection
+  attributes { name type value attributeId displayType id }
+  numberOfVotes
+  productCategories { id name url hierarchy main googleCategories }
+  informations { title value type }
+  available
+  averageRating
+  breadcrumbs { text link }
+  condition
+  createdAt
+  ean
+  id
+  images { url fileName print }
+  minimumOrderQuantity
+  prices {
+    bestInstallment { discount displayName fees name number value }
+    discountPercentage
+    discounted
+    installmentPlans {
+      displayName
+      installments { discount fees number value }
+      name
+    }
+    listPrice
+    multiplicationFactor
+    price
+    priceTables { discountPercentage id listPrice price }
+    wholesalePrices { price quantity }
+  }
+  productBrand { fullUrlLogo logoUrl name alias }
+  productVariantId
+  seller { name }
+  seo { name scheme type httpEquiv content }
+  sku
+  stock
+  variantName
+  parallelOptions
+  urlVideo
+  reviews { rating review reviewDate email customer }
+  similarProducts { alias image imageUrl name }
+  attributeSelections(includeParentIdVariants: $includeParentIdVariants) {
+    selections {
+      attributeId
+      displayType
+      name
+      varyByParent
+      values { alias available value selected printUrl }
+    }
+    canBeMatrix
+    matrix {
+      column { displayType name values { value } }
+      data { available productVariantId stock }
+      row { displayType name values { value printUrl } }
+    }
+    selectedVariant { ...ProductVariant }
+    candidateVariant { ...ProductVariant }
+  }
+  promotions { content disclosureType id fullStampUrl stamp title }
+}
+`;
+
+const SINGLE_PRODUCT = /* GraphQL */ `
+fragment SingleProduct on SingleProduct {
+  ...SingleProductPart
+  buyTogether { productId }
+}
+`;
+
+const SHIPPING_QUOTE = /* GraphQL */ `
+fragment ShippingQuote on ShippingQuote {
+  id
+  type
+  name
+  value
+  deadline
+  shippingQuoteId
+  deliverySchedules { date periods { end id start } }
+  products { productVariantId value }
+}
+`;
+
+const BUY_LIST = /* GraphQL */ `
+fragment BuyList on BuyList {
+  mainVariant
+  productName
+  productId
+  alias
+  collection
+  kit
+  attributes { name type value attributeId displayType id }
+  numberOfVotes
+  productCategories { id name url hierarchy main googleCategories }
+  informations { title value type }
+  available
+  averageRating
+  breadcrumbs { text link }
+  condition
+  createdAt
+  ean
+  id
+  images { url fileName print }
+  minimumOrderQuantity
+  prices {
+    bestInstallment { discount displayName fees name number value }
+    discountPercentage
+    discounted
+    installmentPlans {
+      displayName
+      installments { discount fees number value }
+      name
+    }
+    listPrice
+    multiplicationFactor
+    price
+    priceTables { discountPercentage id listPrice price }
+    wholesalePrices { price quantity }
+  }
+  productBrand { fullUrlLogo logoUrl name alias }
+  productVariantId
+  seller { name }
+  seo { name scheme type httpEquiv content }
+  sku
+  stock
+  variantName
+  parallelOptions
+  urlVideo
+  reviews { rating review reviewDate email customer }
+  similarProducts { alias image imageUrl name }
+  buyTogether { productId }
+  promotions { content disclosureType id fullStampUrl stamp title }
+  buyListId
+  buyListProducts { productId quantity includeSameParent }
+}
+`;
+
+// ── Queries ──────────────────────────────────────────────────────────────────
+
+export const SEARCH_PRODUCTS = `${PRODUCT}
+query Search(
+  $operation: Operation!
+  $query: String
+  $onlyMainVariant: Boolean
+  $minimumPrice: Decimal
+  $maximumPrice: Decimal
+  $limit: Int
+  $offset: Int
+  $sortDirection: SortDirection
+  $sortKey: ProductSearchSortKeys
+  $filters: [ProductFilterInput]
+) {
+  result: search(query: $query, operation: $operation) {
+    aggregations {
+      maximumPrice
+      minimumPrice
+      priceRanges { quantity range }
+      filters { field origin values { quantity name } }
+    }
+    breadcrumbs { link text }
+    forbiddenTerm { text suggested }
+    pageSize
+    redirectUrl
+    searchTime
+    productsByOffset(
+      filters: $filters
+      limit: $limit
+      maximumPrice: $maximumPrice
+      minimumPrice: $minimumPrice
+      onlyMainVariant: $onlyMainVariant
+      offset: $offset
+      sortDirection: $sortDirection
+      sortKey: $sortKey
+    ) {
+      items { ...Product }
+      page
+      pageSize
+      totalCount
+    }
+  }
+}`;
+
+export const LIST_PRODUCTS = `${PRODUCT}
+query ListProducts(
+  $filters: ProductExplicitFiltersInput!
+  $first: Int!
+  $sortDirection: SortDirection!
+  $sortKey: ProductSortKeys!
+  $after: String
+) {
+  products(
+    filters: $filters
+    first: $first
+    sortDirection: $sortDirection
+    sortKey: $sortKey
+    after: $after
+  ) {
+    nodes { ...Product }
+    totalCount
+    pageInfo { hasNextPage endCursor hasPreviousPage startCursor }
+  }
+}`;
+
+export const GET_PRODUCT = `${PRODUCT_VARIANT}
+${SINGLE_PRODUCT_PART}
+${SINGLE_PRODUCT}
+query GetProduct($productId: Long!, $includeParentIdVariants: Boolean) {
+  product(productId: $productId) { ...SingleProduct }
+}`;
+
+export const AUTOCOMPLETE = `${PRODUCT}
+query Autocomplete($limit: Int, $query: String) {
+  autocomplete(limit: $limit, query: $query) {
+    suggestions
+    products { ...Product }
+  }
+}`;
+
+export const PRODUCT_RECOMMENDATIONS = `${PRODUCT}
+query ProductRecommendations(
+  $productId: Long!
+  $algorithm: ProductRecommendationAlgorithm!
+  $quantity: Int!
+) {
+  productRecommendations(productId: $productId, algorithm: $algorithm, quantity: $quantity) {
+    ...Product
+  }
+}`;
+
+export const HOTSITE = `${PRODUCT}
+query Hotsite(
+  $url: String
+  $hotsiteId: Long
+  $filters: [ProductFilterInput]
+  $limit: Int
+  $maximumPrice: Decimal
+  $minimumPrice: Decimal
+  $onlyMainVariant: Boolean
+  $offset: Int
+  $sortDirection: SortDirection
+  $sortKey: ProductSortKeys
+) {
+  result: hotsite(url: $url, hotsiteId: $hotsiteId) {
+    aggregations {
+      filters { field origin values { name quantity } }
+      maximumPrice
+      minimumPrice
+      priceRanges { quantity range }
+    }
+    productsByOffset(
+      filters: $filters
+      limit: $limit
+      maximumPrice: $maximumPrice
+      minimumPrice: $minimumPrice
+      onlyMainVariant: $onlyMainVariant
+      offset: $offset
+      sortDirection: $sortDirection
+      sortKey: $sortKey
+    ) {
+      items { ...Product }
+      page
+      pageSize
+      totalCount
+    }
+    breadcrumbs { link text }
+    endDate
+    expression
+    id
+    name
+    pageSize
+    seo { content httpEquiv name scheme type }
+    sorting { direction field }
+    startDate
+    subtype
+    template
+    url
+    hotsiteId
+  }
+}`;
+
+export const PRODUCT_OPTIONS = `${PRODUCT_VARIANT}
+query ProductOptions($productId: Long!) {
+  productOptions(productId: $productId) {
+    attributes {
+      attributeId
+      displayType
+      id
+      name
+      type
+      values {
+        productVariants { ...ProductVariant }
+        value
+      }
+    }
+    id
+  }
+}`;
+
+export const SHIPPING_QUOTES = `${SHIPPING_QUOTE}
+query ShippingQuotes(
+  $cep: CEP
+  $checkoutId: Uuid
+  $productVariantId: Long
+  $quantity: Int = 1
+  $useSelectedAddress: Boolean
+) {
+  shippingQuotes(
+    cep: $cep
+    checkoutId: $checkoutId
+    productVariantId: $productVariantId
+    quantity: $quantity
+    useSelectedAddress: $useSelectedAddress
+  ) {
+    ...ShippingQuote
+  }
+}`;
+
+export const BUY_LIST_QUERY = `${BUY_LIST}
+query BuyList($id: Long!) {
+  buyList(id: $id) { ...BuyList }
+}`;
+
+export const SHOP = `
+query Shop {
+  shop {
+    checkoutUrl
+    mainUrl
+    mobileCheckoutUrl
+    mobileUrl
+    modifiedName
+    name
+  }
+}`;
+
+export const RESOLVE_URL = `
+query ResolveUrl($url: String!) {
+  uri(url: $url) {
+    hotsiteSubtype
+    kind
+    partnerSubtype
+    productAlias
+    productCategoriesIds
+    redirectCode
+    redirectUrl
+  }
+}`;

--- a/wake/server/lib/storefront.ts
+++ b/wake/server/lib/storefront.ts
@@ -1,0 +1,93 @@
+/**
+ * Wake Storefront GraphQL client.
+ *
+ * The Storefront API lives at a single fixed endpoint and identifies the store
+ * through the `TCS-Access-Token` header — there is no per-account host.
+ */
+import type { Env } from "../types/env.ts";
+
+const STOREFRONT_ENDPOINT = "https://storefront-api.fbits.net/graphql";
+const REQUEST_TIMEOUT_MS = 30_000;
+
+export interface StorefrontClient {
+  query<T = Record<string, unknown>>(
+    query: string,
+    variables?: Record<string, unknown>,
+  ): Promise<T>;
+}
+
+interface GraphQLResponse<T> {
+  data?: T;
+  errors?: Array<{ message: string }>;
+}
+
+/** Reads the Storefront token from the per-request configuration state. */
+export function getStorefrontToken(env: Env): string {
+  const token = env.MESH_REQUEST_CONTEXT?.state?.storefrontToken;
+  if (!token) {
+    throw new Error(
+      "Wake storefrontToken is not configured. Set it in the MCP configuration (used as the TCS-Access-Token header).",
+    );
+  }
+  return token;
+}
+
+export function createStorefrontClient(env: Env): StorefrontClient {
+  const token = getStorefrontToken(env);
+
+  return {
+    async query<T = Record<string, unknown>>(
+      query: string,
+      variables: Record<string, unknown> = {},
+    ): Promise<T> {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+      let response: Response;
+      try {
+        response = await fetch(STOREFRONT_ENDPOINT, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+            "TCS-Access-Token": token,
+          },
+          body: JSON.stringify({ query, variables }),
+          signal: controller.signal,
+        });
+      } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") {
+          throw new Error(
+            `Wake Storefront API request timed out after ${REQUEST_TIMEOUT_MS}ms.`,
+          );
+        }
+        throw error;
+      } finally {
+        clearTimeout(timeout);
+      }
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => "");
+        throw new Error(
+          `Wake Storefront API HTTP ${response.status} ${response.statusText}: ${body.slice(0, 500)}`,
+        );
+      }
+
+      const json = (await response.json()) as GraphQLResponse<T>;
+
+      if (json.errors?.length) {
+        throw new Error(
+          `Wake Storefront GraphQL error: ${json.errors
+            .map((e) => e.message)
+            .join("; ")}`,
+        );
+      }
+
+      if (json.data === undefined || json.data === null) {
+        throw new Error("Wake Storefront API returned no data.");
+      }
+
+      return json.data;
+    },
+  };
+}

--- a/wake/server/lib/storefront.ts
+++ b/wake/server/lib/storefront.ts
@@ -56,7 +56,7 @@ export function createStorefrontClient(env: Env): StorefrontClient {
           signal: controller.signal,
         });
       } catch (error) {
-        if (error instanceof Error && error.name === "AbortError") {
+        if ((error as { name?: string })?.name === "AbortError") {
           throw new Error(
             `Wake Storefront API request timed out after ${REQUEST_TIMEOUT_MS}ms.`,
           );

--- a/wake/server/lib/tool.ts
+++ b/wake/server/lib/tool.ts
@@ -9,6 +9,7 @@ import { createPrivateTool } from "@decocms/runtime/tools";
 import { z } from "zod";
 import type { Env } from "../types/env.ts";
 import { createStorefrontClient, type StorefrontClient } from "./storefront.ts";
+import { type AdminClient, createAdminClient } from "./admin.ts";
 
 /** MCP tool annotations (hints for clients about a tool's side effects). */
 export interface ToolAnnotations {
@@ -40,6 +41,37 @@ export function createWakeTool<
       execute: async ({ context, runtimeContext }) => {
         const env = runtimeContext.env as Env;
         const client = createStorefrontClient(env);
+        return config.handler(context as z.infer<TSchema>, client);
+      },
+    });
+}
+
+/**
+ * Factory for Wake **Admin** REST tools (orders / analytics). Resolves the
+ * Admin REST client (api.fbits.net, Basic auth) from the per-request context.
+ * Every admin tool here is read-only.
+ */
+export function createWakeAdminTool<
+  TSchema extends z.ZodObject<z.ZodRawShape>,
+>(config: {
+  id: string;
+  description: string;
+  inputSchema: TSchema;
+  annotations?: ToolAnnotations;
+  handler: (
+    input: z.infer<TSchema>,
+    client: AdminClient,
+  ) => Promise<Record<string, unknown>>;
+}) {
+  return (_env: Env) =>
+    createPrivateTool({
+      id: config.id,
+      description: config.description,
+      inputSchema: config.inputSchema,
+      annotations: config.annotations ?? { readOnlyHint: true },
+      execute: async ({ context, runtimeContext }) => {
+        const env = runtimeContext.env as Env;
+        const client = createAdminClient(env);
         return config.handler(context as z.infer<TSchema>, client);
       },
     });

--- a/wake/server/lib/tool.ts
+++ b/wake/server/lib/tool.ts
@@ -1,0 +1,46 @@
+/**
+ * Factory for Wake Storefront tools.
+ *
+ * Resolves the Storefront client from the per-request mesh context and hands a
+ * ready-to-use GraphQL client to the handler. Every V1 tool is read-only, so
+ * `readOnlyHint: true` is the default annotation.
+ */
+import { createPrivateTool } from "@decocms/runtime/tools";
+import { z } from "zod";
+import type { Env } from "../types/env.ts";
+import { createStorefrontClient, type StorefrontClient } from "./storefront.ts";
+
+/** MCP tool annotations (hints for clients about a tool's side effects). */
+export interface ToolAnnotations {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
+export function createWakeTool<
+  TSchema extends z.ZodObject<z.ZodRawShape>,
+>(config: {
+  id: string;
+  description: string;
+  inputSchema: TSchema;
+  /** Defaults to a read-only tool. */
+  annotations?: ToolAnnotations;
+  handler: (
+    input: z.infer<TSchema>,
+    client: StorefrontClient,
+  ) => Promise<Record<string, unknown>>;
+}) {
+  return (_env: Env) =>
+    createPrivateTool({
+      id: config.id,
+      description: config.description,
+      inputSchema: config.inputSchema,
+      annotations: config.annotations ?? { readOnlyHint: true },
+      execute: async ({ context, runtimeContext }) => {
+        const env = runtimeContext.env as Env;
+        const client = createStorefrontClient(env);
+        return config.handler(context as z.infer<TSchema>, client);
+      },
+    });
+}

--- a/wake/server/main.ts
+++ b/wake/server/main.ts
@@ -1,0 +1,35 @@
+/**
+ * Wake MCP — Main Entry Point
+ *
+ * V1: read-only access to the Wake Commerce Storefront GraphQL API
+ * (products, search, catalog navigation, shipping quotes and shop metadata).
+ */
+import { withRuntime } from "@decocms/runtime";
+import { serve } from "@decocms/mcps-shared/serve";
+import { withAuth } from "@decocms/mcps-shared/auth";
+
+import { tools } from "./tools/index.ts";
+import { type Env, StateSchema } from "./types/env.ts";
+import packageJson from "../package.json" with { type: "json" };
+
+console.log(`Wake MCP v${packageJson.version}`);
+
+export type { Env };
+export { StateSchema };
+
+const runtime = withRuntime<Env, typeof StateSchema>({
+  configuration: {
+    state: StateSchema,
+  },
+  tools,
+});
+
+/**
+ * `withAuth` is mandatory: this MCP is served on a public hostname, so every
+ * request must present the shared secret from the AUTH_TOKEN environment
+ * variable. It is read at startup — without it the process exits instead of
+ * serving anonymous traffic. `scripts/check-auth.ts` fails CI if it is removed.
+ */
+if (runtime.fetch) {
+  serve(withAuth(runtime.fetch));
+}

--- a/wake/server/tools/catalog.ts
+++ b/wake/server/tools/catalog.ts
@@ -4,17 +4,8 @@
  */
 import { z } from "zod";
 import { createWakeTool } from "../lib/tool.ts";
+import { PRODUCT_SORT_KEYS } from "../lib/constants.ts";
 import { BUY_LIST_QUERY, HOTSITE, PRODUCT_OPTIONS } from "../lib/queries.ts";
-
-const PRODUCT_SORT_KEYS = [
-  "NAME",
-  "SALES",
-  "PRICE",
-  "DISCOUNT",
-  "RANDOM",
-  "RELEASE_DATE",
-  "STOCK",
-] as const;
 
 export const getHotsiteTool = createWakeTool({
   id: "WAKE_GET_HOTSITE",

--- a/wake/server/tools/catalog.ts
+++ b/wake/server/tools/catalog.ts
@@ -1,0 +1,88 @@
+/**
+ * Catalog navigation tools — hotsites (category / landing pages), variant
+ * options and buy lists (kits).
+ */
+import { z } from "zod";
+import { createWakeTool } from "../lib/tool.ts";
+import { BUY_LIST_QUERY, HOTSITE, PRODUCT_OPTIONS } from "../lib/queries.ts";
+
+const PRODUCT_SORT_KEYS = [
+  "NAME",
+  "SALES",
+  "PRICE",
+  "DISCOUNT",
+  "RANDOM",
+  "RELEASE_DATE",
+  "STOCK",
+] as const;
+
+export const getHotsiteTool = createWakeTool({
+  id: "WAKE_GET_HOTSITE",
+  description:
+    "Resolve a hotsite (category, collection or landing page) by URL path or hotsite id, returning its products, aggregations, breadcrumbs and SEO metadata. Use this to render category listing pages.",
+  inputSchema: z.object({
+    url: z
+      .string()
+      .optional()
+      .describe(
+        'Hotsite URL path, e.g. "/masculino" or a full storefront path',
+      ),
+    hotsiteId: z.coerce
+      .number()
+      .int()
+      .optional()
+      .describe("Hotsite id (alternative to url)"),
+    limit: z.coerce.number().int().min(1).max(50).default(24),
+    offset: z.coerce.number().int().min(0).default(0),
+    minimumPrice: z.coerce.number().optional(),
+    maximumPrice: z.coerce.number().optional(),
+    onlyMainVariant: z.boolean().optional(),
+    sortDirection: z.enum(["ASC", "DESC"]).optional(),
+    sortKey: z.enum(PRODUCT_SORT_KEYS).optional(),
+    filters: z
+      .array(
+        z.object({
+          field: z.string(),
+          values: z.array(z.string()),
+        }),
+      )
+      .optional()
+      .describe("Facet filters from a previous aggregations response"),
+  }),
+  handler: async (input, client) => {
+    const data = await client.query(HOTSITE, input);
+    return data as Record<string, unknown>;
+  },
+});
+
+export const productOptionsTool = createWakeTool({
+  id: "WAKE_PRODUCT_OPTIONS",
+  description:
+    "List the selectable attributes (e.g. color, size) and their variants for a product. Use to build variant selectors.",
+  inputSchema: z.object({
+    productId: z.coerce.number().int().describe("Wake product id"),
+  }),
+  handler: async (input, client) => {
+    const data = await client.query(PRODUCT_OPTIONS, input);
+    return data as Record<string, unknown>;
+  },
+});
+
+export const getBuyListTool = createWakeTool({
+  id: "WAKE_GET_BUYLIST",
+  description:
+    "Fetch a buy list (kit / combo) by id, including its component products and pricing.",
+  inputSchema: z.object({
+    id: z.coerce.number().int().describe("Buy list id"),
+  }),
+  handler: async (input, client) => {
+    const data = await client.query(BUY_LIST_QUERY, input);
+    return data as Record<string, unknown>;
+  },
+});
+
+export const catalogTools = [
+  getHotsiteTool,
+  productOptionsTool,
+  getBuyListTool,
+];

--- a/wake/server/tools/index.ts
+++ b/wake/server/tools/index.ts
@@ -1,10 +1,17 @@
 /**
  * Central export of all Wake MCP tools.
  *
- * V1: read-only Storefront GraphQL operations.
+ * Read-only Storefront GraphQL operations (catalog) + Admin REST operations
+ * (orders / analytics).
  */
 import { productTools } from "./products.ts";
 import { catalogTools } from "./catalog.ts";
 import { storeTools } from "./store.ts";
+import { orderTools } from "./orders.ts";
 
-export const tools = [...productTools, ...catalogTools, ...storeTools];
+export const tools = [
+  ...productTools,
+  ...catalogTools,
+  ...storeTools,
+  ...orderTools,
+];

--- a/wake/server/tools/index.ts
+++ b/wake/server/tools/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Central export of all Wake MCP tools.
+ *
+ * V1: read-only Storefront GraphQL operations.
+ */
+import { productTools } from "./products.ts";
+import { catalogTools } from "./catalog.ts";
+import { storeTools } from "./store.ts";
+
+export const tools = [...productTools, ...catalogTools, ...storeTools];

--- a/wake/server/tools/orders.ts
+++ b/wake/server/tools/orders.ts
@@ -1,0 +1,138 @@
+/**
+ * Admin / analytics tools — orders via the Wake Admin REST API (api.fbits.net).
+ *
+ * These are store-level (admin) reads, not per-shopper. They require the
+ * `apiToken` configuration (sent as `Authorization: Basic <token>`).
+ */
+import { z } from "zod";
+import { createWakeAdminTool } from "../lib/tool.ts";
+
+const DATE_FILTER_KINDS = [
+  "DataPedido",
+  "DataAprovacao",
+  "DataModificacaoStatus",
+  "DataAlteracao",
+  "DataCriacao",
+] as const;
+
+/** REST list endpoints return arrays; wrap them so tools always return an object. */
+function asResult(data: unknown): Record<string, unknown> {
+  if (Array.isArray(data)) return { items: data, count: data.length };
+  if (data && typeof data === "object") return data as Record<string, unknown>;
+  return { result: data };
+}
+
+export const listOrdersTool = createWakeAdminTool({
+  id: "WAKE_LIST_ORDERS",
+  description:
+    "List store orders (admin) in descending order within a date range, with filters for status, payment method, customer and SKU. Use for sales analysis and reporting. Paginated (max 50 per page).",
+  inputSchema: z.object({
+    dataInicial: z
+      .string()
+      .optional()
+      .describe(
+        'Start date (inclusive). Format "YYYY-MM-DD" or "YYYY-MM-DD HH:mm:ss".',
+      ),
+    dataFinal: z
+      .string()
+      .optional()
+      .describe(
+        'End date (inclusive). Format "YYYY-MM-DD" or "YYYY-MM-DD HH:mm:ss".',
+      ),
+    enumTipoFiltroData: z
+      .enum(DATE_FILTER_KINDS)
+      .optional()
+      .describe("Which date the range filters on (default DataPedido)."),
+    situacoesPedido: z
+      .string()
+      .optional()
+      .describe(
+        "Comma-separated order status ids to include (see WAKE_LIST_ORDER_STATUSES).",
+      ),
+    formasPagamento: z
+      .string()
+      .optional()
+      .describe("Comma-separated payment method ids to include."),
+    email: z
+      .string()
+      .optional()
+      .describe("Return only orders placed by this customer email."),
+    sku: z
+      .string()
+      .optional()
+      .describe("Return only orders containing this product SKU."),
+    valido: z
+      .boolean()
+      .optional()
+      .describe(
+        "Filter by valid (true), invalid (false) or all orders (omit).",
+      ),
+    apenasAssinaturas: z
+      .boolean()
+      .optional()
+      .describe("Return only subscription orders when true."),
+    pagina: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .default(1)
+      .describe("Page number (default 1)."),
+    quantidadeRegistros: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .default(50)
+      .describe("Records per page (max 50)."),
+  }),
+  handler: async (input, client) => {
+    const data = await client.get("/pedidos", input);
+    return asResult(data);
+  },
+});
+
+export const getOrderTool = createWakeAdminTool({
+  id: "WAKE_GET_ORDER",
+  description:
+    "Get a single store order (admin) by its order id, including items, totals, customer and payment detail.",
+  inputSchema: z.object({
+    pedidoId: z.coerce.number().int().describe("Order id (número do pedido)."),
+  }),
+  handler: async (input, client) => {
+    const data = await client.get(`/pedidos/${input.pedidoId}`);
+    return asResult(data);
+  },
+});
+
+export const getOrderStatusHistoryTool = createWakeAdminTool({
+  id: "WAKE_GET_ORDER_STATUS_HISTORY",
+  description:
+    "Get the status change history (situações) of a store order, for timeline / fulfillment analysis.",
+  inputSchema: z.object({
+    pedidoId: z.coerce.number().int().describe("Order id (número do pedido)."),
+  }),
+  handler: async (input, client) => {
+    const data = await client.get(
+      `/pedidos/${input.pedidoId}/historicoSituacao`,
+    );
+    return asResult(data);
+  },
+});
+
+export const listOrderStatusesTool = createWakeAdminTool({
+  id: "WAKE_LIST_ORDER_STATUSES",
+  description:
+    "List all order statuses (situações de pedido) configured in the store. Use to map status ids/names before filtering WAKE_LIST_ORDERS.",
+  inputSchema: z.object({}),
+  handler: async (_input, client) => {
+    const data = await client.get("/situacoesPedido");
+    return asResult(data);
+  },
+});
+
+export const orderTools = [
+  listOrdersTool,
+  getOrderTool,
+  getOrderStatusHistoryTool,
+  listOrderStatusesTool,
+];

--- a/wake/server/tools/products.ts
+++ b/wake/server/tools/products.ts
@@ -1,0 +1,208 @@
+/**
+ * Product discovery tools — search, listing, detail, autocomplete and
+ * recommendations against the Wake Storefront GraphQL API.
+ */
+import { z } from "zod";
+import { createWakeTool } from "../lib/tool.ts";
+import {
+  AUTOCOMPLETE,
+  GET_PRODUCT,
+  LIST_PRODUCTS,
+  PRODUCT_RECOMMENDATIONS,
+  SEARCH_PRODUCTS,
+} from "../lib/queries.ts";
+
+const PRODUCT_SORT_KEYS = [
+  "NAME",
+  "SALES",
+  "PRICE",
+  "DISCOUNT",
+  "RANDOM",
+  "RELEASE_DATE",
+  "STOCK",
+] as const;
+
+const SEARCH_SORT_KEYS = ["RELEVANCE", ...PRODUCT_SORT_KEYS] as const;
+
+/** [ProductFilterInput] — facet filters returned by search/hotsite aggregations. */
+const facetFilter = z
+  .array(
+    z.object({
+      field: z
+        .string()
+        .describe("Filter field, e.g. an aggregation field name"),
+      values: z.array(z.string()).describe("Selected values for this field"),
+    }),
+  )
+  .optional()
+  .describe(
+    "Facet filters. Use the `aggregations.filters` returned by a previous search/hotsite call to discover valid field/value pairs.",
+  );
+
+export const searchProductsTool = createWakeTool({
+  id: "WAKE_SEARCH_PRODUCTS",
+  description:
+    "Full-text search over the Wake storefront catalog. Returns matching products plus aggregations (facets, price ranges) and breadcrumbs. Use the returned aggregations to drive faceted filtering on a follow-up call.",
+  inputSchema: z.object({
+    query: z.string().optional().describe("Search term. Omit to browse."),
+    operation: z
+      .enum(["AND", "OR"])
+      .default("AND")
+      .describe("How multiple query terms are combined"),
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .default(24)
+      .describe("Number of products to return (max 50)"),
+    offset: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .default(0)
+      .describe("Pagination offset (number of products to skip)"),
+    minimumPrice: z.coerce.number().optional().describe("Minimum price filter"),
+    maximumPrice: z.coerce.number().optional().describe("Maximum price filter"),
+    onlyMainVariant: z
+      .boolean()
+      .optional()
+      .describe("Return only each product's main variant"),
+    sortDirection: z.enum(["ASC", "DESC"]).optional(),
+    sortKey: z.enum(SEARCH_SORT_KEYS).optional(),
+    filters: facetFilter,
+  }),
+  handler: async (input, client) => {
+    const data = await client.query(SEARCH_PRODUCTS, input);
+    return data as Record<string, unknown>;
+  },
+});
+
+export const listProductsTool = createWakeTool({
+  id: "WAKE_LIST_PRODUCTS",
+  description:
+    "List catalog products using explicit filters (by id, sku, ean, category, brand, availability, price, attributes). Cursor-paginated. Prefer this over search when you already know the identifiers or want structured filtering.",
+  inputSchema: z.object({
+    filters: z
+      .object({
+        productId: z.array(z.coerce.number().int()).optional(),
+        productVariantId: z.array(z.coerce.number().int()).optional(),
+        parentId: z.array(z.coerce.number().int()).optional(),
+        sku: z.array(z.string()).optional(),
+        ean: z.array(z.string()).optional(),
+        categoryId: z.array(z.coerce.number().int()).optional(),
+        brandId: z.array(z.coerce.number().int()).optional(),
+        search: z.array(z.string()).optional(),
+        available: z.boolean().optional(),
+        mainVariant: z.boolean().optional(),
+        hasImages: z.boolean().optional(),
+        stock_gte: z.coerce.number().int().optional(),
+        stock_lte: z.coerce.number().int().optional(),
+        prices: z
+          .object({
+            price_gte: z.coerce.number().optional(),
+            price_lte: z.coerce.number().optional(),
+            discount_gte: z.coerce.number().optional(),
+            discount_lte: z.coerce.number().optional(),
+            discounted: z.boolean().optional(),
+          })
+          .optional(),
+        attributes: z
+          .object({
+            id: z.array(z.coerce.number().int()).optional(),
+            name: z.array(z.string()).optional(),
+            type: z.array(z.string()).optional(),
+            value: z.array(z.string()).optional(),
+          })
+          .optional(),
+      })
+      .default({})
+      .describe("Explicit product filters (ProductExplicitFiltersInput)"),
+    first: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .default(24)
+      .describe("Number of products to return (max 50)"),
+    sortDirection: z.enum(["ASC", "DESC"]).default("ASC"),
+    sortKey: z.enum(PRODUCT_SORT_KEYS).default("NAME"),
+    after: z
+      .string()
+      .optional()
+      .describe("Cursor from a previous response's pageInfo.endCursor"),
+  }),
+  handler: async (input, client) => {
+    const data = await client.query(LIST_PRODUCTS, input);
+    return data as Record<string, unknown>;
+  },
+});
+
+export const getProductTool = createWakeTool({
+  id: "WAKE_GET_PRODUCT",
+  description:
+    "Fetch a single product with full detail: variants, attribute selections (variant matrix), prices, reviews, SEO and breadcrumbs.",
+  inputSchema: z.object({
+    productId: z.coerce.number().int().describe("Wake product id"),
+    includeParentIdVariants: z
+      .boolean()
+      .optional()
+      .describe("Include variants that share the same parent id"),
+  }),
+  handler: async (input, client) => {
+    const data = await client.query(GET_PRODUCT, input);
+    return data as Record<string, unknown>;
+  },
+});
+
+export const autocompleteTool = createWakeTool({
+  id: "WAKE_AUTOCOMPLETE",
+  description:
+    "Search-as-you-type suggestions plus a short list of matching products. Ideal for building a search box preview.",
+  inputSchema: z.object({
+    query: z.string().describe("Partial search term"),
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .default(10)
+      .describe("Max products to return (max 50)"),
+  }),
+  handler: async (input, client) => {
+    const data = await client.query(AUTOCOMPLETE, input);
+    return data as Record<string, unknown>;
+  },
+});
+
+export const productRecommendationsTool = createWakeTool({
+  id: "WAKE_PRODUCT_RECOMMENDATIONS",
+  description:
+    "Get products recommended for a given product (e.g. cross-sell / related items).",
+  inputSchema: z.object({
+    productId: z.coerce.number().int().describe("Reference product id"),
+    quantity: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .default(10)
+      .describe("Number of recommendations to return (max 50)"),
+    algorithm: z
+      .enum(["DEFAULT"])
+      .default("DEFAULT")
+      .describe("Recommendation algorithm"),
+  }),
+  handler: async (input, client) => {
+    const data = await client.query(PRODUCT_RECOMMENDATIONS, input);
+    return data as Record<string, unknown>;
+  },
+});
+
+export const productTools = [
+  searchProductsTool,
+  listProductsTool,
+  getProductTool,
+  autocompleteTool,
+  productRecommendationsTool,
+];

--- a/wake/server/tools/products.ts
+++ b/wake/server/tools/products.ts
@@ -4,6 +4,7 @@
  */
 import { z } from "zod";
 import { createWakeTool } from "../lib/tool.ts";
+import { PRODUCT_SORT_KEYS, SEARCH_SORT_KEYS } from "../lib/constants.ts";
 import {
   AUTOCOMPLETE,
   GET_PRODUCT,
@@ -11,18 +12,6 @@ import {
   PRODUCT_RECOMMENDATIONS,
   SEARCH_PRODUCTS,
 } from "../lib/queries.ts";
-
-const PRODUCT_SORT_KEYS = [
-  "NAME",
-  "SALES",
-  "PRICE",
-  "DISCOUNT",
-  "RANDOM",
-  "RELEASE_DATE",
-  "STOCK",
-] as const;
-
-const SEARCH_SORT_KEYS = ["RELEVANCE", ...PRODUCT_SORT_KEYS] as const;
 
 /** [ProductFilterInput] — facet filters returned by search/hotsite aggregations. */
 const facetFilter = z

--- a/wake/server/tools/store.ts
+++ b/wake/server/tools/store.ts
@@ -1,0 +1,71 @@
+/**
+ * Store-level tools — shop metadata, URL resolution and shipping quotes.
+ */
+import { z } from "zod";
+import { createWakeTool } from "../lib/tool.ts";
+import { RESOLVE_URL, SHIPPING_QUOTES, SHOP } from "../lib/queries.ts";
+
+export const shopInfoTool = createWakeTool({
+  id: "WAKE_SHOP_INFO",
+  description:
+    "Get storefront metadata: name, main URL and checkout URLs (desktop and mobile).",
+  inputSchema: z.object({}),
+  handler: async (_input, client) => {
+    const data = await client.query(SHOP);
+    return data as Record<string, unknown>;
+  },
+});
+
+export const resolveUrlTool = createWakeTool({
+  id: "WAKE_RESOLVE_URL",
+  description:
+    "Resolve a storefront URL path to its route kind (product, hotsite/category, redirect, etc.). Use this to decide which other tool to call for a given path.",
+  inputSchema: z.object({
+    url: z
+      .string()
+      .describe('Storefront URL path, e.g. "/some-product" or "/masculino"'),
+  }),
+  handler: async (input, client) => {
+    const data = await client.query(RESOLVE_URL, input);
+    return data as Record<string, unknown>;
+  },
+});
+
+export const shippingQuotesTool = createWakeTool({
+  id: "WAKE_SHIPPING_QUOTES",
+  description:
+    "Estimate shipping options (price, deadline, delivery schedules) for a product variant to a postal code (CEP), or for an existing checkout.",
+  inputSchema: z.object({
+    cep: z
+      .string()
+      .optional()
+      .describe('Destination postal code (Brazilian CEP), e.g. "01310-100"'),
+    productVariantId: z.coerce
+      .number()
+      .int()
+      .optional()
+      .describe("Product variant id to quote"),
+    quantity: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .default(1)
+      .describe("Item quantity"),
+    checkoutId: z
+      .string()
+      .optional()
+      .describe(
+        "Existing checkout id (UUID) to quote instead of a single variant",
+      ),
+    useSelectedAddress: z
+      .boolean()
+      .optional()
+      .describe("Use the customer's selected address instead of a raw CEP"),
+  }),
+  handler: async (input, client) => {
+    const data = await client.query(SHIPPING_QUOTES, input);
+    return data as Record<string, unknown>;
+  },
+});
+
+export const storeTools = [shopInfoTool, resolveUrlTool, shippingQuotesTool];

--- a/wake/server/types/env.ts
+++ b/wake/server/types/env.ts
@@ -2,8 +2,12 @@
  * Environment Type Definitions
  *
  * StateSchema is the configuration form shown when installing the Wake MCP.
- * V1 talks only to the Wake Storefront GraphQL API, which authenticates with a
- * single Storefront token sent as the `TCS-Access-Token` header.
+ *
+ * The MCP talks to two Wake APIs:
+ * - Storefront GraphQL (public catalog), authenticated with `storefrontToken`
+ *   sent as the `TCS-Access-Token` header.
+ * - Admin REST (api.fbits.net, orders/analytics), authenticated with `apiToken`
+ *   sent as the `Authorization: Basic <token>` header.
  */
 import type { DefaultEnv } from "@decocms/runtime";
 import { z } from "zod";
@@ -12,7 +16,13 @@ export const StateSchema = z.object({
   storefrontToken: z
     .string()
     .describe(
-      "Wake Storefront API token, sent as the TCS-Access-Token header. Create one at https://wakecommerce.readme.io/docs/storefront-api-criacao-e-autenticacao-do-token",
+      "Wake Storefront API token, sent as the TCS-Access-Token header. Required for catalog/product tools. Create one at https://wakecommerce.readme.io/docs/storefront-api-criacao-e-autenticacao-do-token",
+    ),
+  apiToken: z
+    .string()
+    .optional()
+    .describe(
+      "Wake Admin API token, sent as the `Authorization: Basic <token>` header for api.fbits.net. Required only for admin tools (orders/analytics). See https://wakecommerce.readme.io/docs/introducao-a-api",
     ),
   account: z
     .string()

--- a/wake/server/types/env.ts
+++ b/wake/server/types/env.ts
@@ -1,0 +1,25 @@
+/**
+ * Environment Type Definitions
+ *
+ * StateSchema is the configuration form shown when installing the Wake MCP.
+ * V1 talks only to the Wake Storefront GraphQL API, which authenticates with a
+ * single Storefront token sent as the `TCS-Access-Token` header.
+ */
+import type { DefaultEnv } from "@decocms/runtime";
+import { z } from "zod";
+
+export const StateSchema = z.object({
+  storefrontToken: z
+    .string()
+    .describe(
+      "Wake Storefront API token, sent as the TCS-Access-Token header. Create one at https://wakecommerce.readme.io/docs/storefront-api-criacao-e-autenticacao-do-token",
+    ),
+  account: z
+    .string()
+    .optional()
+    .describe(
+      'Wake account name (e.g. "erploja2"). Optional; used only for reference and links.',
+    ),
+});
+
+export type Env = DefaultEnv<typeof StateSchema>;

--- a/wake/tsconfig.json
+++ b/wake/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2023", "ES2024"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "allowJs": true,
+    "resolveJsonModule": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+
+    /* Path Aliases */
+    "baseUrl": ".",
+    "paths": {
+      "server/*": ["./server/*"]
+    }
+  },
+  "include": ["server"]
+}


### PR DESCRIPTION
## What

New custom deco HTTP MCP for **Wake Commerce** (fbits), read-only, covering two API surfaces:

- **Storefront GraphQL** (`storefront-api.fbits.net`) — catalog, search, product detail, recommendations, shipping. Mirrors the production-proven [deco.cx Wake app](https://github.com/deco-cx/apps/tree/main/wake) fragments/queries.
- **Admin REST** (`api.fbits.net`) — store-level **orders for analytics** (not per-shopper).

Cart/wishlist/customer (session-based) are intentionally out of scope.

## Tools (15, all read-only)

### Storefront (catalog) — requires `storefrontToken`
| Tool | Description |
| --- | --- |
| `WAKE_SEARCH_PRODUCTS` | Full-text search with facet aggregations & price ranges |
| `WAKE_LIST_PRODUCTS` | Explicit filters (id/sku/ean/category/brand/price/attributes), cursor paginated |
| `WAKE_GET_PRODUCT` | Full detail: variants, attribute matrix, prices, reviews, SEO |
| `WAKE_AUTOCOMPLETE` | Search-as-you-type suggestions + products |
| `WAKE_PRODUCT_RECOMMENDATIONS` | Recommended products for a product |
| `WAKE_GET_HOTSITE` | Category/landing page by URL or id |
| `WAKE_PRODUCT_OPTIONS` | Selectable attributes & their variants |
| `WAKE_GET_BUYLIST` | Buy list (kit/combo) by id |
| `WAKE_SHOP_INFO` | Storefront metadata & checkout URLs |
| `WAKE_RESOLVE_URL` | Resolve a URL path to its route kind |
| `WAKE_SHIPPING_QUOTES` | Shipping options for a variant to a CEP |

### Admin (orders / analytics) — requires `apiToken`
| Tool | Description |
| --- | --- |
| `WAKE_LIST_ORDERS` | List store orders by date range, status, payment method, customer or SKU; paginated (max 50) |
| `WAKE_GET_ORDER` | Full order detail by id |
| `WAKE_GET_ORDER_STATUS_HISTORY` | Status/timeline history of an order |
| `WAKE_LIST_ORDER_STATUSES` | Configured order statuses (id/name mapping) |

## Design

- Custom deco HTTP server based on `template-minimal`: `createPrivateTool` + `withAuth` + `configuration.state`.
- **Config:** `storefrontToken` (required, `TCS-Access-Token` header) for catalog tools; `apiToken` (optional, `Authorization: Basic <token>`) for admin order tools; optional `account`.
- Two clients: `lib/storefront.ts` (GraphQL) and `lib/admin.ts` (REST), each with its own tool factory.
- Endpoint guarded by `withAuth` / `AUTH_TOKEN`.
- Registered in `deploy.json` (`kubernetes-bun`) and root `package.json` workspaces.

## Verification

- ✅ `server/**` type-checks clean (the remaining tsc errors are internal to `@decocms/runtime`, pre-existing repo-wide — deployed MCPs like `google-docs` show the same).
- ✅ `scripts/check-auth.ts wake` passes.
- ✅ All storefront GraphQL queries validated against the live schema.
- ✅ Builds, boots, and lists all 15 tools; `withAuth` enforced.
- ✅ oxlint/oxfmt clean for `wake/`.

## Not yet done

- **`unlisted: true`** until an end-to-end test runs against real tokens (storefront + admin). Storefront scalar formats (CEP, Decimal) and the admin order date/response shapes are unverified end-to-end.
- Confirm `app.json` icon/host (`sites-wake.deco.site/mcp`, repo default) and move the icon to the deco assets CDN before listing.
- Tech debt: migrate `createPrivateTool` (deprecated in runtime) to `createTool` + `ensureAuthenticated` once repo `check-auth` allows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)